### PR TITLE
Add support for special registry key for Zero Hour, refactor installation location

### DIFF
--- a/src/OpenSage.Game/Data/InstallationLocator.cs
+++ b/src/OpenSage.Game/Data/InstallationLocator.cs
@@ -36,7 +36,7 @@ namespace OpenSage.Data
             }
         }
 
-        public GameInstallation(SageGame game, string path, string secondaryPath)
+        public GameInstallation(SageGame game, string path, string secondaryPath = null)
         {
             Game = game;
             Path = path;
@@ -107,21 +107,51 @@ namespace OpenSage.Data
             }
         }
 
+        // Zero Hour requires some special handling compared to any other game.
+        // For starters it is an expansion pack, so it requires an installation of the base game.
+        // It also sometimes uses a registry key which doesn't point directly to the installation directory.
+        private IEnumerable<GameInstallation> FindZeroHourInstallations()
+        {
+            var generalsPath = FindInstallations(SageGame.CncGenerals).FirstOrDefault()?.Path;
+
+            // If there's no installation of Generals there's no reason to bother looking for Zero Hour.
+            if (generalsPath == null)
+            {
+                return Enumerable.Empty<GameInstallation>();
+            }
+
+            var keys = GetRegistryKeysForGame(SageGame.CncGeneralsZeroHour);
+
+            // For an unknown reason sometimes the Origin version gets installed with a different registry key.
+            // This wouldn't be an issue, except for the fact it points to the root of the Generals bundle, not to the Zero Hour expansion itself.
+            var originVersionRootPath = GetRegistryValue(@"SOFTWARE\EA Games\Command and Conquer Generals Zero Hour", "Install Dir");
+            var originVersionPath = originVersionRootPath == null ? null : Path.Combine(originVersionRootPath, "Command and Conquer Generals Zero Hour");
+
+            var paths = new List<string>();
+            paths.AddRange(keys.Select(k => GetRegistryValue(k.keyName, k.valueName)));
+            paths.Add(originVersionPath);
+
+            var installations = paths
+                .Where(Directory.Exists)
+                .Select(p => new GameInstallation(SageGame.CncGeneralsZeroHour, p, generalsPath))
+                .ToList();
+
+            return installations;
+        }
+
         public IEnumerable<GameInstallation> FindInstallations(SageGame game)
         {
+            if (game == SageGame.CncGeneralsZeroHour)
+            {
+                return FindZeroHourInstallations();
+            }
+
             var keys = GetRegistryKeysForGame(game);
 
             var installations = keys
                 .Select(k => GetRegistryValue(k.keyName, k.valueName))
                 .Where(Directory.Exists)
-                .Select(p =>
-                {
-                    var secondaryPath = (game == SageGame.CncGeneralsZeroHour)
-                        ? FindInstallations(SageGame.CncGenerals).FirstOrDefault()?.Path
-                        : null;
-
-                    return new GameInstallation(game, p, secondaryPath);
-                })
+                .Select(p => new GameInstallation(game, p))
                 .ToList();
 
             return installations;


### PR DESCRIPTION
When installing an Origin copy of the Generals + Zero Hour bundle on my secondary workstation I found out that for some reason it uses a different registry key than my other computer for ZH. No idea why.

Since the alternative registry key requires some special handling, I implemented it and decided to move Zero Hour installation resolution to a different method entirely. As a bonus, a Generals installation is only resolved once for all possible Zero Hour installations.
