### PR TITLE
Fix map object z positioning

### DIFF
--- a/src/OpenSage.Game/Content/MapLoader.cs
+++ b/src/OpenSage.Game/Content/MapLoader.cs
@@ -239,7 +239,7 @@ namespace OpenSage.Content
                                 break;
 
                             default:
-                                position.Z = heightMap.GetHeight(position.X, position.Y);
+                                position.Z += heightMap.GetHeight(position.X, position.Y);
 
                                 var objectEntity = contentManager.InstantiateObject(mapObject.TypeName);
                                 if (objectEntity != null)

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -170,6 +170,9 @@ namespace OpenSage
 
                 if (oldScene != null)
                 {
+                    foreach (var system in GameSystems)
+                        system.OnSceneChange();
+
                     RemoveComponentsRecursive(oldScene.Entities);
                     oldScene.Game = null;
                 }

--- a/src/OpenSage.Game/GameSystem.cs
+++ b/src/OpenSage.Game/GameSystem.cs
@@ -50,6 +50,11 @@ namespace OpenSage
                 componentList.Remove(component);
         }
 
+        internal virtual void OnSceneChange() {
+            foreach (var componentList in _componentLists.Values)
+                componentList.Clear();
+        }
+
         internal virtual void OnSwapChainChanged() { }
 
         private List<IList> FindComponentLists(Type componentType)


### PR DESCRIPTION
Fixes map object Z positioning by _adding_ the height map value at current position to the object's Z position instead of ignoring it entirely.

Before: 

![image](https://user-images.githubusercontent.com/803180/34458002-6dfe394e-edcb-11e7-922f-735162bee9a6.png)

After:

![image](https://user-images.githubusercontent.com/803180/34458006-9619ca9c-edcb-11e7-9dd9-632abc561f03.png)

WorldBuilder for reference:

![image](https://user-images.githubusercontent.com/803180/34458009-ac258042-edcb-11e7-9e84-f22f7f5438d3.png)
