### PR TITLE
Fix IniParser.IsFloat on non-English Windows

### DIFF
--- a/src/OpenSage.Game/Data/Ini/Parser/IniParser.cs
+++ b/src/OpenSage.Game/Data/Ini/Parser/IniParser.cs
@@ -223,7 +223,7 @@ namespace OpenSage.Data.Ini.Parser
         public bool IsFloat(IniToken token)
         {
             var floatText = GetFloatText(token);
-            return !string.IsNullOrEmpty(floatText) && float.TryParse(floatText, out _);
+            return !string.IsNullOrEmpty(floatText) && ParseUtility.TryParseFloat(floatText, out _);
         }
 
         public float ScanFloat(IniToken token)


### PR DESCRIPTION
Fixes test `IniFileTests.CanReadIniFiles` for languages that don't use the decimal point. 