### PR TITLE
Add basic launch parameters to launcher using System.CommandLine

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,5 +2,6 @@
 <configuration>
   <packageSources>
     <add key="myget mellinoe" value="https://www.myget.org/F/mellinoe/api/v3/index.json" />
+    <add key="CoreFX Lab" value="https://dotnet.myget.org/F/dotnet-corefxlab/" />
   </packageSources>
 </configuration>

--- a/src/OpenSage.Game/Configuration.cs
+++ b/src/OpenSage.Game/Configuration.cs
@@ -1,0 +1,13 @@
+﻿namespace OpenSage
+{
+    // TODO: Should this be immutable?
+    // TODO: Should there be a way of merging Configuration instances?
+    /// <summary>
+    /// Contains configuration for a game instance, typically gathered from
+    /// command line parameters and configuration files.
+    /// </summary>
+    public sealed class Configuration
+    {
+        public bool LoadShellMap { get; set; } = true;
+    }
+}

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -71,6 +71,8 @@ namespace OpenSage
 
         public SageGame SageGame { get; }
 
+        public Configuration Configuration { get; private set; }
+
         public string UserDataLeafName
         {
             get
@@ -135,6 +137,9 @@ namespace OpenSage
             Type wndCallbacksType,
             Func<GameWindow> createGameWindow)
         {
+            // TODO: Should we receive this as an argument? Do we need configuration in this constructor?
+            Configuration = new Configuration();
+
             Window = AddDisposable(createGameWindow());
 
 #if DEBUG
@@ -170,7 +175,8 @@ namespace OpenSage
                 GraphicsDevice,
                 sageGame,
                 _wndCallbackResolver));
-            
+
+            // TODO: Add these into IGameDefinition? Should we preload all ini files?
             switch (sageGame)
             {
                 case SageGame.Ra3:

--- a/src/OpenSage.Game/GameFactory.cs
+++ b/src/OpenSage.Game/GameFactory.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using OpenSage.Data;
-using Veldrid;
 
 namespace OpenSage
 {
@@ -20,10 +19,7 @@ namespace OpenSage
                 throw new Exception($"No installations for {definition.Game} could be found.");
             }
 
-            return CreateGame(
-                installation,
-                installation.CreateFileSystem(),
-                createWindow);
+            return CreateGame(installation, installation.CreateFileSystem(), createWindow);
         }
 
         public static Game CreateGame(
@@ -32,12 +28,7 @@ namespace OpenSage
             Func<GameWindow> createWindow)
         {
             var definition = installation.Game;
-
-            return new Game(
-                fileSystem,
-                definition.Game,
-                definition.WndCallbackType,
-                createWindow);
+            return new Game(definition, fileSystem, createWindow);
         }
     }
 }

--- a/src/OpenSage.Game/Gui/Apt/AptMainMenuSource.cs
+++ b/src/OpenSage.Game/Gui/Apt/AptMainMenuSource.cs
@@ -1,0 +1,20 @@
+﻿using OpenSage.Content;
+
+namespace OpenSage.Gui.Apt
+{
+    public class AptMainMenuSource : IMainMenuSource
+    {
+        private readonly string _aptFileName;
+
+        public AptMainMenuSource(string aptFileName)
+        {
+            _aptFileName = aptFileName;
+        }
+
+        public void AddToScene(ContentManager contentManager, Scene2D scene)
+        {
+            var aptWindow = contentManager.Load<AptWindow>(_aptFileName);
+            scene.AptWindowManager.PushWindow(aptWindow);
+        }
+    }
+}

--- a/src/OpenSage.Game/Gui/IMainMenuSource.cs
+++ b/src/OpenSage.Game/Gui/IMainMenuSource.cs
@@ -1,0 +1,9 @@
+﻿using OpenSage.Content;
+
+namespace OpenSage.Gui
+{
+    public interface IMainMenuSource
+    {
+        void AddToScene(ContentManager contentManager, Scene2D scene);
+    }
+}

--- a/src/OpenSage.Game/Gui/Wnd/WndMainMenuSource.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndMainMenuSource.cs
@@ -1,0 +1,19 @@
+﻿using OpenSage.Content;
+
+namespace OpenSage.Gui.Wnd
+{
+    public class WndMainMenuSource : IMainMenuSource
+    {
+        private readonly string _wndFileName;
+
+        public WndMainMenuSource(string wndFileName)
+        {
+            _wndFileName = wndFileName;
+        }
+
+        public void AddToScene(ContentManager contentManager, Scene2D scene)
+        {
+            scene.WndWindowManager.PushWindow(_wndFileName);
+        }
+    }
+}

--- a/src/OpenSage.Game/Gui/Wnd/WndWindow.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndWindow.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using OpenSage.Content;
 using OpenSage.Data.Wnd;
@@ -96,7 +97,7 @@ namespace OpenSage.Gui.Wnd
         public UIElementCallback SystemCallback { get; private set; }
         internal UIElementCallback InputCallback { get; private set; }
         internal UIElementCallback TooltipCallback { get; private set; }
-        internal UIElementDrawCallback DrawCallback { get; private set; }
+        public UIElementDrawCallback DrawCallback { get; set; }
 
         private ColorRgba? _backgroundColorOverride;
         public ColorRgba? BackgroundColorOverride
@@ -300,7 +301,7 @@ namespace OpenSage.Gui.Wnd
 
         protected virtual void DefaultSystemOverride(WndWindowMessage message, UIElementCallbackContext context) { }
 
-        public static void DefaultDraw(WndWindow window, Game game)
+        public void DefaultDraw(WndWindow window, Game game)
         {
             var activeState = window.ActiveState;
 

--- a/src/OpenSage.Game/Gui/Wnd/WndWindow.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndWindow.cs
@@ -300,7 +300,7 @@ namespace OpenSage.Gui.Wnd
 
         protected virtual void DefaultSystemOverride(WndWindowMessage message, UIElementCallbackContext context) { }
 
-        protected void DefaultDraw(WndWindow window, Game game)
+        public static void DefaultDraw(WndWindow window, Game game)
         {
             var activeState = window.ActiveState;
 

--- a/src/OpenSage.Game/IGameDefinition.cs
+++ b/src/OpenSage.Game/IGameDefinition.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using OpenSage.Data;
+using OpenSage.Gui;
 
 namespace OpenSage
 {
@@ -15,5 +16,7 @@ namespace OpenSage
         string LauncherImagePath { get; }
 
         IEnumerable<RegistryKeyPath> RegistryKeys { get; }
+
+        IMainMenuSource MainMenu { get; }
     }
 }

--- a/src/OpenSage.Launcher/OpenSage.Launcher.csproj
+++ b/src/OpenSage.Launcher/OpenSage.Launcher.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180210-2" />
+    <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180220-2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenSage.Launcher/OpenSage.Launcher.csproj
+++ b/src/OpenSage.Launcher/OpenSage.Launcher.csproj
@@ -13,6 +13,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180210-2" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\OpenSage.Game\OpenSage.Game.csproj" />

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -1,5 +1,7 @@
 ﻿using OpenSage.Data;
 using OpenSage.Mods.BuiltIn;
+using System.CommandLine;
+using System.Linq;
 
 namespace OpenSage.Launcher
 {
@@ -7,20 +9,47 @@ namespace OpenSage.Launcher
     {
         public static void Main(string[] args)
         {
+            var noShellMap = false;
+            var startupGame = SageGame.CncGenerals;
+
+            ArgumentSyntax.Parse(args, syntax =>
+            {
+                syntax.DefineOption("noshellmap", ref noShellMap, false,
+                    "Disables loading the shell map, speeding up startup time.");
+
+                string gameName = null;
+                var availableMods = GameDefinition.All.Select(def => def.Game.ToString());
+                syntax.DefineOption("game", ref gameName, false,
+                    $"Chooses which game to start. Valid options: {string.Join(", ", availableMods)}");
+
+                if (!TryGetGameByName(gameName, out startupGame))
+                {
+                    syntax.ReportError($"Unknown game: {gameName}");
+                }
+            });
+
             Platform.CurrentPlatform = new Sdl2Platform();
             Platform.CurrentPlatform.Start();
 
-            // TODO: Get the game from a launch parameter.
             // TODO: Support other locators.
             var game = GameFactory.CreateGame(
-                GameDefinition.FromGame(SageGame.CncGenerals),
+                GameDefinition.FromGame(startupGame),
                 new RegistryInstallationLocator(),
                 // TODO: Read game version from assembly metadata or .git folder
                 () => Platform.CurrentPlatform.CreateWindow("OpenSAGE (master)", 100, 100, 1024, 768));
 
             // TODO: Set window icon.
 
-            SetupInitialScene(game);
+            if (!noShellMap)
+            {
+                var shellMapName = game.ContentManager.IniDataContext.GameData.ShellMapName;
+                var mainMenuScene = game.ContentManager.Load<Scene3D>(shellMapName);
+                game.Scene3D = mainMenuScene;
+                game.Scripting.Active = true;
+            }
+
+            // TODO: Configure this per-game, and make it work with APT.
+            game.Scene2D.WndWindowManager.PushWindow("Menus\\MainMenu.wnd");
 
             while (game.IsRunning)
             {
@@ -30,16 +59,17 @@ namespace OpenSage.Launcher
             Platform.CurrentPlatform.Stop();
         }
 
-        // TODO: Extract this logic into a game-specific DLL, or make the scene and menu configurable.
-        // TODO: Implement fast startup, where the shellmap is not loaded.
-        private static void SetupInitialScene(Game game)
+        private static bool TryGetGameByName(string name, out SageGame game)
         {
-            var mainMenuScene = game.ContentManager.Load<Scene3D>("maps\\ShellMap1\\ShellMap1.map");
-            game.Scene3D = mainMenuScene;
-
-            game.Scene2D.WndWindowManager.PushWindow("Menus\\MainMenu.wnd");
-
-            game.Scripting.Active = true;
+            // TODO: Use a short identifier defined in IGameDefinition instead of stringified SageGame
+            var gameOrNull = GameDefinition.All.SingleOrDefault(def => def.Game.ToString().ToLower() == name)?.Game;
+            if (gameOrNull == null)
+            {
+                game = SageGame.CncGenerals;
+                return false;
+            }
+            game = gameOrNull.Value;
+            return true;
         }
     }
 }

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -2,6 +2,7 @@
 using OpenSage.Mods.BuiltIn;
 using System.CommandLine;
 using System.Linq;
+using OpenSage.Gui.Wnd;
 
 namespace OpenSage.Launcher
 {
@@ -31,10 +32,13 @@ namespace OpenSage.Launcher
             Platform.CurrentPlatform = new Sdl2Platform();
             Platform.CurrentPlatform.Start();
 
+            var definition = GameDefinition.FromGame(startupGame);
+            var locator = new RegistryInstallationLocator();
+
             // TODO: Support other locators.
             var game = GameFactory.CreateGame(
-                GameDefinition.FromGame(startupGame),
-                new RegistryInstallationLocator(),
+                definition,
+                locator,
                 // TODO: Read game version from assembly metadata or .git folder
                 () => Platform.CurrentPlatform.CreateWindow("OpenSAGE (master)", 100, 100, 1024, 768));
 
@@ -48,8 +52,7 @@ namespace OpenSage.Launcher
                 game.Scripting.Active = true;
             }
 
-            // TODO: Configure this per-game, and make it work with APT.
-            game.Scene2D.WndWindowManager.PushWindow("Menus\\MainMenu.wnd");
+            definition.MainMenu?.AddToScene(game.ContentManager, game.Scene2D);
 
             while (game.IsRunning)
             {

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -42,10 +42,7 @@ namespace OpenSage.Launcher
                 () => Platform.CurrentPlatform.CreateWindow("OpenSAGE (master)", 100, 100, 1024, 768));
 
             game.Configuration.LoadShellMap = !noShellMap;
-
-
-            // The main menu also loads the shell map.
-            definition.MainMenu?.AddToScene(game.ContentManager, game.Scene2D);
+            game.ShowMainMenu();
 
             while (game.IsRunning)
             {

--- a/src/OpenSage.Mods.Bfme/BfmeDefinition.cs
+++ b/src/OpenSage.Mods.Bfme/BfmeDefinition.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using OpenSage.Data;
+using OpenSage.Gui;
 
 namespace OpenSage.Mods.BFME
 {
@@ -19,6 +20,8 @@ namespace OpenSage.Mods.BFME
         {
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\EA Games\The Battle for Middle-earth", "InstallPath")
         };
+
+        public IMainMenuSource MainMenu { get; }
 
         public static BfmeDefinition Instance { get; } = new BfmeDefinition();
     }

--- a/src/OpenSage.Mods.BfmeII/BfmeIIDefinition.cs
+++ b/src/OpenSage.Mods.BfmeII/BfmeIIDefinition.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using OpenSage.Data;
 using OpenSage.Gui;
+using OpenSage.Gui.Apt;
 
 namespace OpenSage.Mods.BfmeII
 {
@@ -21,7 +22,7 @@ namespace OpenSage.Mods.BfmeII
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\The Battle for Middle-earth II", "InstallPath")
         };
 
-        public IMainMenuSource MainMenu { get; }
+        public IMainMenuSource MainMenu { get; } = new AptMainMenuSource("MainMenu.apt");
 
         public static BfmeIIDefinition Instance { get; } = new BfmeIIDefinition();
     }

--- a/src/OpenSage.Mods.BfmeII/BfmeIIDefinition.cs
+++ b/src/OpenSage.Mods.BfmeII/BfmeIIDefinition.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using OpenSage.Data;
+using OpenSage.Gui;
 
 namespace OpenSage.Mods.BfmeII
 {
@@ -19,6 +20,8 @@ namespace OpenSage.Mods.BfmeII
         {
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\The Battle for Middle-earth II", "InstallPath")
         };
+
+        public IMainMenuSource MainMenu { get; }
 
         public static BfmeIIDefinition Instance { get; } = new BfmeIIDefinition();
     }

--- a/src/OpenSage.Mods.BuiltIn/GameDefinition.cs
+++ b/src/OpenSage.Mods.BuiltIn/GameDefinition.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
-
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using OpenSage.Mods.Generals;
 using OpenSage.Mods.BFME;
 using OpenSage.Mods.BfmeII;
@@ -15,6 +16,14 @@ namespace OpenSage.Mods.BuiltIn
 
         public static IEnumerable<IGameDefinition> All => Games.Values;
         public static IGameDefinition FromGame(SageGame game) => Games[game];
+
+        public static bool TryGetByName(string name, out IGameDefinition definition)
+        {
+            // TODO: Use a short identifier defined in IGameDefinition instead of stringified SageGame
+            definition = All.FirstOrDefault(def =>
+                string.Equals(def.Game.ToString(), name, StringComparison.InvariantCultureIgnoreCase));
+            return definition != null;
+        }
 
         static GameDefinition()
         {

--- a/src/OpenSage.Mods.Cnc3/Cnc3Definition.cs
+++ b/src/OpenSage.Mods.Cnc3/Cnc3Definition.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using OpenSage.Data;
+using OpenSage.Gui;
 
 namespace OpenSage.Mods.CnC3
 {
@@ -18,6 +19,8 @@ namespace OpenSage.Mods.CnC3
         {
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Command and Conquer 3", "InstallPath")
         };
+
+        public IMainMenuSource MainMenu { get; }
 
         public static Cnc3Definition Instance { get; } = new Cnc3Definition();
     }

--- a/src/OpenSage.Mods.Cnc3/Cnc3KanesWrathDefinition.cs
+++ b/src/OpenSage.Mods.Cnc3/Cnc3KanesWrathDefinition.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using OpenSage.Data;
+using OpenSage.Gui;
 
 namespace OpenSage.Mods.CnC3
 {
@@ -18,6 +19,8 @@ namespace OpenSage.Mods.CnC3
         {
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Command and Conquer 3 Kanes Wrath", "InstallPath")
         };
+
+        public IMainMenuSource MainMenu { get; }
 
         public static Cnc3KanesWrathDefinition Instance { get; } = new Cnc3KanesWrathDefinition();
     }

--- a/src/OpenSage.Mods.Cnc4/Cnc4Definition.cs
+++ b/src/OpenSage.Mods.Cnc4/Cnc4Definition.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using OpenSage.Data;
+using OpenSage.Gui;
 
 namespace OpenSage.Mods.Cnc4
 {
@@ -19,6 +20,8 @@ namespace OpenSage.Mods.Cnc4
             new RegistryKeyPath(@"SOFTWARE\EA Games\Command Conquer 4 Tiberian Twilight", "Install Dir"), // Origin
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\command and conquer 4", "install dir") // Steam
         };
+
+        public IMainMenuSource MainMenu { get; }
 
         public static Cnc4Definition Instance { get; } = new Cnc4Definition();
     }

--- a/src/OpenSage.Mods.Generals/GeneralsDefinition.cs
+++ b/src/OpenSage.Mods.Generals/GeneralsDefinition.cs
@@ -21,7 +21,7 @@ namespace OpenSage.Mods.Generals
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\EA Games\Generals", "InstallPath")
         };
 
-        public IMainMenuSource MainMenu => new WndMainMenuSource(@"Menus\MainMenu.wnd");
+        public IMainMenuSource MainMenu { get; } = new WndMainMenuSource(@"Menus\MainMenu.wnd");
 
         public static GeneralsDefinition Instance { get; } = new GeneralsDefinition();
     }

--- a/src/OpenSage.Mods.Generals/GeneralsDefinition.cs
+++ b/src/OpenSage.Mods.Generals/GeneralsDefinition.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using OpenSage.Data;
+using OpenSage.Gui;
+using OpenSage.Gui.Wnd;
 
 namespace OpenSage.Mods.Generals
 {
@@ -18,6 +20,8 @@ namespace OpenSage.Mods.Generals
         {
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\EA Games\Generals", "InstallPath")
         };
+
+        public IMainMenuSource MainMenu => new WndMainMenuSource(@"Menus\MainMenu.wnd");
 
         public static GeneralsDefinition Instance { get; } = new GeneralsDefinition();
     }

--- a/src/OpenSage.Mods.Generals/GeneralsZeroHourDefinition.cs
+++ b/src/OpenSage.Mods.Generals/GeneralsZeroHourDefinition.cs
@@ -23,7 +23,7 @@ namespace OpenSage.Mods.Generals
             new RegistryKeyPath(@"SOFTWARE\EA Games\Command and Conquer Generals Zero Hour", "Install Dir", "Command and Conquer Generals Zero Hour\\")
         };
 
-        public IMainMenuSource MainMenu => new WndMainMenuSource(@"Menus\MainMenu.wnd");
+        public IMainMenuSource MainMenu { get; } = new WndMainMenuSource(@"Menus\MainMenu.wnd");
 
         public static GeneralsZeroHourDefinition Instance { get; } = new GeneralsZeroHourDefinition();
     }

--- a/src/OpenSage.Mods.Generals/GeneralsZeroHourDefinition.cs
+++ b/src/OpenSage.Mods.Generals/GeneralsZeroHourDefinition.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using OpenSage.Data;
+using OpenSage.Gui;
+using OpenSage.Gui.Wnd;
 
 namespace OpenSage.Mods.Generals
 {
@@ -20,6 +22,8 @@ namespace OpenSage.Mods.Generals
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\EA Games\Command and Conquer Generals Zero Hour", "InstallPath"),
             new RegistryKeyPath(@"SOFTWARE\EA Games\Command and Conquer Generals Zero Hour", "Install Dir", "Command and Conquer Generals Zero Hour\\")
         };
+
+        public IMainMenuSource MainMenu => new WndMainMenuSource(@"Menus\MainMenu.wnd");
 
         public static GeneralsZeroHourDefinition Instance { get; } = new GeneralsZeroHourDefinition();
     }

--- a/src/OpenSage.Mods.Generals/WndCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/WndCallbacks.cs
@@ -55,7 +55,11 @@ namespace OpenSage.Mods.Generals
 
         public static void W3DNoDraw(WndWindow element, Game game)
         {
-            
+            // Draw the main menu background if no map is loaded.
+            if (element.Name == "MainMenu.wnd:MainMenuParent" && game.Scene3D == null)
+            {
+                WndWindow.DefaultDraw(element, game);
+            }
         }
 
         public static void MainMenuSystem(WndWindow element, WndWindowMessage message, UIElementCallbackContext context)

--- a/src/OpenSage.Mods.Generals/WndCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/WndCallbacks.cs
@@ -51,16 +51,15 @@ namespace OpenSage.Mods.Generals
             // TODO: Show faction icons when WinScaleUpTransition is implemented.
 
             _doneMainMenuFadeIn = false;
-        }
 
-        public static void W3DNoDraw(WndWindow element, Game game)
-        {
-            // Draw the main menu background if no map is loaded.
-            if (element.Name == "MainMenu.wnd:MainMenuParent" && game.Scene3D == null)
+            if (game.Scene3D == null)
             {
-                WndWindow.DefaultDraw(element, game);
+                // Draw the main menu background if no map is loaded.
+                window.Root.DrawCallback = window.Root.DefaultDraw;
             }
         }
+
+        public static void W3DNoDraw(WndWindow element, Game game) { }
 
         public static void MainMenuSystem(WndWindow element, WndWindowMessage message, UIElementCallbackContext context)
         {

--- a/src/OpenSage.Mods.Generals/WndCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/WndCallbacks.cs
@@ -14,6 +14,19 @@ namespace OpenSage.Mods.Generals
 
         public static void W3DMainMenuInit(WndTopLevelWindow window, Game game)
         {
+            if (game.Configuration.LoadShellMap)
+            {
+                var shellMapName = game.ContentManager.IniDataContext.GameData.ShellMapName;
+                var mainMenuScene = game.ContentManager.Load<Scene3D>(shellMapName);
+                game.Scene3D = mainMenuScene;
+                game.Scripting.Active = true;
+            }
+            else
+            {
+                // Draw the main menu background if no map is loaded.
+                window.Root.DrawCallback = window.Root.DefaultDraw;
+            }
+
             // We'll show these later via window transitions.
             window.Root.FindChild("MainMenu.wnd:MainMenuRuler").Hide();
             window.Root.FindChild("MainMenu.wnd:MainMenuRuler").Opacity = 0;
@@ -51,12 +64,6 @@ namespace OpenSage.Mods.Generals
             // TODO: Show faction icons when WinScaleUpTransition is implemented.
 
             _doneMainMenuFadeIn = false;
-
-            if (game.Scene3D == null)
-            {
-                // Draw the main menu background if no map is loaded.
-                window.Root.DrawCallback = window.Root.DefaultDraw;
-            }
         }
 
         public static void W3DNoDraw(WndWindow element, Game game) { }

--- a/src/OpenSage.Mods.Generals/WndCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/WndCallbacks.cs
@@ -14,14 +14,7 @@ namespace OpenSage.Mods.Generals
 
         public static void W3DMainMenuInit(WndTopLevelWindow window, Game game)
         {
-            if (game.Configuration.LoadShellMap)
-            {
-                var shellMapName = game.ContentManager.IniDataContext.GameData.ShellMapName;
-                var mainMenuScene = game.ContentManager.Load<Scene3D>(shellMapName);
-                game.Scene3D = mainMenuScene;
-                game.Scripting.Active = true;
-            }
-            else
+            if (!game.Configuration.LoadShellMap)
             {
                 // Draw the main menu background if no map is loaded.
                 window.Root.DrawCallback = window.Root.DefaultDraw;

--- a/src/OpenSage.Mods.Ra3/Ra3Definition.cs
+++ b/src/OpenSage.Mods.Ra3/Ra3Definition.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using OpenSage.Data;
+using OpenSage.Gui;
 
 namespace OpenSage.Mods.Ra3
 {
@@ -18,6 +19,8 @@ namespace OpenSage.Mods.Ra3
         {
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Red Alert 3", "Install Dir"),
         };
+
+        public IMainMenuSource MainMenu { get; }
 
         public static Ra3Definition Instance { get; } = new Ra3Definition();
     }

--- a/src/OpenSage.Mods.Ra3/Ra3UprisingDefinition.cs
+++ b/src/OpenSage.Mods.Ra3/Ra3UprisingDefinition.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using OpenSage.Data;
+using OpenSage.Gui;
 
 namespace OpenSage.Mods.Ra3
 {
@@ -18,6 +19,8 @@ namespace OpenSage.Mods.Ra3
         {
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Red Alert 3 Uprising", "Install Dir")
         };
+
+        public IMainMenuSource MainMenu { get; }
 
         public static Ra3UprisingDefinition Instance { get; } = new Ra3UprisingDefinition();
     }


### PR DESCRIPTION
* `--noshellmap`
  * Skips loading the shell map, speeding up initial loading time.
  * Present in SAGE, but with only one dash.
  * Related to this: draw the static background image in Generals & ZH main menu if there's no 3D scene.
* `--game`
  * Chooses which game to start. Generals is still the default.
  * Currently takes the game name as a case-insensitive `SageGame` entry. I'd like to replace this with a shorter string identifier (added to `IGameDefinition`), which could be used for other things such as configuration files, debug information and maybe even multiplayer lobbies.
* Add `IMainMenuSource`, `WndMainMenuSource` and `AptMainMenuSource`
* Add `Configuration` type. The only implemented setting right now is `bool LoadShellMap`.
* Add a reference to `IGameDefinition` in `Game`
* Move shell map handling to `Game`
