### PR TITLE
Use a regex to get localized launcher images

### DIFF
--- a/src/OpenSage.DataViewer/UI/MainForm.cs
+++ b/src/OpenSage.DataViewer/UI/MainForm.cs
@@ -110,8 +110,14 @@ namespace OpenSage.DataViewer.UI
             var launcherImagePath = installation.Game.LauncherImagePath;
             if (launcherImagePath != null)
             {
-                var fullImagePath = Path.Combine(installation.Path, launcherImagePath);
-                _installationImageView.Image = new Bitmap(fullImagePath);
+                var images = Directory.GetFiles(installation.Path, launcherImagePath, SearchOption.TopDirectoryOnly);
+
+                if (images.Length > 0)
+                {
+                    _installationImageView.Image = new Bitmap(images[0]);
+                }
+
+                _installationImageView.Image = null;
             }
             else
             {

--- a/src/OpenSage.Mods.Bfme/BfmeDefinition.cs
+++ b/src/OpenSage.Mods.Bfme/BfmeDefinition.cs
@@ -12,8 +12,7 @@ namespace OpenSage.Mods.BFME
 
         public Type WndCallbackType => null;
 
-        // TODO: Localise?
-        public string LauncherImagePath => "englishsplash.jpg";
+        public string LauncherImagePath => "*splash.jpg";
 
         public IEnumerable<RegistryKeyPath> RegistryKeys { get; } = new[]
         {

--- a/src/OpenSage.Mods.BfmeII/BfmeIIDefinition.cs
+++ b/src/OpenSage.Mods.BfmeII/BfmeIIDefinition.cs
@@ -12,8 +12,7 @@ namespace OpenSage.Mods.BfmeII
 
         public Type WndCallbackType => null;
 
-        // TODO: Localise?
-        public string LauncherImagePath => "EnglishSplash.jpg";
+        public string LauncherImagePath => "*Splash.jpg";
 
         public IEnumerable<RegistryKeyPath> RegistryKeys { get; } = new[]
         {


### PR DESCRIPTION
This PR changed the launcher image loading to a regex to make it possible to load launcher images of different languages,  because for example in Bfme they are called Germansplash.jpg in the german version (which I use).