### PR TITLE
Implement more wnd callbacks for Generals' main menu + close windows with ESC

### DIFF
--- a/src/OpenSage.Game/Gui/Wnd/Transitions/ReverseSoundTransition.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Transitions/ReverseSoundTransition.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace OpenSage.Gui.Wnd.Transitions
+{
+    // TODO: Implement when we have audio support.
+    internal class ReverseSoundTransition : WindowTransitionOperation
+    {
+        public ReverseSoundTransition(WndWindow element, TimeSpan startTime) : base(element, startTime) { }
+
+        protected override int FrameDuration => 0;
+
+        protected override void OnUpdate(float progress) { }
+    }
+}

--- a/src/OpenSage.Game/Gui/Wnd/Transitions/WinScaleUpTransition.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Transitions/WinScaleUpTransition.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace OpenSage.Gui.Wnd.Transitions
+{
+    // TODO: Implement.
+    internal class WinScaleUpTransition : WindowTransitionOperation
+    {
+        public WinScaleUpTransition(WndWindow element, TimeSpan startTime) : base(element, startTime) { }
+
+        protected override int FrameDuration => 6;
+
+        protected override void OnUpdate(float progress) { }
+    }
+}

--- a/src/OpenSage.Game/Gui/Wnd/Transitions/WindowTransitionOperation.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Transitions/WindowTransitionOperation.cs
@@ -27,6 +27,12 @@ namespace OpenSage.Gui.Wnd.Transitions
                 case WindowTransitionStyle.ButtonFlash:
                     return new ButtonFlashTransition(element, startTime);
 
+                case WindowTransitionStyle.WinScaleUp:
+                    return new WinScaleUpTransition(element, startTime);
+
+                case WindowTransitionStyle.ReverseSound:
+                    return new ReverseSoundTransition(element, startTime);
+
                 default:
                     throw new NotImplementedException();
             }

--- a/src/OpenSage.Game/Gui/Wnd/WndInputMessageHandler.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndInputMessageHandler.cs
@@ -80,6 +80,15 @@ namespace OpenSage.Gui.Wnd
                         }
                         break;
                     }
+
+                case InputMessageType.KeyDown:
+                    {
+                        if (message.Key == Key.Escape && _windowManager.OpenWindowCount > 1)
+                        {
+                            _windowManager.PopWindow();
+                        }
+                        break;
+                    }
             }
 
             return InputMessageResult.NotHandled;

--- a/src/OpenSage.Game/Gui/Wnd/WndTopLevelWindow.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndTopLevelWindow.cs
@@ -26,7 +26,7 @@ namespace OpenSage.Gui.Wnd
             // Finds deepest element that is visible and contains mousePosition.
             WndWindow findElementRecursive(WndWindow element)
             {
-                if (!element.Visible || !element.Frame.Contains(mousePosition))
+                if (!element.Visible || element.Opacity != 1 || !element.Frame.Contains(mousePosition))
                 {
                     return null;
                 }

--- a/src/OpenSage.Game/Gui/Wnd/WndWindowManager.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndWindowManager.cs
@@ -13,7 +13,9 @@ namespace OpenSage.Gui.Wnd
     public sealed class WndWindowManager
     {
         private readonly Game _game;
+
         private readonly Stack<WndTopLevelWindow> _windowStack;
+        public int OpenWindowCount => _windowStack.Count;
 
         public WindowTransitionManager TransitionManager { get; }
 

--- a/src/OpenSage.Mods.Generals/WndCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/WndCallbacks.cs
@@ -1,4 +1,5 @@
-﻿using OpenSage.Gui;
+﻿﻿using System.Linq;
+using OpenSage.Gui;
 using OpenSage.Gui.Wnd;
 
 namespace OpenSage.Mods.Generals
@@ -13,17 +14,26 @@ namespace OpenSage.Mods.Generals
             window.Root.FindChild("MainMenu.wnd:MainMenuRuler").Hide();
             window.Root.FindChild("MainMenu.wnd:MainMenuRuler").Opacity = 0;
 
-            window.Root.FindChild("MainMenu.wnd:MapBorder2").Opacity = 0;
-            foreach (var button in window.Root.FindChild("MainMenu.wnd:EarthMap2").Children)
+            var initiallyHiddenSections = new[]
             {
-                button.Opacity = 0;
-                button.TextOpacity = 0;
-            }
+                "MainMenu.wnd:MapBorder",
+                "MainMenu.wnd:MapBorder1",
+                "MainMenu.wnd:MapBorder2",
+                "MainMenu.wnd:MapBorder3",
+                "MainMenu.wnd:MapBorder4"
+            };
 
-            window.Root.FindChild("MainMenu.wnd:MapBorder").Hide();
-            window.Root.FindChild("MainMenu.wnd:MapBorder1").Hide();
-            window.Root.FindChild("MainMenu.wnd:MapBorder3").Hide();
-            window.Root.FindChild("MainMenu.wnd:MapBorder4").Hide();
+            foreach (var controlName in initiallyHiddenSections)
+            {
+                var control = window.Root.FindChild(controlName);
+                control.Opacity = 0;
+
+                foreach (var button in control.Children.First().Children)
+                {
+                    button.Opacity = 0;
+                    button.TextOpacity = 0;
+                }
+            }
 
             window.Root.FindChild("MainMenu.wnd:ButtonUSARecentSave").Hide();
             window.Root.FindChild("MainMenu.wnd:ButtonUSALoadGame").Hide();
@@ -33,6 +43,8 @@ namespace OpenSage.Mods.Generals
 
             window.Root.FindChild("MainMenu.wnd:ButtonChinaRecentSave").Hide();
             window.Root.FindChild("MainMenu.wnd:ButtonChinaLoadGame").Hide();
+
+            // TODO: Show faction icons when WinScaleUpTransition is implemented.
 
             _doneMainMenuFadeIn = false;
         }
@@ -44,11 +56,46 @@ namespace OpenSage.Mods.Generals
 
         public static void MainMenuSystem(WndWindow element, WndWindowMessage message, UIElementCallbackContext context)
         {
+            void QueueTransition(string transition)
+            {
+                context.WindowManager.TransitionManager.QueueTransition(null, element.Window, transition);
+            }
+
             switch (message.MessageType)
             {
                 case WndWindowMessageType.SelectedButton:
                     switch (message.Element.Name)
                     {
+                        case "MainMenu.wnd:ButtonSinglePlayer":
+                            QueueTransition("MainMenuDefaultMenuBack");
+                            QueueTransition("MainMenuSinglePlayerMenu");
+                            break;
+
+                        case "MainMenu.wnd:ButtonSingleBack":
+                            QueueTransition("MainMenuSinglePlayerMenuBack");
+                            QueueTransition("MainMenuDefaultMenu");
+                            break;
+
+                        case "MainMenu.wnd:ButtonMultiplayer":
+                            QueueTransition("MainMenuDefaultMenuBack");
+                            QueueTransition("MainMenuMultiPlayerMenu");
+                            break;
+
+                        case "MainMenu.wnd:ButtonMultiBack":
+                            QueueTransition("MainMenuMultiPlayerMenuReverse");
+                            QueueTransition("MainMenuDefaultMenu");
+                            break;
+
+                        case "MainMenu.wnd:ButtonLoadReplay":
+                            QueueTransition("MainMenuDefaultMenuBack");
+                            QueueTransition("MainMenuLoadReplayMenu");
+                            break;
+
+                        case "MainMenu.wnd:ButtonLoadReplayBack":
+                            QueueTransition("MainMenuLoadReplayMenuBack");
+                            QueueTransition("MainMenuDefaultMenu");
+                            break;
+
                         case "MainMenu.wnd:ButtonOptions":
                             context.WindowManager.PushWindow(@"Menus\OptionsMenu.wnd");
                             break;


### PR DESCRIPTION
* Implement enough UI callbacks to open all subsections of the main menu (except for credits)
* Ignore click events when a component is not fully opaque
* Add stub implementations for `ReverseSoundTransition` and `WinScaleUpTransition`
* Add ESC as a hotkey for closing the topmost window. Entirely optional, can be left out if it causes issues.