### PR TITLE
Skip tests for games you don't have installed

### DIFF
--- a/src/OpenSage.Game.Tests/Apt/AptFileTest.cs
+++ b/src/OpenSage.Game.Tests/Apt/AptFileTest.cs
@@ -17,7 +17,7 @@ namespace OpenSage.Game.Tests.Apt
             _output = output;
         }
 
-        [Fact]
+        [GameFact(SageGame.BattleForMiddleEarthII)]
         public void CanReadAptFiles()
         {
             InstalledFilesTestData.ReadFiles(".apt", _output, entry =>
@@ -28,7 +28,7 @@ namespace OpenSage.Game.Tests.Apt
             });
         }
 
-        [Fact]
+        [GameFact(SageGame.BattleForMiddleEarthII)]
         public void CheckEntryCount()
         {
             var fileSystem = new FileSystem(InstalledFilesTestData.GetInstallationDirectory(SageGame.BattleForMiddleEarthII));

--- a/src/OpenSage.Game.Tests/Apt/ConstFileTests.cs
+++ b/src/OpenSage.Game.Tests/Apt/ConstFileTests.cs
@@ -17,7 +17,7 @@ namespace OpenSage.Game.Tests.Apt
             _output = output;
         }
 
-        [Fact]
+        [GameFact(SageGame.BattleForMiddleEarthII)]
         public void CanReadConstFiles()
         {
             InstalledFilesTestData.ReadFiles(".const", _output, entry =>
@@ -28,7 +28,7 @@ namespace OpenSage.Game.Tests.Apt
             });
         }
 
-        [Fact]
+        [GameFact(SageGame.BattleForMiddleEarthII)]
         public void CheckEntryCount()
         {
             var bigFilePath = Path.Combine(InstalledFilesTestData.GetInstallationDirectory(SageGame.BattleForMiddleEarthII), "apt/MainMenu.big");

--- a/src/OpenSage.Game.Tests/Big/BigArchiveTests.cs
+++ b/src/OpenSage.Game.Tests/Big/BigArchiveTests.cs
@@ -1,5 +1,6 @@
-using System.IO;
+﻿using System.IO;
 using OpenSage.Data.Big;
+using OpenSage.Game.Tests;
 using Xunit;
 
 namespace OpenSage.Data.Tests.Big
@@ -13,7 +14,7 @@ namespace OpenSage.Data.Tests.Big
             BigFilePath = Path.Combine(InstalledFilesTestData.GetInstallationDirectory(SageGame.CncGeneralsZeroHour), "W3DZH.big");
         }
 
-        [Fact]
+        [GameFact(SageGame.CncGeneralsZeroHour)]
         public void OpenBigArchive()
         {
             using (var bigStream = File.OpenRead(BigFilePath))
@@ -23,7 +24,7 @@ namespace OpenSage.Data.Tests.Big
             }
         }
 
-        [Fact]
+        [GameFact(SageGame.CncGeneralsZeroHour)]
         public void ReadFirstEntry()
         {
             using (var bigStream = File.OpenRead(BigFilePath))
@@ -36,7 +37,7 @@ namespace OpenSage.Data.Tests.Big
             }
         }
 
-        [Fact]
+        [GameFact(SageGame.CncGeneralsZeroHour)]
         public void ReadFirstEntryStream()
         {
             using (var bigStream = File.OpenRead(BigFilePath))
@@ -55,7 +56,7 @@ namespace OpenSage.Data.Tests.Big
             }
         }
 
-        [Fact]
+        [GameFact(SageGame.CncGeneralsZeroHour)]
         public void GetEntryByName()
         {
             using (var bigStream = File.OpenRead(BigFilePath))

--- a/src/OpenSage.Game.Tests/GameTestDiscoverer.cs
+++ b/src/OpenSage.Game.Tests/GameTestDiscoverer.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenSage.Data;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace OpenSage.Game.Tests
+{
+    public sealed class GameTestDiscoverer : IXunitTestCaseDiscoverer
+    {
+        private readonly IMessageSink _diagnosticMessageSink;
+
+        static readonly ISet<SageGame> InstalledGames;
+
+        public GameTestDiscoverer(IMessageSink diagnosticMessageSink)
+        {
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        {
+            var arguments = factAttribute.GetConstructorArguments();
+            var game = (SageGame) arguments.Single();
+
+            if (!InstalledGames.Contains(game))
+            {
+                _diagnosticMessageSink.OnMessage(
+                    new DiagnosticMessage($"Skipped test {testMethod.TestClass.Class.Name}.{testMethod.Method.Name}, because it requires {game} to be installed.")
+                );
+                yield break;
+            }
+
+            yield return new XunitTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+        }
+
+        static GameTestDiscoverer()
+        {
+            var locator = new RegistryInstallationLocator();
+            InstalledGames = new HashSet<SageGame>(SageGames.GetAll().Where(game => locator.FindInstallations(game).Any()));
+        }
+    }
+
+    [XunitTestCaseDiscoverer("OpenSage.Game.Tests.GameTestDiscoverer", "OpenSage.Game.Tests")]
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class GameFact : FactAttribute
+    {
+        public readonly SageGame Game;
+
+        public GameFact(SageGame game)
+        {
+            Game = game;
+        }
+    }
+}

--- a/src/OpenSage.Game/Data/InstallationLocator.cs
+++ b/src/OpenSage.Game/Data/InstallationLocator.cs
@@ -36,7 +36,7 @@ namespace OpenSage.Data
             }
         }
 
-        public GameInstallation(SageGame game, string path, string secondaryPath)
+        public GameInstallation(SageGame game, string path, string secondaryPath = null)
         {
             Game = game;
             Path = path;
@@ -107,21 +107,51 @@ namespace OpenSage.Data
             }
         }
 
+        // Zero Hour requires some special handling compared to any other game.
+        // For starters it is an expansion pack, so it requires an installation of the base game.
+        // It also sometimes uses a registry key which doesn't point directly to the installation directory.
+        private IEnumerable<GameInstallation> FindZeroHourInstallations()
+        {
+            var generalsPath = FindInstallations(SageGame.CncGenerals).FirstOrDefault()?.Path;
+
+            // If there's no installation of Generals there's no reason to bother looking for Zero Hour.
+            if (generalsPath == null)
+            {
+                return Enumerable.Empty<GameInstallation>();
+            }
+
+            var keys = GetRegistryKeysForGame(SageGame.CncGeneralsZeroHour);
+
+            // For an unknown reason sometimes the Origin version gets installed with a different registry key.
+            // This wouldn't be an issue, except for the fact it points to the root of the Generals bundle, not to the Zero Hour expansion itself.
+            var originVersionRootPath = GetRegistryValue(@"SOFTWARE\EA Games\Command and Conquer Generals Zero Hour", "Install Dir");
+            var originVersionPath = originVersionRootPath == null ? null : Path.Combine(originVersionRootPath, "Command and Conquer Generals Zero Hour");
+
+            var paths = new List<string>();
+            paths.AddRange(keys.Select(k => GetRegistryValue(k.keyName, k.valueName)));
+            paths.Add(originVersionPath);
+
+            var installations = paths
+                .Where(Directory.Exists)
+                .Select(p => new GameInstallation(SageGame.CncGeneralsZeroHour, p, generalsPath))
+                .ToList();
+
+            return installations;
+        }
+
         public IEnumerable<GameInstallation> FindInstallations(SageGame game)
         {
+            if (game == SageGame.CncGeneralsZeroHour)
+            {
+                return FindZeroHourInstallations();
+            }
+
             var keys = GetRegistryKeysForGame(game);
 
             var installations = keys
                 .Select(k => GetRegistryValue(k.keyName, k.valueName))
                 .Where(Directory.Exists)
-                .Select(p =>
-                {
-                    var secondaryPath = (game == SageGame.CncGeneralsZeroHour)
-                        ? FindInstallations(SageGame.CncGenerals).FirstOrDefault()?.Path
-                        : null;
-
-                    return new GameInstallation(game, p, secondaryPath);
-                })
+                .Select(p => new GameInstallation(game, p))
                 .ToList();
 
             return installations;


### PR DESCRIPTION
(Based on #15)

This PR implements a custom XUnit test discoverer, which filters the tests by the games you have installed. Tests that require a specific game can be tagged with `[GameFact(SageGame.GameName)]`. I haven't classified every test yet, but I can do that if required.

The motivation behind this is that it doesn't make much sense to run tests that couldn't possibly pass because of missing data files. It also documents in a neat, declarative way which tests require which games.