### PR TITLE
Updated Nuget packages for Xunit and the Test SDK

### DIFF
--- a/src/OpenSage.Game.Tests/OpenSage.Game.Tests.csproj
+++ b/src/OpenSage.Game.Tests/OpenSage.Game.Tests.csproj
@@ -11,9 +11,9 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0-preview-20171211-02" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenSage.Game\OpenSage.Game.csproj" />


### PR DESCRIPTION
This change is necessary, because the tests aren't properly detected or run, in some instances (including my machine). By updating the NuGet Packages everything is working again as expected