### PR TITLE
Optimize particle systems

### DIFF
--- a/src/OpenSage.DataViewer/UI/Viewers/Ini/ParticleSystemView.cs
+++ b/src/OpenSage.DataViewer/UI/Viewers/Ini/ParticleSystemView.cs
@@ -11,6 +11,9 @@ namespace OpenSage.DataViewer.UI.Viewers.Ini
 {
     public sealed class ParticleSystemView : GameControl
     {
+        // We need to copy the identity matrix so that we can pass it by reference.
+        private static readonly Matrix4x4 WorldIdentity = Matrix4x4.Identity;
+
         public ParticleSystemView(Func<IntPtr, Game> createGame, ParticleSystemDefinition particleSystemDefinition)
         {
             CreateGame = h =>
@@ -20,7 +23,7 @@ namespace OpenSage.DataViewer.UI.Viewers.Ini
                 var particleSystem = new ParticleSystem(
                     game.ContentManager,
                     particleSystemDefinition,
-                    () => Matrix4x4.Identity);
+                    () => ref WorldIdentity);
 
                 game.Updating += (sender, e) =>
                 {

--- a/src/OpenSage.Game/Data/Ini/ParticleSystem.cs
+++ b/src/OpenSage.Game/Data/Ini/ParticleSystem.cs
@@ -200,12 +200,12 @@ namespace OpenSage.Data.Ini
             return new RgbColorKeyframe
             {
                 Color = IniColorRgb.Parse(parser),
-                Time = parser.ParseUnsignedInteger()
+                Time = parser.ParseInteger()
             };
         }
 
         public IniColorRgb Color;
-        public uint Time;
+        public int Time;
     }
 
     public enum ParticleSystemShader

--- a/src/OpenSage.Game/Graphics/ParticleSystems/Particle.cs
+++ b/src/OpenSage.Game/Graphics/ParticleSystems/Particle.cs
@@ -31,10 +31,10 @@ namespace OpenSage.Graphics.ParticleSystems
         public float Alpha;
     }
 
-    internal sealed class ParticleAlphaKeyframe
+    internal readonly struct ParticleAlphaKeyframe : IParticleKeyframe
     {
-        public int Time;
-        public float Alpha;
+        public int Time { get; }
+        public readonly float Alpha;
 
         public ParticleAlphaKeyframe(RandomAlphaKeyframe keyframe)
         {

--- a/src/OpenSage.Game/Graphics/ParticleSystems/ParticleSystem.cs
+++ b/src/OpenSage.Game/Graphics/ParticleSystems/ParticleSystem.cs
@@ -17,10 +17,11 @@ using Veldrid;
 
 namespace OpenSage.Graphics.ParticleSystems
 {
-    public delegate ref readonly Matrix4x4 GetMatrixReferenceDelegate();
 
     public sealed class ParticleSystem : DisposableBase
     {
+        public delegate ref readonly Matrix4x4 GetMatrixReferenceDelegate();
+
         private readonly GetMatrixReferenceDelegate _getWorldMatrix;
 
         private readonly GraphicsDevice _graphicsDevice;
@@ -43,14 +44,14 @@ namespace OpenSage.Graphics.ParticleSystems
         private int _timer;
         private int _nextBurst;
 
-        private Particle[] _particles;
-        private List<int> _deadList;
+        private readonly Particle[] _particles;
+        private readonly List<int> _deadList;
 
-        private DeviceBuffer _vertexBuffer;
-        private ParticleVertex[] _vertices;
+        private readonly DeviceBuffer _vertexBuffer;
+        private readonly ParticleVertex[] _vertices;
 
-        private DeviceBuffer _indexBuffer;
-        private uint _numIndices;
+        private readonly DeviceBuffer _indexBuffer;
+        private readonly uint _numIndices;
 
         public ParticleSystemDefinition Definition { get; }
 
@@ -311,11 +312,6 @@ namespace OpenSage.Graphics.ParticleSystems
 
             particle.VelocityDamping = Definition.VelocityDamping.GetRandomFloat();
 
-            RandomiseAlphaKeyframes(ref particle);
-        }
-
-        private void RandomiseAlphaKeyframes(ref Particle particle)
-        {
             var alphaKeyframes = particle.AlphaKeyframes;
             alphaKeyframes.Clear();
 
@@ -369,7 +365,7 @@ namespace OpenSage.Graphics.ParticleSystems
             particle.AngleZ += particle.AngularRateZ;
             particle.AngularRateZ *= particle.AngularDamping;
 
-            FindKeyFrames(particle.Timer, _colorKeyframes, out var nextC, out var prevC);
+            FindKeyframes(particle.Timer, _colorKeyframes, out var nextC, out var prevC);
 
             if (!prevC.Equals(nextC))
             {
@@ -387,7 +383,7 @@ namespace OpenSage.Graphics.ParticleSystems
 
             if (particle.AlphaKeyframes.Count > 1)
             {
-                FindKeyFrames(particle.Timer, particle.AlphaKeyframes, out var nextA, out var prevA);
+                FindKeyframes(particle.Timer, particle.AlphaKeyframes, out var nextA, out var prevA);
 
                 if (!prevA.Equals(nextA))
                 {
@@ -407,10 +403,10 @@ namespace OpenSage.Graphics.ParticleSystems
             particle.Timer += 1;
         }
 
-        private static void FindKeyFrames<TKeyFrame>(int timer,
-            IReadOnlyList<TKeyFrame> keyFrames,
-            out TKeyFrame next, out TKeyFrame prev)
-            where TKeyFrame : struct, IParticleKeyframe
+        private static void FindKeyframes<T>(int timer,
+            IReadOnlyList<T> keyFrames,
+            out T next, out T prev)
+            where T : struct, IParticleKeyframe
         {
             prev = keyFrames[0];
             next = prev;
@@ -455,7 +451,7 @@ namespace OpenSage.Graphics.ParticleSystems
             _graphicsDevice.UpdateBuffer(_vertexBuffer, 0, _vertices);
         }
 
-        public Matrix4x4 GetWorldMatrix() => _getWorldMatrix();
+        public ref readonly Matrix4x4 GetWorldMatrix() => ref _getWorldMatrix();
 
         public void BuildRenderList(RenderList renderList, in Matrix4x4 worldMatrix)
         {

--- a/src/OpenSage.Game/Graphics/ParticleSystems/ParticleSystem.cs
+++ b/src/OpenSage.Game/Graphics/ParticleSystems/ParticleSystem.cs
@@ -66,6 +66,14 @@ namespace OpenSage.Graphics.ParticleSystems
 
             _getWorldMatrix = getWorldMatrix;
 
+            var maxParticles = CalculateMaxParticles();
+
+            // If this system never emits any particles, there's no reason to fully initialise it.
+            if (maxParticles == 0)
+            {
+                return;
+            }
+
             _graphicsDevice = contentManager.GraphicsDevice;
 
             _particleMaterial = AddDisposable(new ParticleMaterial(contentManager, contentManager.EffectLibrary.Particle));
@@ -112,8 +120,6 @@ namespace OpenSage.Graphics.ParticleSystems
             addColorKeyframe(Definition.Color6, Definition.Color5);
             addColorKeyframe(Definition.Color7, Definition.Color6);
             addColorKeyframe(Definition.Color8, Definition.Color7);
-
-            var maxParticles = CalculateMaxParticles();
 
             _particles = new Particle[maxParticles];
             for (var i = 0; i < _particles.Length; i++)
@@ -188,6 +194,11 @@ namespace OpenSage.Graphics.ParticleSystems
 
         public void Update(GameTime gameTime)
         {
+            if (_particles == null)
+            {
+                return;
+            }
+
             if (gameTime.TotalGameTime < _nextUpdate)
             {
                 return;
@@ -455,6 +466,11 @@ namespace OpenSage.Graphics.ParticleSystems
 
         public void BuildRenderList(RenderList renderList, in Matrix4x4 worldMatrix)
         {
+            if (_particles == null)
+            {
+                return;
+            }
+
             renderList.Transparent.AddRenderItemDrawIndexed(
                 _particleMaterial,
                 _vertexBuffer,

--- a/src/OpenSage.Game/Graphics/ParticleSystems/ParticleSystemSystem.cs
+++ b/src/OpenSage.Game/Graphics/ParticleSystems/ParticleSystemSystem.cs
@@ -43,7 +43,7 @@ namespace OpenSage.Graphics.ParticleSystems
             // TODO: Keep particle count under GameData.MaxParticleCount
             foreach (var attachedParticleSystem in _scene.GetAllAttachedParticleSystems())
             {
-                var worldMatrix = attachedParticleSystem.ParticleSystem.GetWorldMatrix();
+                ref readonly var worldMatrix = ref attachedParticleSystem.ParticleSystem.GetWorldMatrix();
 
                 attachedParticleSystem.ParticleSystem.BuildRenderList(
                     renderList,

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -188,7 +188,7 @@ namespace OpenSage.Logic.Object
                     particleSystems.Add(new ParticleSystem(
                         _contentManager,
                         particleSystemDefinition,
-                        () => modelInstance.AbsoluteBoneTransforms[bone.Index]));
+                        () => ref modelInstance.AbsoluteBoneTransforms[bone.Index]));
                 }
             }
 

--- a/src/OpenSage.Game/Mathematics/Vector3Utility.cs
+++ b/src/OpenSage.Game/Mathematics/Vector3Utility.cs
@@ -4,13 +4,13 @@ namespace OpenSage.Mathematics
 {
     public static class Vector3Utility
     {
-        public static Vector3 Lerp(ref Vector3 x, ref Vector3 y, float s)
+        public static Vector3 Lerp(in Vector3 x, in Vector3 y, float s)
         {
             return x + s * (y - x);
         }
 
         //  From https://keithmaggio.wordpress.com/2011/02/15/math-magician-lerp-slerp-and-nlerp/
-        public static Vector3 Slerp(Vector3 start, Vector3 end, float percent)
+        public static Vector3 Slerp(in Vector3 start, in Vector3 end, float percent)
         {
             // Dot product - the cosine of the angle between 2 vectors.
             float dot = Vector3.Dot(start, end);


### PR DESCRIPTION
* Change `ParticleAlphaKeyframe` and `ParticleColorKeyframe` into structs to reduce allocations during rendering.
* Reuse alpha keyframe lists
* Extract the logic for finding the current and previous keyframes into a separate function
* Reduce large struct copies by adding `in` to `Vector3` arguments and passing world matrices by a readonly reference.
  * Note that Vector3 copies can't be completely eliminated, because `System.Numerics` doesn't use `in` parameters yet.
* Fix engine crash when trying to initialize particle systems with burst count of 0. Fixed by adding an early return to `ParticleSystem` constructor, and null checks in `Update` and `BuildRenderList`.

With this patch particle systems should allocate **0 bytes** after initialisation.