### PR TITLE
[launcher] Fix soft_oal.dll not being copied to the output directory

### DIFF
--- a/src/OpenSage.Launcher/OpenSage.Launcher.csproj
+++ b/src/OpenSage.Launcher/OpenSage.Launcher.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net462</TargetFramework>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>latest</LangVersion>
     <ApplicationIcon>Resources\AppIcon.ico</ApplicationIcon>
   </PropertyGroup>

--- a/src/OpenSage.Launcher/OpenSage.Launcher.csproj
+++ b/src/OpenSage.Launcher/OpenSage.Launcher.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net462</TargetFramework>
+    <PlatformTarget>x64</PlatformTarget>
     <LangVersion>latest</LangVersion>
     <ApplicationIcon>Resources\AppIcon.ico</ApplicationIcon>
   </PropertyGroup>
@@ -10,6 +11,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\AppIcon.ico" />
     <Content Include="$(NuGetPackageRoot)\veldrid.sdl2\4.1.0-g9dfc41af8e\runtimes\win-x64\native\SDL2.dll" Link="SDL2.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="$(NuGetPackageRoot)openal-cs\1.0.0\runtimes\win-x64\native\soft_oal.dll" Link="soft_oal.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
…and explicitly set PlatformTarget to x64 to avoid BadImageFormatException (as x86 is the implicit default for SDK-based netfx projects)