### PR TITLE
Map loading fixes

### DIFF
--- a/src/OpenSage.Game.Tests/GameTestDiscoverer.cs
+++ b/src/OpenSage.Game.Tests/GameTestDiscoverer.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using OpenSage.Data;
+using OpenSage.Utilities.Extensions;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -39,7 +40,7 @@ namespace OpenSage.Game.Tests
         static GameTestDiscoverer()
         {
             var locator = new RegistryInstallationLocator();
-            InstalledGames = new HashSet<SageGame>(SageGames.GetAll().Where(game => locator.FindInstallations(game).Any()));
+            InstalledGames = SageGames.GetAll().Where(game => locator.FindInstallations(game).Any()).ToSet();
         }
     }
 }

--- a/src/OpenSage.Game/Data/InstallationLocator.cs
+++ b/src/OpenSage.Game/Data/InstallationLocator.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using OpenSage.Utilities.Extensions;
 
 namespace OpenSage.Data
 {
@@ -111,7 +112,7 @@ namespace OpenSage.Data
         private IEnumerable<string> GetValidPaths(IEnumerable<string> paths)
         {
             return paths
-                .Where(p => !string.IsNullOrWhiteSpace(p))
+                .WhereNot(string.IsNullOrWhiteSpace)
                 .Distinct()
                 .Where(Directory.Exists);
         }

--- a/src/OpenSage.Game/Scripting/Actions/MoveCameraAlongWaypointPathAction.cs
+++ b/src/OpenSage.Game/Scripting/Actions/MoveCameraAlongWaypointPathAction.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Numerics;
 using OpenSage.Graphics.Cameras;
 using OpenSage.Settings;
 using ScriptAction = OpenSage.Data.Map.ScriptAction;
@@ -9,7 +8,6 @@ namespace OpenSage.Scripting.Actions
     public sealed class MoveCameraAlongWaypointPathAction : MapScriptAction
     {
         private readonly WaypointPath _waypointPath;
-        private readonly Vector3 _direction;
         private readonly TimeSpan _duration;
         private readonly float _shutter;
 
@@ -17,9 +15,9 @@ namespace OpenSage.Scripting.Actions
 
         public MoveCameraAlongWaypointPathAction(ScriptAction action, SceneSettings sceneSettings)
         {
-            _waypointPath = sceneSettings.WaypointPaths[action.Arguments[0].StringValue];
+            var firstNode = sceneSettings.Waypoints[action.Arguments[0].StringValue];
 
-            _direction = _waypointPath.End.Position - _waypointPath.Start.Position;
+            _waypointPath = sceneSettings.WaypointPaths[firstNode];
 
             _duration = TimeSpan.FromSeconds(action.Arguments[1].FloatValue.Value);
 

--- a/src/OpenSage.Game/Terrain/HeightMap.cs
+++ b/src/OpenSage.Game/Terrain/HeightMap.cs
@@ -17,11 +17,20 @@ namespace OpenSage.Terrain
 
         public float GetHeight(int x, int y) => _heightMapData.Elevations[x, y] * _verticalScale;
 
+        /// <summary>
+        /// Gets height at the given world space coordinate.
+        /// Returns 0 if the coordinate is out of bounds.
+        /// </summary>
         public float GetHeight(float x, float y)
         {
             // convert coordinates to heightmap scale
             x = x / HorizontalScale + _heightMapData.BorderWidth;
             y = y / HorizontalScale + _heightMapData.BorderWidth;
+
+            if (x >= Width || y >= Height || x < 0 || y < 0)
+            {
+                return 0;
+            }
 
             // get integer and fractional parts of coordinates
             int nIntX0 = MathUtility.FloorToInt(x);

--- a/src/OpenSage.Game/Utilities/Extensions/EnumerableExtensions.cs
+++ b/src/OpenSage.Game/Utilities/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenSage.Utilities.Extensions
+{
+    public static class EnumerableExtensions
+    {
+        /// <summary>
+        /// Complement of Where.
+        /// </summary>
+        public static IEnumerable<T> WhereNot<T>(this IEnumerable<T> enumerable, Predicate<T> predicate)
+        {
+            return enumerable.Where(x => !predicate(x));
+        }
+
+        /// <summary>
+        /// Creates a HashSet from an enumerable.
+        /// </summary>
+        public static HashSet<T> ToSet<T>(this IEnumerable<T> enumerable)
+        {
+            return new HashSet<T>(enumerable);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #22, fixes #27.

Fixes a number of campaign maps. Every map in the China campaign loads except for `CHI03`.

* Check if the coordinate is within bounds in `HeightMap.GetHeight`, return 0 if not.
* Parse `wayPointPathLabel` properties and store them in `Settings.Waypoint`s.
* Implement `WaypointPathCollection` which allows looking up `WaypointPath`s by their first node and their label.
* Fix `MoveCameraAlongWaypointPathAction`.
* As a bonus, add two self-explanatory LINQ extensions: `WhereNot` and `ToSet`. Not absolutely necessary, but I though they'd be useful.