### PR TITLE
Clear game systems' component lists on scene change

### DIFF
--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -170,6 +170,9 @@ namespace OpenSage
 
                 if (oldScene != null)
                 {
+                    foreach (var system in GameSystems)
+                        system.OnSceneChange();
+
                     RemoveComponentsRecursive(oldScene.Entities);
                     oldScene.Game = null;
                 }

--- a/src/OpenSage.Game/GameSystem.cs
+++ b/src/OpenSage.Game/GameSystem.cs
@@ -50,6 +50,11 @@ namespace OpenSage
                 componentList.Remove(component);
         }
 
+        internal virtual void OnSceneChange() {
+            foreach (var componentList in _componentLists.Values)
+                componentList.Clear();
+        }
+
         internal virtual void OnSwapChainChanged() { }
 
         private List<IList> FindComponentLists(Type componentType)


### PR DESCRIPTION
Fixes #19 .

`OnSceneChange` is virtual so that systems can customise the behaviour it if necessary.