### PR TITLE
Catch exceptions of corrupted big files

### DIFF
--- a/src/OpenSage.Game/Data/FileSystem.cs
+++ b/src/OpenSage.Game/Data/FileSystem.cs
@@ -34,7 +34,15 @@ namespace OpenSage.Data
                 var ext = Path.GetExtension(file).ToLower();
                 if (ext == ".big")
                 {
-                    var archive = new BigArchive(file);
+                    BigArchive archive;
+                    try
+                    {
+                        archive = new BigArchive(file);
+                    }
+                    catch (Exception e)
+                    {
+                        continue;
+                    }
 
                     _bigArchives.Add(archive);
 


### PR DESCRIPTION
I recognized that OpenSAGE crashed with my battle for middle earth installation, because of a corrupted big file which the installer placed. I added some lines to skip over such files.