### PR TITLE
Rename SageGame entries for BFME games, add BFME2 expansion

### DIFF
--- a/src/OpenSage.Game.Tests/Data/Apt/AptFileTest.cs
+++ b/src/OpenSage.Game.Tests/Data/Apt/AptFileTest.cs
@@ -14,7 +14,7 @@ namespace OpenSage.Tests.Data.Apt
             _output = output;
         }
 
-        [GameFact(SageGame.BattleForMiddleEarth, SageGame.BattleForMiddleEarthII)]
+        [GameFact(SageGame.Bfme, SageGame.Bfme2, SageGame.Bfme2Rotwk)]
         public void CanReadAptFiles()
         {
             InstalledFilesTestData.ReadFiles(".apt", _output, entry =>
@@ -30,10 +30,10 @@ namespace OpenSage.Tests.Data.Apt
             });
         }
 
-        [GameFact(SageGame.BattleForMiddleEarthII)]
+        [GameFact(SageGame.Bfme2)]
         public void CheckEntryCount()
         {
-            var fileSystem = new FileSystem(InstalledFilesTestData.GetInstallationDirectory(SageGame.BattleForMiddleEarthII));
+            var fileSystem = new FileSystem(InstalledFilesTestData.GetInstallationDirectory(SageGame.Bfme2));
             var entry = fileSystem.GetFile(@"MainMenu.apt");
 
             var data = AptFile.FromFileSystemEntry(entry);

--- a/src/OpenSage.Game.Tests/Data/Apt/ConstFileTests.cs
+++ b/src/OpenSage.Game.Tests/Data/Apt/ConstFileTests.cs
@@ -16,7 +16,7 @@ namespace OpenSage.Tests.Data.Apt
             _output = output;
         }
 
-        [GameFact(SageGame.BattleForMiddleEarth, SageGame.BattleForMiddleEarthII)]
+        [GameFact(SageGame.Bfme, SageGame.Bfme2, SageGame.Bfme2Rotwk)]
         public void CanReadConstFiles()
         {
             InstalledFilesTestData.ReadFiles(".const", _output, entry =>
@@ -27,10 +27,10 @@ namespace OpenSage.Tests.Data.Apt
             });
         }
 
-        [GameFact(SageGame.BattleForMiddleEarthII)]
+        [GameFact(SageGame.Bfme2)]
         public void CheckEntryCount()
         {
-            var bigFilePath = Path.Combine(InstalledFilesTestData.GetInstallationDirectory(SageGame.BattleForMiddleEarthII), "apt/MainMenu.big");
+            var bigFilePath = Path.Combine(InstalledFilesTestData.GetInstallationDirectory(SageGame.Bfme2), "apt/MainMenu.big");
 
             using (var bigArchive = new BigArchive(bigFilePath))
             {

--- a/src/OpenSage.Game/Content/TranslationManager.cs
+++ b/src/OpenSage.Game/Content/TranslationManager.cs
@@ -18,8 +18,9 @@ namespace OpenSage.Content
                 case SageGame.CncGeneralsZeroHour:
                     csfEntry = fileSystem.GetFile(@"Data\English\generals.csf");
                     break;
-                case SageGame.BattleForMiddleEarth:
-                case SageGame.BattleForMiddleEarthII:
+                case SageGame.Bfme:
+                case SageGame.Bfme2:
+                case SageGame.Bfme2Rotwk:
                     csfEntry = fileSystem.GetFile(@"lotr.csf");
                     break;
                 case SageGame.Cnc3:

--- a/src/OpenSage.Game/Content/WindowLoader.cs
+++ b/src/OpenSage.Game/Content/WindowLoader.cs
@@ -24,11 +24,12 @@ namespace OpenSage.Content
                     contentManager.IniDataContext.LoadIniFile(@"Data\English\HeaderTemplate.ini");
                     break;
 
-                case SageGame.BattleForMiddleEarth:
+                case SageGame.Bfme:
                     contentManager.IniDataContext.LoadIniFile(@"lang\english\headertemplate.ini");
                     break;
 
-                case SageGame.BattleForMiddleEarthII:
+                case SageGame.Bfme2:
+                case SageGame.Bfme2Rotwk:
                     contentManager.IniDataContext.LoadIniFile(@"headertemplate.ini");
                     break;
             }

--- a/src/OpenSage.Game/Data/Csf/CsfLanguage.cs
+++ b/src/OpenSage.Game/Data/Csf/CsfLanguage.cs
@@ -11,6 +11,7 @@
         Japanese = 6,
         Unknown = 7,
         Korean = 8,
-        Chinese = 9
+        Chinese = 9,
+        EnglishInternational = 23
     }
 }

--- a/src/OpenSage.Game/Data/Ini/AIData.cs
+++ b/src/OpenSage.Game/Data/Ini/AIData.cs
@@ -100,19 +100,19 @@ namespace OpenSage.Data.Ini
             { "AttackPriority", (parser, x) => x.AttackPriorities.Add(AttackPriority.Parse(parser)) },
         };
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool UseLowLodTrees { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float LowLodTreeScale { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string LowLodTreeName { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string LowLodTreeNameNoGrab { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string LowLodTreeNameNoHarvest { get; private set; }
 
         public float StructureSeconds { get; private set; }
@@ -158,34 +158,34 @@ namespace OpenSage.Data.Ini
         public float MinDistanceForGroup { get; private set; }
         public float DistanceRequiresGroup { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float FormationEnemyDistance { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float FormationColumnWidth { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float FormationRowDepth { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float FormationSquadSpacing { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int FormationColumns { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool UseFormations { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool WaitForOthers { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float NarrowPassageScale { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool HordesWaitForHordes { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool AttackMoveUsesFormations { get; private set; }
 
         public int InfantryPathfindDiameter { get; private set; }
@@ -197,16 +197,16 @@ namespace OpenSage.Data.Ini
         public float AIDozerBoredRadiusModifier { get; private set; }
         public bool AICrushesInfantry { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float MeleeApproachDist { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float MeleeApproachTolerance { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float MeleeAcquireLimitDist { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float WadeWaterDepth { get; private set; }
 
         [AddedIn(SageGame.CncGeneralsZeroHour)]
@@ -215,23 +215,23 @@ namespace OpenSage.Data.Ini
         [AddedIn(SageGame.CncGeneralsZeroHour)]
         public float RetaliationFriendsRadius { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float ChaseFromBehindLimit { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool ForceHordesToLowLod { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool AllowForestFires { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float CastleSiegeStandBackDistance { get; private set; }
 
         public List<AISideInfo> SideInfos { get; } = new List<AISideInfo>();
 
         public List<AISkirmishBuildList> SkirmishBuildLists { get; } = new List<AISkirmishBuildList>();
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public List<AttackPriority> AttackPriorities { get; } = new List<AttackPriority>();
     }
 

--- a/src/OpenSage.Game/Data/Ini/AmbientStream.cs
+++ b/src/OpenSage.Game/Data/Ini/AmbientStream.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class AmbientStream : BaseSingleSound
     {
         internal static AmbientStream Parse(IniParser parser)
@@ -21,7 +21,7 @@ namespace OpenSage.Data.Ini
         public string Filename { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public enum AudioVolumeSlider
     {
         [IniEnum("MUSIC")]

--- a/src/OpenSage.Game/Data/Ini/AnimationSoundClientBehaviorGlobalSetting.cs
+++ b/src/OpenSage.Game/Data/Ini/AnimationSoundClientBehaviorGlobalSetting.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class AnimationSoundClientBehaviorGlobalSetting
     {
         internal static AnimationSoundClientBehaviorGlobalSetting Parse(IniParser parser) => parser.ParseTopLevelBlock(FieldParseTable);

--- a/src/OpenSage.Game/Data/Ini/Armor.cs
+++ b/src/OpenSage.Game/Data/Ini/Armor.cs
@@ -23,7 +23,7 @@ namespace OpenSage.Data.Ini
         /// <summary>
         /// Scales all damage done to this unit.
         /// </summary>
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float DamageScalar { get; private set; }
 
         public List<ArmorValue> Values { get; } = new List<ArmorValue>();

--- a/src/OpenSage.Game/Data/Ini/AttackPriority.cs
+++ b/src/OpenSage.Game/Data/Ini/AttackPriority.cs
@@ -3,7 +3,7 @@ using OpenSage.Data.Ini.Parser;
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class AttackPriority
     {
         internal static AttackPriority Parse(IniParser parser)
@@ -25,7 +25,7 @@ namespace OpenSage.Data.Ini
         public List<AttackPriorityTarget> Targets { get; } = new List<AttackPriorityTarget>();
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class AttackPriorityTarget
     {
         internal static AttackPriorityTarget Parse(IniParser parser)

--- a/src/OpenSage.Game/Data/Ini/AudioLod.cs
+++ b/src/OpenSage.Game/Data/Ini/AudioLod.cs
@@ -3,7 +3,7 @@ using OpenSage.Data.Ini.Parser;
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class AudioLod
     {
         internal static AudioLod Parse(IniParser parser)

--- a/src/OpenSage.Game/Data/Ini/AudioSettings.cs
+++ b/src/OpenSage.Game/Data/Ini/AudioSettings.cs
@@ -82,7 +82,7 @@ namespace OpenSage.Data.Ini
         public string MusicFolder { get; private set; }
         public string StreamingFolder { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string AmbientStreamFolder { get; private set; }
 
         public string SoundsExtension { get; private set; }
@@ -92,43 +92,43 @@ namespace OpenSage.Data.Ini
         public int OutputBits { get; private set; }
         public int OutputChannels { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int MixaheadLatency { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int MixaheadLatencyDuringMovies { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int _3DBufferLengthMS { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int _3DBufferCallbackCallsPerBufferLength { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ForceResetTimeSeconds { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int EmergencyResetTimeSeconds { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string MusicScriptLibraryName { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int AutomaticSubtitleDurationMS { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int AutomaticSubtitleWindowWidth { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int AutomaticSubtitleLines { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public ColorRgba AutomaticSubtitleWindowColor { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public ColorRgba AutomaticSubtitleTextColor { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int PositionDeltaForReverbRecheck { get; private set; }
 
         public int SampleCount2D { get; private set; }
@@ -141,20 +141,20 @@ namespace OpenSage.Data.Ini
         public int AudioFootprintInBytes { get; private set; }
         public int MinSampleVolume { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int AmbientStreamHysteresisVolume { get; private set; }
 
         public float Relative2DVolume { get; private set; }
 
         public float DefaultSoundVolume { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float DefaultAmbientVolume { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float DefaultMovieVolume { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float DefaultVoiceVolume { get; private set; }
 
         public float Default3DSoundVolume { get; private set; }
@@ -171,16 +171,16 @@ namespace OpenSage.Data.Ini
 
         public float MicrophoneMaxPercentageBetweenGroundAndCamera { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float MicrophonePreferredFractionCameraToGround { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float MicrophoneMinDistanceToCamera { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float MicrophoneMaxDistanceToCamera { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float MicrophonePullTowardsTerrainLookAtPointPercent { get; private set; }
 
         public float ZoomMinDistance { get; private set; }
@@ -188,13 +188,13 @@ namespace OpenSage.Data.Ini
 
         public float ZoomSoundVolumePercentageAmount { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float LivingWorldMicrophonePreferredFractionCameraToGround { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float LivingWorldMicrophoneMaxDistanceToCamera { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float LivingWorldZoomMaxDistance { get; private set; }
     }
 }

--- a/src/OpenSage.Game/Data/Ini/BannerType.cs
+++ b/src/OpenSage.Game/Data/Ini/BannerType.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class BannerType
     {
         internal static BannerType Parse(IniParser parser)

--- a/src/OpenSage.Game/Data/Ini/BannerUI.cs
+++ b/src/OpenSage.Game/Data/Ini/BannerUI.cs
@@ -3,7 +3,7 @@ using OpenSage.Data.Ini.Parser;
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class BannerUI
     {
         internal static BannerUI Parse(IniParser parser) => parser.ParseTopLevelBlock(FieldParseTable);
@@ -18,7 +18,7 @@ namespace OpenSage.Data.Ini
         public List<BannerUnitCategory> UnitCategories { get; } = new List<BannerUnitCategory>();
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class BannerUnitCategory
     {
         internal static BannerUnitCategory Parse(IniParser parser) => parser.ParseTopLevelBlock(FieldParseTable);

--- a/src/OpenSage.Game/Data/Ini/CommandButton.cs
+++ b/src/OpenSage.Game/Data/Ini/CommandButton.cs
@@ -79,76 +79,76 @@ namespace OpenSage.Data.Ini
         public WeaponSlot WeaponSlot { get; private set; }
         public string UnitSpecificSound { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string UnitSpecificSound2 { get; private set; }
 
         public int MaxShotsToFire { get; private set; }
         public string Object { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool InPalantir { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool DoubleClick { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public ModelConditionFlag? FlagsUsedForToggle { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool AutoAbility { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string SetAutoAbilityUnitSound { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float AutoDelay { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool AffectsAllies { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool NeedDamagedTarget { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float PresetRange { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public BitArray<ModelConditionFlag> DisableOnModelCondition { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public BitArray<ModelConditionFlag> EnableOnModelCondition { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string CommandTrigger { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public WeaponSlot? WeaponSlotToggle1 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public WeaponSlot? WeaponSlotToggle2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string NeededUpgrade { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string BuildUpgrades { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool Radial { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool IsClickable { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool ShowProductionCount { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public BitArray<ObjectKinds> AffectsKindOf { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool RequiresValidContainer { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string LacksPrerequisiteLabel { get; private set; }
     }
 
@@ -253,61 +253,61 @@ namespace OpenSage.Data.Ini
         [IniEnum("SPECIAL_POWER_CONSTRUCT_FROM_SHORTCUT"), AddedIn(SageGame.CncGeneralsZeroHour)]
         SpecialPowerConstructFromShortcut,
 
-        [IniEnum("HORDE_TOGGLE_FORMATION"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("HORDE_TOGGLE_FORMATION"), AddedIn(SageGame.Bfme)]
         HordeToggleFormation,
 
-        [IniEnum("TOGGLE_WEAPONSET"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("TOGGLE_WEAPONSET"), AddedIn(SageGame.Bfme)]
         ToggleWeaponSet,
 
-        [IniEnum("WAKE_AUTO_PICKUP"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("WAKE_AUTO_PICKUP"), AddedIn(SageGame.Bfme)]
         WakeAutoPickup,
 
-        [IniEnum("BLOODTHIRSTY"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("BLOODTHIRSTY"), AddedIn(SageGame.Bfme)]
         Bloodthirsty,
 
-        [IniEnum("MONSTERDOCK"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("MONSTERDOCK"), AddedIn(SageGame.Bfme)]
         MonsterDock,
 
-        [IniEnum("CREW_EVACUATE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("CREW_EVACUATE"), AddedIn(SageGame.Bfme)]
         CrewEvacuate,
 
-        [IniEnum("TOGGLE_WEAPON"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("TOGGLE_WEAPON"), AddedIn(SageGame.Bfme)]
         ToggleWeapon,
 
-        [IniEnum("EVACUATE_CONTESTED"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("EVACUATE_CONTESTED"), AddedIn(SageGame.Bfme)]
         EvacuateContested,
 
-        [IniEnum("FOUNDATION_CONSTRUCT"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("FOUNDATION_CONSTRUCT"), AddedIn(SageGame.Bfme)]
         FoundationConstruct,
 
-        [IniEnum("CASTLE_UNPACK"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("CASTLE_UNPACK"), AddedIn(SageGame.Bfme)]
         CastleUnpack,
 
-        [IniEnum("CASTLE_UNPACK_EXPLICIT_OBJECT"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("CASTLE_UNPACK_EXPLICIT_OBJECT"), AddedIn(SageGame.Bfme)]
         CastleUnpackExplicitObject,
 
-        [IniEnum("CASTLE_UPGRADE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("CASTLE_UPGRADE"), AddedIn(SageGame.Bfme)]
         CastleUpgrade,
 
-        [IniEnum("REVIVE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("REVIVE"), AddedIn(SageGame.Bfme)]
         Revive,
 
-        [IniEnum("FOUNDATION_CONSTRUCT_CANCEL"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("FOUNDATION_CONSTRUCT_CANCEL"), AddedIn(SageGame.Bfme)]
         FoundationConstructCancel,
 
-        [IniEnum("SPELL_BOOK"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("SPELL_BOOK"), AddedIn(SageGame.Bfme)]
         SpellBook,
 
-        [IniEnum("ONE_RING"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("ONE_RING"), AddedIn(SageGame.Bfme)]
         OneRing,
 
-        [IniEnum("TOGGLE_NO_AUTO_ACQUIRE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("TOGGLE_NO_AUTO_ACQUIRE"), AddedIn(SageGame.Bfme)]
         ToggleNoAutoAcquire,
 
-        [IniEnum("TOGGLE_GATE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("TOGGLE_GATE"), AddedIn(SageGame.Bfme)]
         ToggleGate,
 
-        [IniEnum("START_SELF_REPAIR"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("START_SELF_REPAIR"), AddedIn(SageGame.Bfme)]
         StartSelfRepair,
     }
 
@@ -386,43 +386,43 @@ namespace OpenSage.Data.Ini
         [IniEnum("MUST_BE_STOPPED"), AddedIn(SageGame.CncGeneralsZeroHour)]
         MustBeStopped,
 
-        [IniEnum("TOGGLE_IMAGE_ON_FORMATION"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("TOGGLE_IMAGE_ON_FORMATION"), AddedIn(SageGame.Bfme)]
         ToggleImageOnFormation,
 
-        [IniEnum("TOGGLE_IMAGE_ON_WEAPONSET"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("TOGGLE_IMAGE_ON_WEAPONSET"), AddedIn(SageGame.Bfme)]
         ToggleImageOnWeaponSet,
 
-        [IniEnum("ALLOW_SHRUBBERY_TARGET"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("ALLOW_SHRUBBERY_TARGET"), AddedIn(SageGame.Bfme)]
         AllowShrubberyTarget,
 
-        [IniEnum("ALLOW_ROCK_TARGET"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("ALLOW_ROCK_TARGET"), AddedIn(SageGame.Bfme)]
         AllowRockTarget,
 
-        [IniEnum("NONPRESSABLE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("NONPRESSABLE"), AddedIn(SageGame.Bfme)]
         NonPressable,
 
-        [IniEnum("CANCELABLE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("CANCELABLE"), AddedIn(SageGame.Bfme)]
         Cancelable,
 
-        [IniEnum("UNMOUNTED_ONLY"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("UNMOUNTED_ONLY"), AddedIn(SageGame.Bfme)]
         UnmountedOnly,
 
-        [IniEnum("MOUNTED_ONLY"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("MOUNTED_ONLY"), AddedIn(SageGame.Bfme)]
         MountedOnly,
 
-        [IniEnum("ON_GROUND_ONLY"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("ON_GROUND_ONLY"), AddedIn(SageGame.Bfme)]
         OnGroundOnly,
 
-        [IniEnum("HIDE_WHILE_DISABLED"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("HIDE_WHILE_DISABLED"), AddedIn(SageGame.Bfme)]
         HideWhileDisabled,
 
-        [IniEnum("NO_PLAY_UNIT_SPECIFIC_SOUND_FOR_AUTO_ABILITY"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("NO_PLAY_UNIT_SPECIFIC_SOUND_FOR_AUTO_ABILITY"), AddedIn(SageGame.Bfme)]
         NoPlayUnitSpecificSoundForAutoAbility,
 
-        [IniEnum("TOGGLE_IMAGE_ON_WEAPON"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("TOGGLE_IMAGE_ON_WEAPON"), AddedIn(SageGame.Bfme)]
         ToggleImageOnWeapon,
 
-        [IniEnum("NEEDS_CASTLE_KINDOF"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("NEEDS_CASTLE_KINDOF"), AddedIn(SageGame.Bfme)]
         NeedsCastleKindOf,
     }
 
@@ -440,7 +440,7 @@ namespace OpenSage.Data.Ini
 
     public enum CommandButtonRadiusCursorType
     {
-        [IniEnum("NONE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("NONE"), AddedIn(SageGame.Bfme)]
         None,
 
         [IniEnum("DAISYCUTTER")]
@@ -530,91 +530,91 @@ namespace OpenSage.Data.Ini
         [IniEnum("HELIX_NAPALM_BOMB"), AddedIn(SageGame.CncGeneralsZeroHour)]
         HelixNapalmBomb,
 
-        [IniEnum("FIRE_BREATH"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("FIRE_BREATH"), AddedIn(SageGame.Bfme)]
         FireBreath,
 
-        [IniEnum("TRAINING"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("TRAINING"), AddedIn(SageGame.Bfme)]
         Training,
 
-        [IniEnum("SUMMON_OATH_BREAKERS"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("SUMMON_OATH_BREAKERS"), AddedIn(SageGame.Bfme)]
         SummonOathBreakers,
 
-        [IniEnum("KINGS_FAVOR"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("KINGS_FAVOR"), AddedIn(SageGame.Bfme)]
         KingsFavor,
 
-        [IniEnum("CAPTAIN_OF_GONDOR"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("CAPTAIN_OF_GONDOR"), AddedIn(SageGame.Bfme)]
         CaptainOfGondor,
 
-        [IniEnum("ARROWSTORM"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("ARROWSTORM"), AddedIn(SageGame.Bfme)]
         ArrowStorm,
 
-        [IniEnum("ATHELAS"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("ATHELAS"), AddedIn(SageGame.Bfme)]
         Athelas,
 
-        [IniEnum("ARCHERY_TRAINING"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("ARCHERY_TRAINING"), AddedIn(SageGame.Bfme)]
         ArcheryTraining,
 
-        [IniEnum("LIGHTNING_SWORD"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("LIGHTNING_SWORD"), AddedIn(SageGame.Bfme)]
         LightningSword,
 
-        [IniEnum("LEAP"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("LEAP"), AddedIn(SageGame.Bfme)]
         Leap,
 
-        [IniEnum("FELL_BEAST_SWOOP"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("FELL_BEAST_SWOOP"), AddedIn(SageGame.Bfme)]
         FellBeastSwoop,
 
-        [IniEnum("EAGLE_SWOOP"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("EAGLE_SWOOP"), AddedIn(SageGame.Bfme)]
         EagleSwoop,
 
-        [IniEnum("REVEAL_MAP_AREA"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("REVEAL_MAP_AREA"), AddedIn(SageGame.Bfme)]
         RevealMapArea,
 
-        [IniEnum("WAR_CHANT"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("WAR_CHANT"), AddedIn(SageGame.Bfme)]
         WarChant,
 
-        [IniEnum("INDUSTRY"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("INDUSTRY"), AddedIn(SageGame.Bfme)]
         Industry,
 
-        [IniEnum("DEVASTATION"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("DEVASTATION"), AddedIn(SageGame.Bfme)]
         Devastation,
 
-        [IniEnum("TAINT"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("TAINT"), AddedIn(SageGame.Bfme)]
         Taint,
 
-        [IniEnum("EYE_OF_SAURON"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("EYE_OF_SAURON"), AddedIn(SageGame.Bfme)]
         EyeOfSauron,
 
-        [IniEnum("SUMMON_BALROG"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("SUMMON_BALROG"), AddedIn(SageGame.Bfme)]
         SummonBalrog,
 
-        [IniEnum("HEAL"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("HEAL"), AddedIn(SageGame.Bfme)]
         Heal,
 
-        [IniEnum("ELVEN_ALLIES"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("ELVEN_ALLIES"), AddedIn(SageGame.Bfme)]
         ElvenAllies,
 
-        [IniEnum("ROHAN_ALLIES"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("ROHAN_ALLIES"), AddedIn(SageGame.Bfme)]
         RohanAllies,
 
-        [IniEnum("ELVEN_WOOD"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("ELVEN_WOOD"), AddedIn(SageGame.Bfme)]
         ElvenWood,
 
-        [IniEnum("ENT_ALLIES"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("ENT_ALLIES"), AddedIn(SageGame.Bfme)]
         EntAllies,
 
-        [IniEnum("ARMY_OF_THE_DEAD"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("ARMY_OF_THE_DEAD"), AddedIn(SageGame.Bfme)]
         ArmyOfTheDead,
 
-        [IniEnum("EAGLE_ALLIES"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("EAGLE_ALLIES"), AddedIn(SageGame.Bfme)]
         EagleAllies,
 
-        [IniEnum("PALANTIR_VISION"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("PALANTIR_VISION"), AddedIn(SageGame.Bfme)]
         PalantirVision,
 
-        [IniEnum("SPEECH_CRAFT"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("SPEECH_CRAFT"), AddedIn(SageGame.Bfme)]
         SpeechCraft,
 
-        [IniEnum("DOMINATE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("DOMINATE"), AddedIn(SageGame.Bfme)]
         Dominate,
     }
 }

--- a/src/OpenSage.Game/Data/Ini/ControlBarScheme.cs
+++ b/src/OpenSage.Game/Data/Ini/ControlBarScheme.cs
@@ -122,7 +122,7 @@ namespace OpenSage.Data.Ini
         public ColorRgba ButtonBorderUpgradeColor { get; private set; }
         public ColorRgba ButtonBorderSystemColor { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public ColorRgba ButtonBorderAlteredColor { get; private set; }
 
         public string GenBarButtonIn { get; private set; }

--- a/src/OpenSage.Game/Data/Ini/DamageType.cs
+++ b/src/OpenSage.Game/Data/Ini/DamageType.cs
@@ -116,73 +116,73 @@
         [IniEnum("KILL_GARRISONED"), AddedIn(SageGame.CncGeneralsZeroHour)]
         KillGarrisoned,
 
-        [IniEnum("SLASH"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("SLASH"), AddedIn(SageGame.Bfme)]
         Slash,
 
-        [IniEnum("PIERCE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("PIERCE"), AddedIn(SageGame.Bfme)]
         Pierce,
 
-        [IniEnum("URUK"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("URUK"), AddedIn(SageGame.Bfme)]
         Uruk,
 
-        [IniEnum("HERO"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("HERO"), AddedIn(SageGame.Bfme)]
         Hero,
 
-        [IniEnum("HERO_RANGED"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("HERO_RANGED"), AddedIn(SageGame.Bfme)]
         HeroRanged,
 
-        [IniEnum("SIEGE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("SIEGE"), AddedIn(SageGame.Bfme)]
         Siege,
 
-        [IniEnum("SPECIALIST"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("SPECIALIST"), AddedIn(SageGame.Bfme)]
         Specialist,
 
-        [IniEnum("MAGIC"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("MAGIC"), AddedIn(SageGame.Bfme)]
         Magic,
 
-        [IniEnum("STRUCTURAL"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("STRUCTURAL"), AddedIn(SageGame.Bfme)]
         Structural,
 
-        [IniEnum("CHOP"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("CHOP"), AddedIn(SageGame.Bfme)]
         Chop,
 
-        [IniEnum("FORCE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("FORCE"), AddedIn(SageGame.Bfme)]
         Force,
 
-        [IniEnum("FLY_INTO"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("FLY_INTO"), AddedIn(SageGame.Bfme)]
         FlyInto,
 
-        [IniEnum("GOOD_ARROW_PIERCE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("GOOD_ARROW_PIERCE"), AddedIn(SageGame.Bfme)]
         GoodArrowPierce,
 
-        [IniEnum("EVIL_ARROW_PIERCE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("EVIL_ARROW_PIERCE"), AddedIn(SageGame.Bfme)]
         EvilArrowPierce,
 
-        [IniEnum("SWORD_SLASH"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("SWORD_SLASH"), AddedIn(SageGame.Bfme)]
         SwordSlash,
 
-        [IniEnum("WITCH_KING_MORGUL_BLADE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("WITCH_KING_MORGUL_BLADE"), AddedIn(SageGame.Bfme)]
         WitchKingMorgulBlade,
 
-        [IniEnum("REFLECTED"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("REFLECTED"), AddedIn(SageGame.Bfme)]
         Reflected,
 
-        [IniEnum("BALROG_SWORD"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("BALROG_SWORD"), AddedIn(SageGame.Bfme)]
         BalrogSword,
 
-        [IniEnum("BALROG_WHIP"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("BALROG_WHIP"), AddedIn(SageGame.Bfme)]
         BalrogWhip,
 
-        [IniEnum("ELECTRIC"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("ELECTRIC"), AddedIn(SageGame.Bfme)]
         Electric,
 
-        [IniEnum("GIMLI_LEAP"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("GIMLI_LEAP"), AddedIn(SageGame.Bfme)]
         GimliLeap,
 
-        [IniEnum("BIG_ROCK"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("BIG_ROCK"), AddedIn(SageGame.Bfme)]
         BigRock,
 
-        [IniEnum("CLUBBING"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("CLUBBING"), AddedIn(SageGame.Bfme)]
         Clubbing,
     }
 }

--- a/src/OpenSage.Game/Data/Ini/EmotionNugget.cs
+++ b/src/OpenSage.Game/Data/Ini/EmotionNugget.cs
@@ -3,7 +3,7 @@ using OpenSage.Logic.Object;
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class EmotionNugget
     {
         internal static EmotionNugget Parse(IniParser parser)

--- a/src/OpenSage.Game/Data/Ini/Environment.cs
+++ b/src/OpenSage.Game/Data/Ini/Environment.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class Environment
     {
         public CloudEffect CloudEffect { get; internal set; }
@@ -11,7 +11,7 @@ namespace OpenSage.Data.Ini
         public RingEffect RingEffect { get; internal set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class GlowEffect
     {
         internal static GlowEffect Parse(IniParser parser) => parser.ParseTopLevelBlock(FieldParseTable);
@@ -42,7 +42,7 @@ namespace OpenSage.Data.Ini
         public bool MultipassGlowEnabled { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class RingEffect
     {
         internal static RingEffect Parse(IniParser parser) => parser.ParseTopLevelBlock(FieldParseTable);
@@ -75,7 +75,7 @@ namespace OpenSage.Data.Ini
         public int BaseBlurDiameter { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class CloudEffect
     {
         internal static CloudEffect Parse(IniParser parser) => parser.ParseTopLevelBlock(FieldParseTable);

--- a/src/OpenSage.Game/Data/Ini/EvaEvent.cs
+++ b/src/OpenSage.Game/Data/Ini/EvaEvent.cs
@@ -31,12 +31,12 @@ namespace OpenSage.Data.Ini
         public int Priority { get; private set; }
         public int TimeBetweenChecksMS { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int TimeBetweenEventsMS { get; private set; }
 
         public int ExpirationTimeMS { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int QuietTimeMS { get; private set; }
 
         public List<EvaSideSound> SideSounds { get; } = new List<EvaSideSound>();

--- a/src/OpenSage.Game/Data/Ini/ExperienceLevel.cs
+++ b/src/OpenSage.Game/Data/Ini/ExperienceLevel.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class ExperienceLevel
     {
         internal static ExperienceLevel Parse(IniParser parser)

--- a/src/OpenSage.Game/Data/Ini/ExperienceScalarTable.cs
+++ b/src/OpenSage.Game/Data/Ini/ExperienceScalarTable.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class ExperienceScalarTable
     {
         internal static ExperienceScalarTable Parse(IniParser parser)

--- a/src/OpenSage.Game/Data/Ini/FXList.cs
+++ b/src/OpenSage.Game/Data/Ini/FXList.cs
@@ -109,7 +109,7 @@ namespace OpenSage.Data.Ini
 
         public bool AttachToObject { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string AttachToBone { get; private set; }
 
         public int Count { get; private set; } = 1;
@@ -124,31 +124,31 @@ namespace OpenSage.Data.Ini
         public int RotateY { get; private set; }
         public bool UseCallersRadius { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string CreateBoneOverride { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string TargetBoneOverride { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool UseTargetOffset { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public Coord3D TargetOffset { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int TargetCoeff { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int SystemLife { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool SetTargetMatrix { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool OnlyIfOnLand { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool OnlyIfOnWater { get; private set; }
     }
 
@@ -248,7 +248,7 @@ namespace OpenSage.Data.Ini
         public float Width { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class BuffNugget : FXListItem
     {
         internal static BuffNugget Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -279,7 +279,7 @@ namespace OpenSage.Data.Ini
         public IniColorRgb Color { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class CameraShakerVolumeFXNugget : FXListItem
     {
         internal static CameraShakerVolumeFXNugget Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -296,7 +296,7 @@ namespace OpenSage.Data.Ini
         public float Amplitude { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class DynamicDecalFXNugget : FXListItem
     {
         internal static DynamicDecalFXNugget Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -335,7 +335,7 @@ namespace OpenSage.Data.Ini
         public int Lifetime { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class EvaEventFXNugget : FXListItem
     {
         internal static EvaEventFXNugget Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -350,7 +350,7 @@ namespace OpenSage.Data.Ini
         public string EvaEventAlly { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class TintDrawableFXNugget : FXListItem
     {
         internal static TintDrawableFXNugget Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -373,7 +373,7 @@ namespace OpenSage.Data.Ini
         public float Amplitude { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleSysBoneNugget : FXListItem
     {
         internal static FXParticleSysBoneNugget Parse(IniParser parser)
@@ -391,7 +391,7 @@ namespace OpenSage.Data.Ini
         public bool FollowBone { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class AttachedModelFXNugget : FXListItem
     {
         internal static AttachedModelFXNugget Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -404,7 +404,7 @@ namespace OpenSage.Data.Ini
         public string ModelName { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class CursorParticleSystemFXNugget : FXListItem
     {
         internal static CursorParticleSystemFXNugget Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -441,7 +441,7 @@ namespace OpenSage.Data.Ini
         [IniEnum("SEVERE")]
         Severe,
 
-        [IniEnum("CINE_EXTREME"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("CINE_EXTREME"), AddedIn(SageGame.Bfme)]
         CineExtreme
     }
 

--- a/src/OpenSage.Game/Data/Ini/FXParticleSystemTemplate.cs
+++ b/src/OpenSage.Game/Data/Ini/FXParticleSystemTemplate.cs
@@ -4,7 +4,7 @@ using OpenSage.Data.Ini.Parser;
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleSystemTemplate
     {
         internal static FXParticleSystemTemplate Parse(IniParser parser)
@@ -159,7 +159,7 @@ namespace OpenSage.Data.Ini
         public FXParticleEventBase Event { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleColor
     {
         internal static FXParticleColor Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -189,7 +189,7 @@ namespace OpenSage.Data.Ini
         public RandomVariable ColorScale { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleAlpha
     {
         internal static FXParticleAlpha Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -216,13 +216,13 @@ namespace OpenSage.Data.Ini
         public RandomAlphaKeyframe Alpha8 { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public abstract class FXParticleUpdateBase
     {
 
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleUpdateDefault : FXParticleUpdateBase
     {
         internal static FXParticleUpdateDefault Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -245,7 +245,7 @@ namespace OpenSage.Data.Ini
         public FXParticleSystemRotationType Rotation { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleUpdateRenderObject : FXParticleUpdateBase
     {
         internal static FXParticleUpdateRenderObject Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -290,7 +290,7 @@ namespace OpenSage.Data.Ini
         public FXParticleSystemRotationType Rotation { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public enum FXParticleSystemRotationType
     {
         [IniEnum("ROTATE_X")]
@@ -306,13 +306,13 @@ namespace OpenSage.Data.Ini
         RotateV
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public abstract class FXParticlePhysicsBase
     {
 
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleDefaultPhysics : FXParticlePhysicsBase
     {
         internal static FXParticleDefaultPhysics Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -329,7 +329,7 @@ namespace OpenSage.Data.Ini
         public Coord3D DriftVelocity { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public class FXParticleDrawBase
     {
         internal static FXParticleDrawBase Parse(IniParser parser) => parser.ParseBlock(BaseFieldParseTable);
@@ -337,7 +337,7 @@ namespace OpenSage.Data.Ini
         internal static readonly IniParseTable<FXParticleDrawBase> BaseFieldParseTable = new IniParseTable<FXParticleDrawBase>();
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleDrawRenderObject : FXParticleDrawBase
     {
         internal new static FXParticleDrawRenderObject Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -345,7 +345,7 @@ namespace OpenSage.Data.Ini
         private static readonly IniParseTable<FXParticleDrawRenderObject> FieldParseTable = BaseFieldParseTable.Concat(new IniParseTable<FXParticleDrawRenderObject>());
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleDrawStreak : FXParticleDrawBase
     {
         internal new static FXParticleDrawStreak Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -353,7 +353,7 @@ namespace OpenSage.Data.Ini
         private static readonly IniParseTable<FXParticleDrawStreak> FieldParseTable = BaseFieldParseTable.Concat(new IniParseTable<FXParticleDrawStreak>());
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleDrawButterfly : FXParticleDrawBase
     {
         internal new static FXParticleDrawButterfly Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -361,7 +361,7 @@ namespace OpenSage.Data.Ini
         private static readonly IniParseTable<FXParticleDrawButterfly> FieldParseTable = BaseFieldParseTable.Concat(new IniParseTable<FXParticleDrawButterfly>());
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleDrawLightning : FXParticleDrawBase
     {
         internal new static FXParticleDrawLightning Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -378,7 +378,7 @@ namespace OpenSage.Data.Ini
         public RandomVariable OffsetZ { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleDrawQuad : FXParticleDrawBase
     {
         internal new static FXParticleDrawQuad Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -386,7 +386,7 @@ namespace OpenSage.Data.Ini
         private static readonly IniParseTable<FXParticleDrawQuad> FieldParseTable = BaseFieldParseTable.Concat(new IniParseTable<FXParticleDrawQuad>());
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleWind
     {
         internal static FXParticleWind Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -421,13 +421,13 @@ namespace OpenSage.Data.Ini
         public float TurbulenceFrequency { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public abstract class FXParticleEmissionVelocityBase
     {
 
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleEmissionVelocityCylinder : FXParticleEmissionVelocityBase
     {
         internal static FXParticleEmissionVelocityCylinder Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -442,7 +442,7 @@ namespace OpenSage.Data.Ini
         public RandomVariable Normal { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleEmissionVelocityOrtho : FXParticleEmissionVelocityBase
     {
         internal static FXParticleEmissionVelocityOrtho Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -459,7 +459,7 @@ namespace OpenSage.Data.Ini
         public RandomVariable Z { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleEmissionVelocityOutward : FXParticleEmissionVelocityBase
     {
         internal static FXParticleEmissionVelocityOutward Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -474,7 +474,7 @@ namespace OpenSage.Data.Ini
         public RandomVariable OtherSpeed { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public class FXParticleEmissionVelocitySphere : FXParticleEmissionVelocityBase
     {
         internal static FXParticleEmissionVelocitySphere Parse(IniParser parser) => parser.ParseBlock(SphereFieldParseTable);
@@ -487,7 +487,7 @@ namespace OpenSage.Data.Ini
         public RandomVariable Speed { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleEmissionVelocityHemisphere : FXParticleEmissionVelocitySphere
     {
         internal new static FXParticleEmissionVelocityHemisphere Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -495,7 +495,7 @@ namespace OpenSage.Data.Ini
         private static readonly IniParseTable<FXParticleEmissionVelocityHemisphere> FieldParseTable = SphereFieldParseTable.Concat(new IniParseTable<FXParticleEmissionVelocityHemisphere>());
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public abstract class FXParticleEmissionVolumeBase
     {
         internal static readonly IniParseTable<FXParticleEmissionVolumeBase> BaseFieldParseTable = new IniParseTable<FXParticleEmissionVolumeBase>
@@ -506,7 +506,7 @@ namespace OpenSage.Data.Ini
         public bool IsHollow { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleEmissionVolumeCylinder : FXParticleEmissionVolumeBase
     {
         internal static FXParticleEmissionVolumeCylinder Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -523,7 +523,7 @@ namespace OpenSage.Data.Ini
         public Coord3D Offset { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleEmissionVolumeLine : FXParticleEmissionVolumeBase
     {
         internal static FXParticleEmissionVolumeLine Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -538,7 +538,7 @@ namespace OpenSage.Data.Ini
         public Coord3D EndPoint { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleEmissionVolumeSphere : FXParticleEmissionVolumeBase
     {
         internal static FXParticleEmissionVolumeSphere Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -551,7 +551,7 @@ namespace OpenSage.Data.Ini
         public float Radius { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleEmissionVolumeBox : FXParticleEmissionVolumeBase
     {
         internal static FXParticleEmissionVolumeBox Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -564,7 +564,7 @@ namespace OpenSage.Data.Ini
         public Coord3D HalfSize { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleEmissionVolumePoint : FXParticleEmissionVolumeBase
     {
         internal static FXParticleEmissionVolumePoint Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -572,7 +572,7 @@ namespace OpenSage.Data.Ini
         private static readonly IniParseTable<FXParticleEmissionVolumePoint> FieldParseTable = BaseFieldParseTable.Concat(new IniParseTable<FXParticleEmissionVolumePoint>());
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleEmissionVolumeLightning : FXParticleEmissionVolumeBase
     {
         internal static FXParticleEmissionVolumeLightning Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -595,7 +595,7 @@ namespace OpenSage.Data.Ini
         public RandomVariable Phase3 { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public abstract class FXParticleEventBase
     {
         internal static readonly IniParseTable<FXParticleEventBase> BaseFieldParseTable = new IniParseTable<FXParticleEventBase>
@@ -610,7 +610,7 @@ namespace OpenSage.Data.Ini
         public bool KillAfterEvent { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FXParticleEventCollision : FXParticleEventBase
     {
         internal static FXParticleEventCollision Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);

--- a/src/OpenSage.Game/Data/Ini/FactionVictoryData.cs
+++ b/src/OpenSage.Game/Data/Ini/FactionVictoryData.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FactionVictoryData
     {
         internal static FactionVictoryData Parse(IniParser parser)

--- a/src/OpenSage.Game/Data/Ini/FontDefaultSetting.cs
+++ b/src/OpenSage.Game/Data/Ini/FontDefaultSetting.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FontDefaultSetting
     {
         internal static FontDefaultSetting Parse(IniParser parser)

--- a/src/OpenSage.Game/Data/Ini/FontSubstitution.cs
+++ b/src/OpenSage.Game/Data/Ini/FontSubstitution.cs
@@ -3,7 +3,7 @@ using OpenSage.Data.Ini.Parser;
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class FontSubstitution
     {
         internal static FontSubstitution Parse(IniParser parser)
@@ -27,7 +27,7 @@ namespace OpenSage.Data.Ini
         public List<Substitution> Substitutions { get; } = new List<Substitution>();
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class Substitution
     {
         public int Size { get; private set; }

--- a/src/OpenSage.Game/Data/Ini/GameData.cs
+++ b/src/OpenSage.Game/Data/Ini/GameData.cs
@@ -599,7 +599,9 @@ namespace OpenSage.Data.Ini
             { "DebugCashValueMapTileDuration", (parser, x) => x.DebugCashValueMapTileDuration = parser.ParseInteger() },
             { "MaxDebugCashValueMapValue", (parser, x) => x.MaxDebugCashValueMapValue = parser.ParseInteger() },
 
-            { "VTune", (parser, x) => x.VTune = parser.ParseBoolean() }
+            { "VTune", (parser, x) => x.VTune = parser.ParseBoolean() },
+
+            { "ShellMapOn", (parser, x) => x.ShellMapOn = parser.ParseBoolean() }
         };
 
         public string ShellMapName { get; private set; }
@@ -609,17 +611,17 @@ namespace OpenSage.Data.Ini
         [AddedIn(SageGame.Cnc3)]
         public float MoveHintZBias { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool ShowProps { get; private set; }
 
         public bool UseTrees { get; private set; }
         public bool UseFpsLimit { get; private set; }
         public int FramesPerSecondLimit { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool UseHighQualityVideo { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool DisablePixelShader { get; private set; }
 
         public int ChipsetType { get; private set; }
@@ -627,14 +629,14 @@ namespace OpenSage.Data.Ini
         public bool Wireframe { get; private set; }
         public bool UseCloudMap { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public bool AllowTreeFading { get; private set; }
 
         public bool UseLightMap { get; private set; }
         public bool BilinearTerrainTex { get; private set; }
         public bool TrilinearTerrainTex { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool AnisotropicTerrainTex { get; private set; }
 
         public bool MultiPassTerrain { get; private set; }
@@ -654,19 +656,19 @@ namespace OpenSage.Data.Ini
         public bool UseShadowVolumes { get; private set; }
         public bool UseShadowDecals { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public bool UseShadowMapping { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool ShowSelectedUnitMarker { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool UseSimpleHordeDecals { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool UseSimpleMergeDecals { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float OpacityOfSimpleMergeDecals { get; private set; }
 
         public bool UseBehindBuildingMarker { get; private set; }
@@ -752,25 +754,25 @@ namespace OpenSage.Data.Ini
         public float SkyBoxPositionZ { get; private set; }
         public float SkyBoxScale { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float DefaultCameraMinHeight { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float DefaultCameraMaxHeight { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float DefaultCameraPitchAngle { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float DefaultCameraYawAngle { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float DefaultCameraScrollSpeedScalar { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float CameraLockHeightDelta { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float CameraTerrainSampleRadiusForHeight { get; private set; }
 
         [AddedIn(SageGame.Cnc3)]
@@ -785,7 +787,7 @@ namespace OpenSage.Data.Ini
         public float MaxCameraHeight { get; private set; }
         public float MinCameraHeight { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool UseCameraInReplay { get; private set; }
 
         public float CameraAdjustSpeed { get; private set; }
@@ -804,7 +806,7 @@ namespace OpenSage.Data.Ini
 
         public float PartitionCellSize { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float TerrainResourceCellSize { get; private set; }
 
         public float ParticleScale { get; private set; }
@@ -854,10 +856,10 @@ namespace OpenSage.Data.Ini
         public float GetHealedAnimationTime { get; private set; }
         public float GetHealedAnimationZRise { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string GenericDamageFieldName { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string GenericDamageWarningName { get; private set; }
 
         public int MaxTerrainTracks { get; private set; }
@@ -934,172 +936,172 @@ namespace OpenSage.Data.Ini
         public int MaxRoadIndex { get; private set; }
         public int MaxRoadTypes { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int GoodCommandPointLimit { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int EvilCommandPointLimit { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int PowerLimit { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float ResourceMultiplierLimit { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int InitialMaxRingLevel { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public bool SkipMapUnroll { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float ResourceBonusMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public CommandPoints GoodCommandPoints { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public CommandPoints EvilCommandPoints { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int GoodCommandPointsBonus { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int EvilCommandPointsBonus { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public CommandPoints GoodCommandPointsAI { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public CommandPoints EvilCommandPointsAI { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public CommandPoints GoodCommandPointsMP2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public CommandPoints EvilCommandPointsMP2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public CommandPoints GoodCommandPointsMP3 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public CommandPoints EvilCommandPointsMP3 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public CommandPoints GoodCommandPointsMP4 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public CommandPoints EvilCommandPointsMP4 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public CommandPoints GoodCommandPointsMP5 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public CommandPoints EvilCommandPointsMP5 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public CommandPoints GoodCommandPointsMP6 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public CommandPoints EvilCommandPointsMP6 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public CommandPoints GoodCommandPointsMP7 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public CommandPoints EvilCommandPointsMP7 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public CommandPoints GoodCommandPointsMP8 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public CommandPoints EvilCommandPointsMP8 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public CommandPoints GoodCommandPointsMP56 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public CommandPoints EvilCommandPointsMP56 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public CommandPoints GoodCommandPointsMP78 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public CommandPoints EvilCommandPointsMP78 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public MultiPlayerTuningFactor MultiPlayMoneyMult { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public MultiPlayerTuningFactor MultiPlayUnitXPMult { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public MultiPlayerTuningFactor MultiPlayBuildingXPMult { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public MultiPlayerTuningFactor MultiPlayUnitSpeedMult { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public MultiPlayerTuningFactor MultiPlayBuildingSpeedMult { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed5 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed10 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed15 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed20 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed25 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed30 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed35 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed40 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed45 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed50 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed55 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed60 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed65 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed70 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed75 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed80 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed85 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed90 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed95 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float HandicapBuildSpeed100 { get; private set; }
 
         public int ValuePerSupplyBox { get; private set; }
@@ -1107,7 +1109,7 @@ namespace OpenSage.Data.Ini
         [AddedIn(SageGame.Cnc3)]
         public int SupplyBoxesPerTibCrystal { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int SupplyBoxesPerTree { get; private set; }
 
         [AddedIn(SageGame.Cnc3)]
@@ -1140,10 +1142,10 @@ namespace OpenSage.Data.Ini
         public float HorizontalScrollSpeedFactor { get; private set; }
         public float VerticalScrollSpeedFactor { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float ScreenEdgeScrollSpeedFactor { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float ScreenEdgeScrollRampTime { get; private set; }
 
         public float KeyboardScrollSpeedFactor { get; private set; }
@@ -1162,7 +1164,7 @@ namespace OpenSage.Data.Ini
         public float HumanSoloPlayerHealthBonusNormal { get; private set; }
         public float HumanSoloPlayerHealthBonusHard { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float AttributeModifierArmorMaxBonus { get; private set; }
 
         public int GroupSelectMinSelectSize { get; private set; }
@@ -1170,7 +1172,7 @@ namespace OpenSage.Data.Ini
         public float GroupSelectVolumeIncrement { get; private set; }
         public int MaxUnitSelectSounds { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float DamageRadiusMinimumForSplash { get; private set; }
 
         public float SelectionFlashSaturationFactor { get; private set; }
@@ -1207,16 +1209,16 @@ namespace OpenSage.Data.Ini
         public byte FogAlpha { get; private set; }
         public byte ShroudAlpha { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool TaintOn { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public IniColorRgb TaintColor { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public byte TaintAlpha { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public IniColorRgb ElvenWoodColor { get; private set; }
 
         public int NetworkFpsHistoryLength { get; private set; }
@@ -1233,283 +1235,283 @@ namespace OpenSage.Data.Ini
 
         public string UserDataLeafName { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int DefaultVoiceAttackChargeTimeout { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int DefaultMaxDistanceForEngaged { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int DefaultEngagedStateTimeout { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int AnimationSharingCap { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int AnimationSharingFrameTolerance { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float AnimationSharingSpeedTolerance { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float AnimationSharingWorryThreshold { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float AnimationSharingDrasticThreshold { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string ParticleCursorAnim2DTemplateName { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ParticleCursorBurstCount { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public RandomVariable ParticleCursorBurstFactor { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float ParticleCursorStopBurstFactor { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ParticleCursorBurstFrequency { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public RandomVariable ParticleCursorParticleLife { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public RandomVariable ParticleCursorSystemLife { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public RandomVariable ParticleCursorDriftVelX { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public RandomVariable ParticleCursorDriftVelY { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public RandomVariable ParticleCursorVelocityDrag { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public RandomVariable ParticleCursorParticleSize { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool ParticleCursorPerFrameSize { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public byte ParticleCursorAlpha { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public Coord2D ParticleCursorOffset { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public Coord2D ProgressMovieOffset { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public Coord2D ProgressMovieSize { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool UseHelpTextSystem { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool EnableHouseColor { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public ObjectFilter TreeFadeObjectFilter { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public ObjectFilter CamouflageDetectorObjectFilter { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public ObjectFilter VeterancyPipDrawObjectFilter { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int ReinvisibilityDelay { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float InvisibilityOpacityMin { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float InvisibilityOpacityMax { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int InvisibilityOpacityCycleFrames { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int BuilderFadeOutTime { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int BuilderFadeInTime { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int BuilderMoveFromNewStructureDistance { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int MaxCastleRadius { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public ObjectFilter VictoryConditionStructureObjectFilter { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public ObjectFilter VictoryConditionUnitObjectFilter { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string TutorialMap { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string TutorialLoadMovie { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string TutorialObjective { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public string BasicTutorialMap { get; private set; }
 
         [AddedIn(SageGame.Cnc3)]
         public string BasicTutorialMapConsole { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public string BasicTutorialLoadScreenStillImage { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public string BasicTutorialLoadScreenMusicTrack { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public string BasicTutorialObjective { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int BasicTutorialMillisecondsAfterStartToStartFadeUp { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public string AdvancedTutorialMap { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public string AdvancedTutorialLoadScreenStillImage { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public string AdvancedTutorialLoadScreenMusicTrack { get; private set; }
 
         [AddedIn(SageGame.Cnc3)]
         public string AdvancedTutorialLoadMovie { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public string AdvancedTutorialObjective { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int AdvancedTutorialMillisecondsAfterStartToStartFadeUp { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public ObjectFilter ObjectsThatScore { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_UnitsBuiltMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_UnitsDestroyedMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_StructuresBuiltMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_StructuresDestroyedMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_HeroesVettedMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_UnitsVettedMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_ObjectivesCompletedMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float ScoreKeeper_SuppliesCollectedMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float ScoreKeeper_SkillPointsMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_PowerPointsMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_RegionCommandPointsMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_RegionResourcesMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_RegionPowerPointsMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_TimeTakenMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_TimeTakenMaximumScore { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_TimeTakenMinimumScore { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_TotalVictoryRequiredScore { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_NormalVictoryRequiredScore { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int ScoreKeeper_NormalVictoryRequiredObjectivesPercentage { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float ScoreKeeper_PlayerEliminatedMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int TintUnitIfPathingForMoreThan { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public float GarrisonedRangeMultiplier { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int MaxPathfindCellsPerFrame { get; private set; }
 
         [AddedIn(SageGame.Cnc3)]
         public int MaxPathfindCellsPerPhase { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int MaxCellsFindMeleeEngagementLocation { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int MaxCellsAdjustDestination { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int MaxCellsAdjustHordeMeleeDestination { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int MaxCellsAdjustTargetDestination { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int MaxCellsAdjustToPossibleDestination { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int MaxCellsAdjustToMeleeDestination { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int MaxCellsAdjustToNearestGroundCell { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int MaxCellsAdjustToNearestValidCell { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int MaxCellsPatchPath { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int MaxCellsFindPathLimit { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int MaxCellsFindAttackPath { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int MaxCellsFindAttackPathSideways { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int MaxCellsToExamineTowardsGoal { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public int NumMinutesBeforePlayersCanTransferMoney { get; private set; }
 
         [AddedIn(SageGame.Cnc3)]
@@ -1521,13 +1523,13 @@ namespace OpenSage.Data.Ini
         public bool FogOfWarOn { get; private set; }
         public bool ShowCollisionExtents { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int DebugAerialTileWidth { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int DebugAerialTileDuration { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public IniColorRgb DebugAerialTileColor { get; private set; }
 
         public int DebugProjectileTileWidth { get; private set; }
@@ -1549,6 +1551,9 @@ namespace OpenSage.Data.Ini
         public int MaxDebugCashValueMapValue { get; private set; }
 
         public bool VTune { get; private set; }
+
+        [AddedIn(SageGame.Bfme2Rotwk)]
+        public bool ShellMapOn { get; private set; }
     }
 
     public enum BodyDamageType
@@ -1703,7 +1708,7 @@ namespace OpenSage.Data.Ini
         FrenzyThree,
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class MultiPlayerTuningFactor
     {
         internal static MultiPlayerTuningFactor Parse(IniParser parser)
@@ -1731,7 +1736,7 @@ namespace OpenSage.Data.Ini
         public float MP8 { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarthII)]
+    [AddedIn(SageGame.Bfme2)]
     public struct CommandPoints
     {
         internal static CommandPoints Parse(IniParser parser)

--- a/src/OpenSage.Game/Data/Ini/InGameUI.cs
+++ b/src/OpenSage.Game/Data/Ini/InGameUI.cs
@@ -208,13 +208,13 @@ namespace OpenSage.Data.Ini
         public ColorRgba Color { get; private set; }
         public bool OnlyVisibleToOwningPlayer { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int MinRadius { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int MaxRadius { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int MaxSelectedUnits { get; private set; }
     }
 
@@ -226,7 +226,7 @@ namespace OpenSage.Data.Ini
         [IniEnum("SHADOW_ADDITIVE_DECAL")]
         ShadowAdditiveDecal,
 
-        [IniEnum("SHADOW_MERGE_DECAL"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("SHADOW_MERGE_DECAL"), AddedIn(SageGame.Bfme)]
         ShadowMergeDecal
     }
 }

--- a/src/OpenSage.Game/Data/Ini/Language.cs
+++ b/src/OpenSage.Game/Data/Ini/Language.cs
@@ -40,7 +40,7 @@ namespace OpenSage.Data.Ini
             { "HelpBoxDescriptionFont", (parser, x) => x.HelpBoxDescriptionFont = WndFont.Parse(parser) },
         };
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string ThousandSeparator { get; private set; }
 
         public List<string> LocalFontFiles { get; } = new List<string>();
@@ -55,7 +55,7 @@ namespace OpenSage.Data.Ini
         [AddedIn(SageGame.CncGeneralsZeroHour)]
         public int MilitaryCaptionDelayMS { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public WndFont AudioSubtitleFont { get; private set; }
 
         public WndFont SuperweaponCountdownNormalFont { get; private set; }
@@ -73,16 +73,16 @@ namespace OpenSage.Data.Ini
         public WndFont CreditsNormalFont { get; private set; }
         public float ResolutionFontAdjustment { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public WndFont HelpBoxNameFont { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public WndFont HelpBoxCostFont { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public WndFont HelpBoxShortcutFont { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public WndFont HelpBoxDescriptionFont { get; private set; }
     }
 }

--- a/src/OpenSage.Game/Data/Ini/LivingWorldCampaign.cs
+++ b/src/OpenSage.Game/Data/Ini/LivingWorldCampaign.cs
@@ -3,7 +3,7 @@ using OpenSage.Data.Ini.Parser;
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldCampaign
     {
         internal static LivingWorldCampaign Parse(IniParser parser)
@@ -27,7 +27,7 @@ namespace OpenSage.Data.Ini
         public List<LivingWorldCampaignAct> Acts { get; } = new List<LivingWorldCampaignAct>();
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldCampaignAct
     {
         internal static LivingWorldCampaignAct Parse(IniParser parser)
@@ -64,13 +64,13 @@ namespace OpenSage.Data.Ini
         public List<LivingWorldCampaignActNugget> Nuggets { get; } = new List<LivingWorldCampaignActNugget>();
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public abstract class LivingWorldCampaignActNugget
     {
 
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldCampaignActWorldText : LivingWorldCampaignActNugget
     {
         internal static LivingWorldCampaignActWorldText Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -85,7 +85,7 @@ namespace OpenSage.Data.Ini
         public string StringTag { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldCampaignActAudioEvent : LivingWorldCampaignActNugget
     {
         internal static LivingWorldCampaignActAudioEvent Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -102,7 +102,7 @@ namespace OpenSage.Data.Ini
         public bool SummaryEvent { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldCampaignActDespawnArmy : LivingWorldCampaignActNugget
     {
         internal static LivingWorldCampaignActDespawnArmy Parse(IniParser parser) => new LivingWorldCampaignActDespawnArmy { Name = parser.ParseAssetReference() };
@@ -110,7 +110,7 @@ namespace OpenSage.Data.Ini
         public string Name { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldCampaignActSplineCamera : LivingWorldCampaignActNugget
     {
         internal static LivingWorldCampaignActSplineCamera Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -125,7 +125,7 @@ namespace OpenSage.Data.Ini
         public List<LivingWorldControlPoint> ControlPoints { get; } = new List<LivingWorldControlPoint>();
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldCampaignActSpawnArmy : LivingWorldCampaignActNugget
     {
         internal static LivingWorldCampaignActSpawnArmy Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -158,7 +158,7 @@ namespace OpenSage.Data.Ini
         public bool IsCity { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldCampaignActToggleArmyControl : LivingWorldCampaignActNugget
     {
         internal static LivingWorldCampaignActToggleArmyControl Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -173,7 +173,7 @@ namespace OpenSage.Data.Ini
         public bool PlayerControl { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldCampaignActEnableRegion : LivingWorldCampaignActNugget
     {
         internal static LivingWorldCampaignActEnableRegion Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -186,7 +186,7 @@ namespace OpenSage.Data.Ini
         public string Region { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldCampaignActMoveArmy : LivingWorldCampaignActNugget
     {
         internal static LivingWorldCampaignActMoveArmy Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -207,7 +207,7 @@ namespace OpenSage.Data.Ini
         public float MoveSpeed { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldCampaignActForceBattle : LivingWorldCampaignActNugget
     {
         internal static LivingWorldCampaignActForceBattle Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -226,7 +226,7 @@ namespace OpenSage.Data.Ini
         public Coord2D ArmyAttackDirection { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldCampaignActEyeTowerPoints : LivingWorldCampaignActNugget
     {
         internal static LivingWorldCampaignActEyeTowerPoints Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -239,7 +239,7 @@ namespace OpenSage.Data.Ini
         public List<Coord2D> LookPoints { get; } = new List<Coord2D>();
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldCampaignActMoveCamera : LivingWorldCampaignActNugget
     {
         internal static LivingWorldCampaignActMoveCamera Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -258,7 +258,7 @@ namespace OpenSage.Data.Ini
         public float ScrollTime { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldCampaignActModifyArmyEntry : LivingWorldCampaignActNugget
     {
         internal static LivingWorldCampaignActModifyArmyEntry Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -275,7 +275,7 @@ namespace OpenSage.Data.Ini
         public string NewUnitTemplate { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldCampaignActMergePlayerArmy : LivingWorldCampaignActNugget
     {
         internal static LivingWorldCampaignActMergePlayerArmy Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -294,7 +294,7 @@ namespace OpenSage.Data.Ini
         public bool SplitArmy { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldCampaignActRegionReinforcements : LivingWorldCampaignActNugget
     {
         internal static LivingWorldCampaignActRegionReinforcements Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);

--- a/src/OpenSage.Game/Data/Ini/LivingWorldPlayerArmy.cs
+++ b/src/OpenSage.Game/Data/Ini/LivingWorldPlayerArmy.cs
@@ -3,7 +3,7 @@ using OpenSage.Data.Ini.Parser;
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldPlayerArmy
     {
         internal static LivingWorldPlayerArmy Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -30,7 +30,7 @@ namespace OpenSage.Data.Ini
         public List<LivingWorldPlayerArmyEntry> ArmyEntries { get; } = new List<LivingWorldPlayerArmyEntry>();
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldPlayerArmyEntry
     {
         internal static LivingWorldPlayerArmyEntry Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);

--- a/src/OpenSage.Game/Data/Ini/LivingWorldRegionCampaign.cs
+++ b/src/OpenSage.Game/Data/Ini/LivingWorldRegionCampaign.cs
@@ -4,7 +4,7 @@ using OpenSage.Mathematics;
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldRegionCampaign
     {
         internal static LivingWorldRegionCampaign Parse(IniParser parser)
@@ -80,7 +80,7 @@ namespace OpenSage.Data.Ini
         public List<LivingWorldRegionCampaignRegion> Regions { get; } = new List<LivingWorldRegionCampaignRegion>();
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldRegionCampaignEffect
     {
         internal static LivingWorldRegionCampaignEffect Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -95,7 +95,7 @@ namespace OpenSage.Data.Ini
         public List<LivingWorldControlPoint> ControlPoints { get; } = new List<LivingWorldControlPoint>();
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldControlPoint
     {
         internal static LivingWorldControlPoint Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -125,7 +125,7 @@ namespace OpenSage.Data.Ini
         public float Time { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldRegionCampaignRegion
     {
         internal static LivingWorldRegionCampaignRegion Parse(IniParser parser)
@@ -201,7 +201,7 @@ namespace OpenSage.Data.Ini
         public List<Coord2D> ArmyPlacementPositions { get; } = new List<Coord2D>();
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LivingWorldRegionCampaignRegionSkirmishOpponent
     {
         internal static LivingWorldRegionCampaignRegionSkirmishOpponent Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);

--- a/src/OpenSage.Game/Data/Ini/LoadSubsystem.cs
+++ b/src/OpenSage.Game/Data/Ini/LoadSubsystem.cs
@@ -3,7 +3,7 @@ using OpenSage.Data.Ini.Parser;
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class LoadSubsystem
     {
         internal static LoadSubsystem Parse(IniParser parser)

--- a/src/OpenSage.Game/Data/Ini/MiscEvaData.cs
+++ b/src/OpenSage.Game/Data/Ini/MiscEvaData.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class MiscEvaData
     {
         internal static MiscEvaData Parse(IniParser parser) => parser.ParseTopLevelBlock(FieldParseTable);

--- a/src/OpenSage.Game/Data/Ini/ModifierList.cs
+++ b/src/OpenSage.Game/Data/Ini/ModifierList.cs
@@ -7,7 +7,7 @@ namespace OpenSage.Data.Ini
     /// <summary>
     /// A set of bonuses that can given together as a package.
     /// </summary>
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class ModifierList
     {
         internal static ModifierList Parse(IniParser parser)
@@ -51,7 +51,7 @@ namespace OpenSage.Data.Ini
         public ModifierUpgrade? Upgrade { get; private set; }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public struct Modifier
     {
         internal static Modifier Parse(IniParser parser)
@@ -67,7 +67,7 @@ namespace OpenSage.Data.Ini
         public float Amount;
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public struct ModifierUpgrade
     {
         internal static ModifierUpgrade Parse(IniParser parser)
@@ -83,7 +83,7 @@ namespace OpenSage.Data.Ini
         public int Delay;
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public enum ModifierCategory
     {
         [IniEnum("LEADERSHIP")]
@@ -105,7 +105,7 @@ namespace OpenSage.Data.Ini
         Level
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public enum ModifierType
     {
         [IniEnum("ARMOR")]

--- a/src/OpenSage.Game/Data/Ini/ParticleSystem.cs
+++ b/src/OpenSage.Game/Data/Ini/ParticleSystem.cs
@@ -159,13 +159,13 @@ namespace OpenSage.Data.Ini
         public bool IsParticleUpTowardsEmitter { get; private set; }
         public ParticleSystemWindMotion WindMotion { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float WindStrength { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float WindFullStrengthDist { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float WindZeroStrengthDist { get; private set; }
 
         public float WindAngleChangeMin { get; private set; }
@@ -225,13 +225,13 @@ namespace OpenSage.Data.Ini
         [IniEnum("MULTIPLY")]
         Multiply,
 
-        [IniEnum("W3D_EMISSIVE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("W3D_EMISSIVE"), AddedIn(SageGame.Bfme)]
         W3dEmissive,
 
-        [IniEnum("W3D_ALPHA"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("W3D_ALPHA"), AddedIn(SageGame.Bfme)]
         W3dAlpha,
 
-        [IniEnum("W3D_DIFFUSE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("W3D_DIFFUSE"), AddedIn(SageGame.Bfme)]
         W3dDiffuse,
     }
 
@@ -249,7 +249,7 @@ namespace OpenSage.Data.Ini
         [IniEnum("STREAK")]
         Streak,
 
-        [IniEnum("SMUDGE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("SMUDGE"), AddedIn(SageGame.Bfme)]
         Smudge,
     }
 
@@ -303,7 +303,7 @@ namespace OpenSage.Data.Ini
         [IniEnum("PingPong")]
         PingPong,
 
-        [IniEnum("Circular"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("Circular"), AddedIn(SageGame.Bfme)]
         Circular
     }
 }

--- a/src/OpenSage.Game/Data/Ini/SkyboxTextureSet.cs
+++ b/src/OpenSage.Game/Data/Ini/SkyboxTextureSet.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class SkyboxTextureSet
     {
         internal static SkyboxTextureSet Parse(IniParser parser)

--- a/src/OpenSage.Game/Data/Ini/StaticGameLod.cs
+++ b/src/OpenSage.Game/Data/Ini/StaticGameLod.cs
@@ -51,10 +51,10 @@ namespace OpenSage.Data.Ini
         public int MaxParticleCount { get; private set; }
         public bool UseShadowVolumes { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool UseAnisotropic { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool UsePixelShaders { get; private set; }
 
         public bool UseShadowDecals { get; private set; }
@@ -67,10 +67,10 @@ namespace OpenSage.Data.Ini
         public bool UseBuildupScaffolds { get; private set; }
         public bool UseTreeSway { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool ShowProps { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool UseHighQualityVideo { get; private set; }
 
         public bool UseEmissiveNightMaterials { get; private set; }
@@ -78,16 +78,16 @@ namespace OpenSage.Data.Ini
 
         public AnimationLodType AnimationDetail { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public ParticleSystemPriority MinParticlePriority { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public ParticleSystemPriority MinParticleSkipPriority { get; private set; }
     }
 
     public enum GameLodType
     {
-        [IniEnum("VeryLow"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("VeryLow"), AddedIn(SageGame.Bfme)]
         VeryLow,
 
         [IniEnum("LOW")]
@@ -102,11 +102,11 @@ namespace OpenSage.Data.Ini
         [IniEnum("VeryHigh")]
         VeryHigh,
 
-        [IniEnum("UltraHigh"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("UltraHigh"), AddedIn(SageGame.Bfme)]
         UltraHigh,
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public enum AnimationLodType
     {
         [IniEnum("VeryLow")]

--- a/src/OpenSage.Game/Data/Ini/Upgrade.cs
+++ b/src/OpenSage.Game/Data/Ini/Upgrade.cs
@@ -29,7 +29,7 @@ namespace OpenSage.Data.Ini
         public UpgradeType Type { get; private set; } = UpgradeType.Player;
         public string DisplayName { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string Tooltip { get; private set; }
 
         public float BuildTime { get; private set; }

--- a/src/OpenSage.Game/Data/Ini/VictorySystemData.cs
+++ b/src/OpenSage.Game/Data/Ini/VictorySystemData.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class VictorySystemData
     {
         internal static VictorySystemData Parse(IniParser parser)

--- a/src/OpenSage.Game/Data/Ini/Video.cs
+++ b/src/OpenSage.Game/Data/Ini/Video.cs
@@ -24,10 +24,10 @@ namespace OpenSage.Data.Ini
         public string Filename { get; private set; }
         public string Comment { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int Volume { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool IsDefault { get; private set; }
     }
 }

--- a/src/OpenSage.Game/Data/Ini/WaterTextureList.cs
+++ b/src/OpenSage.Game/Data/Ini/WaterTextureList.cs
@@ -3,7 +3,7 @@ using OpenSage.Data.Ini.Parser;
 
 namespace OpenSage.Data.Ini
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class WaterTextureList
     {
         internal static WaterTextureList Parse(IniParser parser)

--- a/src/OpenSage.Game/Data/Ini/Weather.cs
+++ b/src/OpenSage.Game/Data/Ini/Weather.cs
@@ -28,7 +28,7 @@ namespace OpenSage.Data.Ini
 
         public bool SnowEnabled { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool IsSnowing { get; private set; }
 
         public string SnowTexture { get; private set; }

--- a/src/OpenSage.Game/Data/Map/BlendTileData.cs
+++ b/src/OpenSage.Game/Data/Map/BlendTileData.cs
@@ -19,25 +19,25 @@ namespace OpenSage.Data.Map
 
         public bool[,] Impassability { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool[,] ImpassabilityToPlayers { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool[,] PassageWidths { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool[,] Taintability { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool[,] ExtraPassability { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public TileFlammability[,] Flammability { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public bool[,] Visibility { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool[,] ImpassabilityToAirUnits { get; private set; }
 
         [AddedIn(SageGame.Cnc3)]
@@ -363,7 +363,7 @@ namespace OpenSage.Data.Map
         }
     }
 
-    [AddedIn(SageGame.BattleForMiddleEarthII)]
+    [AddedIn(SageGame.Bfme2)]
     public enum TileFlammability
     {
         FireResistant = 0,

--- a/src/OpenSage.Game/Data/Map/CameraAnimationList.cs
+++ b/src/OpenSage.Game/Data/Map/CameraAnimationList.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Map
 {
-    [AddedIn(SageGame.BattleForMiddleEarthII)]
+    [AddedIn(SageGame.Bfme2)]
     public sealed class CameraAnimationList : Asset
     {
         public const string AssetName = "CameraAnimationList";

--- a/src/OpenSage.Game/Data/Map/MapFile.cs
+++ b/src/OpenSage.Game/Data/Map/MapFile.cs
@@ -21,21 +21,21 @@ namespace OpenSage.Data.Map
         public BlendTileData BlendTileData { get; private set; }
         public WorldInfo WorldInfo { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public MPPositionList MPPositionList { get; private set; }
 
         public SidesList SidesList { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public LibraryMapLists LibraryMapLists { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public Teams Teams { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public PlayerScriptsList PlayerScriptsList { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public BuildLists BuildLists { get; private set; }
 
         public ObjectsList ObjectsList { get; private set; }
@@ -43,7 +43,7 @@ namespace OpenSage.Data.Map
         // Either PolygonTriggers (Generals, ZH, BFME I) or TriggerAreas + StandingWaterAreas + RiverAreas + StandingWaveAreas (BFME II and later)
         public PolygonTriggers PolygonTriggers { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public TriggerAreas TriggerAreas { get; private set; }
 
         [AddedIn(SageGame.Cnc3)]
@@ -58,32 +58,32 @@ namespace OpenSage.Data.Map
         [AddedIn(SageGame.Ra3)]
         public MissionObjectives MissionObjectives { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public StandingWaterAreas StandingWaterAreas { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public RiverAreas RiverAreas { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public StandingWaveAreas StandingWaveAreas { get; private set; }
 
         public GlobalLighting GlobalLighting { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public PostEffectsChunk PostEffectsChunk { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public EnvironmentData EnvironmentData { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public NamedCameras NamedCameras { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         public CameraAnimationList CameraAnimationList { get; private set; }
 
         public WaypointsList WaypointsList { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public SkyboxSettings SkyboxSettings { get; private set; }
 
         public PlayerScriptsList GetPlayerScriptsList() => SidesList.PlayerScripts ?? PlayerScriptsList;

--- a/src/OpenSage.Game/Data/Map/PostEffectsChunk.cs
+++ b/src/OpenSage.Game/Data/Map/PostEffectsChunk.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Map
 {
-    [AddedIn(SageGame.BattleForMiddleEarthII)]
+    [AddedIn(SageGame.Bfme2)]
     public sealed class PostEffectsChunk : Asset
     {
         public const string AssetName = "PostEffectsChunk";

--- a/src/OpenSage.Game/Data/Map/RiverAreas.cs
+++ b/src/OpenSage.Game/Data/Map/RiverAreas.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Map
 {
-    [AddedIn(SageGame.BattleForMiddleEarthII)]
+    [AddedIn(SageGame.Bfme2)]
     public sealed class RiverAreas : Asset
     {
         public const string AssetName = "RiverAreas";

--- a/src/OpenSage.Game/Data/Map/RoadType.cs
+++ b/src/OpenSage.Game/Data/Map/RoadType.cs
@@ -20,7 +20,7 @@ namespace OpenSage.Data.Map
 
         EndCap = 128,
 
-        [AddedIn(SageGame.BattleForMiddleEarthII)]
+        [AddedIn(SageGame.Bfme2)]
         Unknown3 = 256,
 
         [AddedIn(SageGame.Cnc4)]

--- a/src/OpenSage.Game/Data/Map/StandingWaterAreas.cs
+++ b/src/OpenSage.Game/Data/Map/StandingWaterAreas.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Map
 {
-    [AddedIn(SageGame.BattleForMiddleEarthII)]
+    [AddedIn(SageGame.Bfme2)]
     public sealed class StandingWaterAreas : Asset
     {
         public const string AssetName = "StandingWaterAreas";

--- a/src/OpenSage.Game/Data/Map/StandingWaveArea.cs
+++ b/src/OpenSage.Game/Data/Map/StandingWaveArea.cs
@@ -4,7 +4,7 @@ using OpenSage.Data.Utilities.Extensions;
 
 namespace OpenSage.Data.Map
 {
-    [AddedIn(SageGame.BattleForMiddleEarthII)]
+    [AddedIn(SageGame.Bfme2)]
     public sealed class StandingWaveArea
     {
         public uint UniqueID { get; private set; }

--- a/src/OpenSage.Game/Data/Map/StandingWaveAreas.cs
+++ b/src/OpenSage.Game/Data/Map/StandingWaveAreas.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Map
 {
-    [AddedIn(SageGame.BattleForMiddleEarthII)]
+    [AddedIn(SageGame.Bfme2)]
     public sealed class StandingWaveAreas : Asset
     {
         public const string AssetName = "StandingWaveAreas";

--- a/src/OpenSage.Game/Data/Map/TriggerAreas.cs
+++ b/src/OpenSage.Game/Data/Map/TriggerAreas.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Data.Map
 {
-    [AddedIn(SageGame.BattleForMiddleEarthII)]
+    [AddedIn(SageGame.Bfme2)]
     public sealed class TriggerAreas : Asset
     {
         public const string AssetName = "TriggerAreas";

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -201,8 +201,9 @@ namespace OpenSage
             {
                 case SageGame.CncGenerals:
                 case SageGame.CncGeneralsZeroHour:
-                case SageGame.BattleForMiddleEarth:
-                case SageGame.BattleForMiddleEarthII:
+                case SageGame.Bfme:
+                case SageGame.Bfme2:
+                case SageGame.Bfme2Rotwk:
                     ContentManager.IniDataContext.LoadIniFile(@"Data\INI\ParticleSystem.ini");
                     break;
             }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/ShareExperienceBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/ShareExperienceBehavior.cs
@@ -3,7 +3,7 @@ using OpenSage.Data.Ini.Parser;
 
 namespace OpenSage.Logic.Object
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class ShareExperienceBehaviorModuleData : UpdateModuleData
     {
         internal static ShareExperienceBehaviorModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);

--- a/src/OpenSage.Game/Logic/Object/Collide/SalvageCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/SalvageCrateCollide.cs
@@ -35,31 +35,31 @@ namespace OpenSage.Logic.Object
         public int MinMoney { get; private set; }
         public int MaxMoney { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string ExecuteFX { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float PorterChance { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float BannerChance { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float LevelUpChance { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float LevelUpRadius { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public float ResourceChance { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int MinResource { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int MaxResource { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public bool AllowAIPickup { get; private set; }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Collide/VeterancyCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/VeterancyCrateCollide.cs
@@ -22,10 +22,10 @@ namespace OpenSage.Logic.Object
         public bool AddsOwnerVeterancy { get; private set; }
         public bool IsPilot { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string ExecuteFX { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int AffectsUpToLevel { get; private set; }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dScriptedModelDrawModuleData.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dScriptedModelDrawModuleData.cs
@@ -3,7 +3,7 @@ using OpenSage.Data.Ini.Parser;
 
 namespace OpenSage.Logic.Object
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class W3dScriptedModelDrawModuleData : W3dModelDrawModuleData
     {
         internal static W3dScriptedModelDrawModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);

--- a/src/OpenSage.Game/Logic/Object/ModelConditionFlag.cs
+++ b/src/OpenSage.Game/Logic/Object/ModelConditionFlag.cs
@@ -343,49 +343,49 @@ namespace OpenSage.Logic.Object
         [IniEnum("TAKING_DAMAGE"), AddedIn(SageGame.CncGeneralsZeroHour)]
         TakingDamage,
 
-        [IniEnum("HERO"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("HERO"), AddedIn(SageGame.Bfme)]
         Hero,
 
-        [IniEnum("UPGRADE_ECONOMY_BONUS"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("UPGRADE_ECONOMY_BONUS"), AddedIn(SageGame.Bfme)]
         UpgradeEconomyBonus,
 
-        [IniEnum("WAR_CHANT"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("WAR_CHANT"), AddedIn(SageGame.Bfme)]
         WarChant,
 
-        [IniEnum("JUST_BUILT"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("JUST_BUILT"), AddedIn(SageGame.Bfme)]
         JustBuilt,
 
-        [IniEnum("EMOTION_AFRAID"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("EMOTION_AFRAID"), AddedIn(SageGame.Bfme)]
         EmotionAfraid,
 
-        [IniEnum("WEAPONSET_TOGGLE_1"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("WEAPONSET_TOGGLE_1"), AddedIn(SageGame.Bfme)]
         WeaponSetToggle1,
 
-        [IniEnum("MOUNTED"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("MOUNTED"), AddedIn(SageGame.Bfme)]
         Mounted,
 
-        [IniEnum("WEAPONLOCK_SECONDARY"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("WEAPONLOCK_SECONDARY"), AddedIn(SageGame.Bfme)]
         WeaponLockSecondary,
 
-        [IniEnum("EMOTION_TAUNTING"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("EMOTION_TAUNTING"), AddedIn(SageGame.Bfme)]
         EmotionTaunting,
 
-        [IniEnum("EMOTION_ALERT"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("EMOTION_ALERT"), AddedIn(SageGame.Bfme)]
         EmotionAlert,
 
-        [IniEnum("EMOTION_CELEBRATING"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("EMOTION_CELEBRATING"), AddedIn(SageGame.Bfme)]
         EmotionCelebrating,
 
-        [IniEnum("EMOTION_UNCONTROLLABLY_AFRAID"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("EMOTION_UNCONTROLLABLY_AFRAID"), AddedIn(SageGame.Bfme)]
         EmotionUncontrollablyAfraid,
 
-        [IniEnum("EMOTION_TERROR"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("EMOTION_TERROR"), AddedIn(SageGame.Bfme)]
         EmotionTerror,
 
-        [IniEnum("EMOTION_POINTING"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("EMOTION_POINTING"), AddedIn(SageGame.Bfme)]
         EmotionPointing,
 
-        [IniEnum("EMOTION_DOOM"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("EMOTION_DOOM"), AddedIn(SageGame.Bfme)]
         EmotionDoom,
     }
 }

--- a/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
@@ -308,39 +308,39 @@ namespace OpenSage.Logic.Object
         // Audio
         public string VoiceSelect { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceSelectGroup { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceSelectBattle { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceSelectBattleGroup { get; private set; }
 
         public string VoiceMove { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceMoveGroup { get; private set; }
 
         public string VoiceGuard { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceGuardGroup { get; private set; }
 
         public string VoiceAttack { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackGroup { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackCharge { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackChargeGroup { get; private set; }
 
         public string VoiceAttackAir { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackAirGroup { get; private set; }
 
         public string VoiceGroupSelect { get; private set; }
@@ -352,208 +352,208 @@ namespace OpenSage.Logic.Object
         public string VoiceTaskUnable { get; private set; }
         public string VoiceTaskComplete { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceDefect { get; private set; }
 
         public string VoiceMeetEnemy { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAlert { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceFullyCreated { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceRetreatToCastle { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceRetreatToCastleGroup { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceMoveToCamp { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceMoveToCampGroup { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackStructure { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackStructureGroup { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackMachine { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackMachineGroup { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceMoveWhileAttacking { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceMoveWhileAttackingGroup { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAmbushed { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceCombineWithHorde { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateAttack { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateAttackCharge { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateAttackAir { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateAttackStructure { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateAttackMachine { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateMove { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateRetreatToCastle { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateMoveToCamp { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateMoveWhileAttacking { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceSelect2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceSelectGroup2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceSelectBattle2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceSelectBattleGroup2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceMove2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceMoveGroup2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceGuard2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceGuardGroup2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttack2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackGroup2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackCharge2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackChargeGroup2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackAir2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackAirGroup2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceFear2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceCreated2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceTaskComplete2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceDefect2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAlert2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceFullyCreated2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceRetreatToCastle2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceRetreatToCastleGroup2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceMoveToCamp2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceMoveToCampGroup2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackStructure2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackStructureGroup2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackMachine2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAttackMachineGroup2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceMoveWhileAttacking2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceMoveWhileAttackingGroup2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceAmbushed2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceCombineWithHorde2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateAttack2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateAttackCharge2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateAttackAir2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateAttackStructure2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateAttackMachine2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateMove2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateRetreatToCastle2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateMoveToCamp2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string VoiceEnterStateMoveWhileAttacking2 { get; private set; }
 
         public string SoundMoveStart { get; private set; }
         public string SoundMoveStartDamaged { get; private set; }
         public string SoundMoveLoop { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string SoundMoveLoopDamaged { get; private set; }
 
         public string SoundOnDamaged { get; private set; }
@@ -569,58 +569,58 @@ namespace OpenSage.Logic.Object
         public string SoundAmbientReallyDamaged { get; private set; }
         public string SoundAmbientRubble { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string SoundAmbient2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string SoundAmbientDamaged2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string SoundAmbientReallyDamaged2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string SoundAmbientRubble2 { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string SoundAmbientBattle { get; private set; }
 
         public string SoundCreated { get; private set; }
         public string SoundEnter { get; private set; }
         public string SoundExit { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string SoundPromotedVeteran { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string SoundPromotedElite { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string SoundPromotedHero { get; private set; }
 
         public string SoundFallingFromPlane { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string SoundImpact { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string SoundCrushing { get; private set; }
 
         public UnitSpecificAssets UnitSpecificSounds { get; private set; }
         public UnitSpecificAssets UnitSpecificFX { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int VoicePriority { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int GroupVoiceThreshold { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int VoiceAmbushBlockingRadius { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public int VoiceAmbushTimeout { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string EvaEnemyUnitSightedEvent { get; private set; }
 
         // Engineering
@@ -662,7 +662,7 @@ namespace OpenSage.Logic.Object
         public string BuildCompletion { get; private set; }
         public string[] BuildVariations { get; private set; }
 
-        [AddedIn(SageGame.BattleForMiddleEarth)]
+        [AddedIn(SageGame.Bfme)]
         public string ExperienceScalarTable { get; private set; }
 
         public List<InheritableModule> InheritableModules { get; } = new List<InheritableModule>();

--- a/src/OpenSage.Game/Logic/Object/ObjectKinds.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectKinds.cs
@@ -359,46 +359,46 @@
         [IniEnum("REJECT_UNMANNED"), AddedIn(SageGame.CncGeneralsZeroHour)]
         RejectUnmanned,
 
-        [IniEnum("TACTICAL_MARKER"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("TACTICAL_MARKER"), AddedIn(SageGame.Bfme)]
         TacticalMarker,
 
-        [IniEnum("CAVALRY"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("CAVALRY"), AddedIn(SageGame.Bfme)]
         Cavalry,
 
-        [IniEnum("MONSTER"), AddedIn(SageGame.BattleForMiddleEarthII)]
+        [IniEnum("MONSTER"), AddedIn(SageGame.Bfme2)]
         Monster,
 
-        [IniEnum("MACHINE"), AddedIn(SageGame.BattleForMiddleEarthII)]
+        [IniEnum("MACHINE"), AddedIn(SageGame.Bfme2)]
         Machine,
 
-        [IniEnum("HORDE"), AddedIn(SageGame.BattleForMiddleEarthII)]
+        [IniEnum("HORDE"), AddedIn(SageGame.Bfme2)]
         Horde,
 
-        [IniEnum("IGNORE_FOR_VICTORY"), AddedIn(SageGame.BattleForMiddleEarthII)]
+        [IniEnum("IGNORE_FOR_VICTORY"), AddedIn(SageGame.Bfme2)]
         IgnoreForVictory,
 
-        [IniEnum("ECONOMY_STRUCTURE"), AddedIn(SageGame.BattleForMiddleEarthII)]
+        [IniEnum("ECONOMY_STRUCTURE"), AddedIn(SageGame.Bfme2)]
         EconomyStructure,
 
-        [IniEnum("WALL_UPGRADE"), AddedIn(SageGame.BattleForMiddleEarthII)]
+        [IniEnum("WALL_UPGRADE"), AddedIn(SageGame.Bfme2)]
         WallUpgrade,
 
-        [IniEnum("WALL_HUB"), AddedIn(SageGame.BattleForMiddleEarthII)]
+        [IniEnum("WALL_HUB"), AddedIn(SageGame.Bfme2)]
         WallHub,
 
-        [IniEnum("WALL_SEGMENT"), AddedIn(SageGame.BattleForMiddleEarthII)]
+        [IniEnum("WALL_SEGMENT"), AddedIn(SageGame.Bfme2)]
         WallSegment,
 
-        [IniEnum("NOT_AUTOACQUIRABLE"), AddedIn(SageGame.BattleForMiddleEarthII)]
+        [IniEnum("NOT_AUTOACQUIRABLE"), AddedIn(SageGame.Bfme2)]
         NotAutoAcquirable,
 
-        [IniEnum("BLOCKING_GATE"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("BLOCKING_GATE"), AddedIn(SageGame.Bfme)]
         BlockingGate,
 
-        [IniEnum("ENVIRONMENT"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("ENVIRONMENT"), AddedIn(SageGame.Bfme)]
         Environment,
 
-        [IniEnum("CREEP"), AddedIn(SageGame.BattleForMiddleEarth)]
+        [IniEnum("CREEP"), AddedIn(SageGame.Bfme)]
         Creep,
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AttributeModifierPoolUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AttributeModifierPoolUpdate.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Logic.Object
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class AttributeModifierPoolUpdateModuleData : UpdateModuleData
     {
         internal static AttributeModifierPoolUpdateModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);

--- a/src/OpenSage.Game/Logic/Object/Update/TemporarilyDefectUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/TemporarilyDefectUpdate.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Logic.Object
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class TemporarilyDefectUpdateModuleData : UpdateModuleData
     {
         internal static TemporarilyDefectUpdateModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);

--- a/src/OpenSage.Game/Logic/Object/Upgrade/AttributeModifierUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/AttributeModifierUpgrade.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Logic.Object
 {
-    [AddedIn(SageGame.BattleForMiddleEarth)]
+    [AddedIn(SageGame.Bfme)]
     public sealed class AttributeModifierUpgradeModuleData : UpgradeModuleData
     {
         internal static AttributeModifierUpgradeModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);

--- a/src/OpenSage.Game/SageGame.cs
+++ b/src/OpenSage.Game/SageGame.cs
@@ -4,8 +4,9 @@
     {
         CncGenerals,
         CncGeneralsZeroHour,
-        BattleForMiddleEarth,
-        BattleForMiddleEarthII,
+        Bfme,
+        Bfme2,
+        Bfme2Rotwk,
         Cnc3,
         Cnc3KanesWrath,
         Ra3,

--- a/src/OpenSage.Mods.Bfme/BfmeDefinition.cs
+++ b/src/OpenSage.Mods.Bfme/BfmeDefinition.cs
@@ -7,7 +7,7 @@ namespace OpenSage.Mods.BFME
 {
     public class BfmeDefinition : IGameDefinition
     {
-        public SageGame Game => SageGame.BattleForMiddleEarth;
+        public SageGame Game => SageGame.Bfme;
         public string DisplayName => "The Lord of the Rings (tm): The Battle for Middle-earth (tm)";
         public IGameDefinition BaseGame => null;
 

--- a/src/OpenSage.Mods.Bfme2/Bfme2Definition.cs
+++ b/src/OpenSage.Mods.Bfme2/Bfme2Definition.cs
@@ -4,11 +4,11 @@ using OpenSage.Data;
 using OpenSage.Gui;
 using OpenSage.Gui.Apt;
 
-namespace OpenSage.Mods.BfmeII
+namespace OpenSage.Mods.Bfme2
 {
-    public class BfmeIIDefinition : IGameDefinition
+    public class Bfme2Definition : IGameDefinition
     {
-        public SageGame Game => SageGame.BattleForMiddleEarthII;
+        public SageGame Game => SageGame.Bfme2;
         public string DisplayName => "The Lord of the Rings (tm): The Battle for Middle-earth (tm) II";
         public IGameDefinition BaseGame => null;
 
@@ -24,6 +24,6 @@ namespace OpenSage.Mods.BfmeII
 
         public IMainMenuSource MainMenu { get; } = new AptMainMenuSource("MainMenu.apt");
 
-        public static BfmeIIDefinition Instance { get; } = new BfmeIIDefinition();
+        public static Bfme2Definition Instance { get; } = new Bfme2Definition();
     }
 }

--- a/src/OpenSage.Mods.Bfme2/Bfme2RotwkDefinition.cs
+++ b/src/OpenSage.Mods.Bfme2/Bfme2RotwkDefinition.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using OpenSage.Data;
+using OpenSage.Gui;
+using OpenSage.Gui.Apt;
+
+namespace OpenSage.Mods.Bfme2
+{
+    public class Bfme2RotwkDefinition : IGameDefinition
+    {
+        public SageGame Game => SageGame.Bfme2Rotwk;
+        public string DisplayName => "The Lord of the Rings (tm): The Battle for Middle-earth (tm) II: The Rise of the Witch-king";
+        public IGameDefinition BaseGame => Bfme2Definition.Instance;
+
+        public Type WndCallbackType => null;
+
+        // TODO: Localise?
+        public string LauncherImagePath => "EnglishSplash.jpg";
+
+        public IEnumerable<RegistryKeyPath> RegistryKeys { get; } = new[]
+        {
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\The Lord of the Rings, The Rise of the Witch-king", "InstallPath") 
+        };
+
+        public IMainMenuSource MainMenu { get; } = new AptMainMenuSource("MainMenu.apt");
+
+        public static Bfme2RotwkDefinition Instance { get; } = new Bfme2RotwkDefinition();
+    }
+}

--- a/src/OpenSage.Mods.Bfme2/OpenSage.Mods.Bfme2.csproj
+++ b/src/OpenSage.Mods.Bfme2/OpenSage.Mods.Bfme2.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>OpenSage.Mods.Bfme2</RootNamespace>
+    <AssemblyName>OpenSage.Mods.Bfme2</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenSage.Game\OpenSage.Game.csproj" />

--- a/src/OpenSage.Mods.BuiltIn/GameDefinition.cs
+++ b/src/OpenSage.Mods.BuiltIn/GameDefinition.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenSage.Mods.Generals;
 using OpenSage.Mods.BFME;
-using OpenSage.Mods.BfmeII;
+using OpenSage.Mods.Bfme2;
 using OpenSage.Mods.Cnc4;
 using OpenSage.Mods.CnC3;
 using OpenSage.Mods.Ra3;
@@ -31,8 +31,9 @@ namespace OpenSage.Mods.BuiltIn
             {
                 [SageGame.CncGenerals] = GeneralsDefinition.Instance,
                 [SageGame.CncGeneralsZeroHour] = GeneralsZeroHourDefinition.Instance,
-                [SageGame.BattleForMiddleEarth] = BfmeDefinition.Instance,
-                [SageGame.BattleForMiddleEarthII] = BfmeIIDefinition.Instance,
+                [SageGame.Bfme] = BfmeDefinition.Instance,
+                [SageGame.Bfme2] = Bfme2Definition.Instance,
+                [SageGame.Bfme2Rotwk] = Bfme2RotwkDefinition.Instance,
                 [SageGame.Cnc3] = Cnc3Definition.Instance,
                 [SageGame.Cnc3KanesWrath] = Cnc3KanesWrathDefinition.Instance,
                 [SageGame.Ra3] = Ra3Definition.Instance,

--- a/src/OpenSage.Mods.BuiltIn/OpenSage.Mods.BuiltIn.csproj
+++ b/src/OpenSage.Mods.BuiltIn/OpenSage.Mods.BuiltIn.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenSage.Game\OpenSage.Game.csproj" />
-    <ProjectReference Include="..\OpenSage.Mods.BfmeII\OpenSage.Mods.BfmeII.csproj" />
+    <ProjectReference Include="..\OpenSage.Mods.Bfme2\OpenSage.Mods.Bfme2.csproj" />
     <ProjectReference Include="..\OpenSage.Mods.Bfme\OpenSage.Mods.Bfme.csproj" />
     <ProjectReference Include="..\OpenSage.Mods.Cnc3\OpenSage.Mods.Cnc3.csproj" />
     <ProjectReference Include="..\OpenSage.Mods.Cnc4\OpenSage.Mods.Cnc4.csproj" />

--- a/src/OpenSage.sln
+++ b/src/OpenSage.sln
@@ -25,7 +25,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenSage.Mods.Cnc4", "OpenS
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenSage.Mods.Bfme", "OpenSage.Mods.Bfme\OpenSage.Mods.Bfme.csproj", "{0521E24E-859B-4F7A-BE23-9CBC53A14595}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenSage.Mods.BfmeII", "OpenSage.Mods.BfmeII\OpenSage.Mods.BfmeII.csproj", "{771E6271-64F9-4BB4-9E38-DF4DA0029898}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenSage.Mods.Bfme2", "OpenSage.Mods.Bfme2\OpenSage.Mods.Bfme2.csproj", "{771E6271-64F9-4BB4-9E38-DF4DA0029898}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Mods", "Mods", "{9410748F-ABB1-45AF-98E3-98858A8C0010}"
 EndProject


### PR DESCRIPTION
Huge diff, but very few manual changes.

* Rename `SageGame` entries for BFME and BFME2
* Rename BFME II assembly (and definition, and project) to BFME2
* Add the BFME2 expansion pack:
  * Add `Bfme2Rotwk` to `SageGame`
    * Add this entry to e.g switch statements where `Bfme2` was used already
  * Add `Bfme2RotwkDefinition` to `OpenSage.Mods.Bfme2`, including the registry key.
  * Run some APT-related tests for the expansion pack
  * Add the new `ShellMapOn` property to `GameData` and parse it.