### PR TITLE
Fix controls with null header template

### DIFF
--- a/src/OpenSage.Game/Data/Ini/Parser/IniParser.cs
+++ b/src/OpenSage.Game/Data/Ini/Parser/IniParser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using OpenSage.Data.Utilities;
 using OpenSage.Logic.Object;
 using OpenSage.Mathematics;
 
@@ -227,7 +228,7 @@ namespace OpenSage.Data.Ini.Parser
 
         public float ScanFloat(IniToken token)
         {
-            return Convert.ToSingle(GetFloatText(token));
+            return ParseUtility.ParseFloat(GetFloatText(token));
         }
 
         public float ParseFloat() => ScanFloat(GetNextToken());

--- a/src/OpenSage.Game/Data/Wnd/WndFile.cs
+++ b/src/OpenSage.Game/Data/Wnd/WndFile.cs
@@ -83,6 +83,8 @@ namespace OpenSage.Data.Wnd
         public WndSliderData SliderData { get; internal set; }
 
         public WndWindow[] ChildWindows { get; internal set; }
+
+        public bool HasHeaderTemplate => HeaderTemplate != null && !string.Equals(HeaderTemplate, "[NONE]", StringComparison.InvariantCultureIgnoreCase);
     }
 
     public sealed class WndTextEntryData

--- a/src/OpenSage.Game/Gui/Elements/UIElement.cs
+++ b/src/OpenSage.Game/Gui/Elements/UIElement.cs
@@ -174,7 +174,7 @@ namespace OpenSage.Gui.Elements
             _wndWindow = wndWindow;
             _needsRender = true;
 
-            if (!string.Equals(wndWindow.HeaderTemplate, "[NONE]", StringComparison.InvariantCultureIgnoreCase))
+            if (wndWindow.HasHeaderTemplate)
             {
                 _headerTemplate = contentManager.IniDataContext.HeaderTemplates.First(x => x.Name == wndWindow.HeaderTemplate);
             }


### PR DESCRIPTION
(Based on #13)

Treat UI elements with null HeaderTemplate like ones set to "[NONE]"

Fixes crashes when viewing certain UI controls in the data viewer, such as the MOTD.
