### PR TITLE
Add team class, improve map loading

### DIFF
--- a/src/OpenSage.DataViewer/UI/Viewers/Ini/ObjectDefinitionView.cs
+++ b/src/OpenSage.DataViewer/UI/Viewers/Ini/ObjectDefinitionView.cs
@@ -5,6 +5,7 @@ using Eto.Forms;
 using OpenSage.Data.Ini;
 using OpenSage.DataViewer.Controls;
 using OpenSage.Graphics.Cameras.Controllers;
+using OpenSage.Logic;
 using OpenSage.Logic.Object;
 using OpenSage.Settings;
 
@@ -48,7 +49,9 @@ namespace OpenSage.DataViewer.UI.Viewers.Ini
                         gameObjects,
                         new WaypointCollection(),
                         new WaypointPathCollection(),
-                        WorldLighting.CreateDefault());
+                        WorldLighting.CreateDefault(),
+                        Array.Empty<Player>(),
+                        Array.Empty<Team>());
 
                     return game;
                 }

--- a/src/OpenSage.DataViewer/UI/Viewers/Ini/ParticleSystemView.cs
+++ b/src/OpenSage.DataViewer/UI/Viewers/Ini/ParticleSystemView.cs
@@ -4,6 +4,7 @@ using OpenSage.Data.Ini;
 using OpenSage.DataViewer.Controls;
 using OpenSage.Graphics.Cameras.Controllers;
 using OpenSage.Graphics.ParticleSystems;
+using OpenSage.Logic;
 using OpenSage.Logic.Object;
 using OpenSage.Settings;
 
@@ -44,7 +45,9 @@ namespace OpenSage.DataViewer.UI.Viewers.Ini
                     new GameObjectCollection(game.ContentManager),
                     new WaypointCollection(),
                     new WaypointPathCollection(),
-                    WorldLighting.CreateDefault());
+                    WorldLighting.CreateDefault(),
+                    Array.Empty<Player>(),
+                    Array.Empty<Team>());
 
                 return game;
             };

--- a/src/OpenSage.DataViewer/UI/Viewers/W3dView.cs
+++ b/src/OpenSage.DataViewer/UI/Viewers/W3dView.cs
@@ -9,6 +9,7 @@ using OpenSage.DataViewer.Controls;
 using OpenSage.Graphics;
 using OpenSage.Graphics.Animation;
 using OpenSage.Graphics.Cameras.Controllers;
+using OpenSage.Logic;
 using OpenSage.Logic.Object;
 using OpenSage.Mathematics;
 using OpenSage.Settings;
@@ -68,7 +69,9 @@ namespace OpenSage.DataViewer.UI.Viewers
                         new GameObjectCollection(game.ContentManager),
                         new WaypointCollection(),
                         new WaypointPathCollection(),
-                        WorldLighting.CreateDefault());
+                        WorldLighting.CreateDefault(),
+                        Array.Empty<Player>(),
+                        Array.Empty<Team>());
 
                     var animations = new List<AnimationInstance>(modelInstance.AnimationInstances);
 

--- a/src/OpenSage.Game/Content/MapLoader.cs
+++ b/src/OpenSage.Game/Content/MapLoader.cs
@@ -105,20 +105,21 @@ namespace OpenSage.Content
                 macroTexture,
                 contentManager.SolidWhiteTexture);
 
-            LoadObjects(
-                contentManager,
-                heightMap,
-                mapFile.ObjectsList.Objects,
-                out var waypoints,
-                out var gameObjects);
-
             // TODO: Store this somewhere.
-            var players = Player.FromMapData(mapFile.SidesList.Players, contentManager).ToList();
+            var players = Player.FromMapData(mapFile.SidesList.Players, contentManager).ToArray();
 
             // TODO: Store this somewhere.
             var teams = (mapFile.SidesList.Teams ?? mapFile.Teams.Items)
                 .Select(team => Team.FromMapData(team, players))
-                .ToList();
+                .ToArray();
+
+            LoadObjects(
+                contentManager,
+                heightMap,
+                mapFile.ObjectsList.Objects,
+                teams,
+                out var waypoints,
+                out var gameObjects);
 
             var lighting = new WorldLighting(
                 mapFile.GlobalLighting.LightingConfigurations.ToLightSettingsDictionary(),
@@ -222,10 +223,8 @@ namespace OpenSage.Content
 
             string[] pathLabels = null;
 
-            var label1 = mapObject.Properties["waypointPathLabel1"];
-
             // It seems that if one of the label properties exists, all of them do
-            if (label1 != null)
+            if (mapObject.Properties.TryGetValue("waypointPathLabel1", out var label1))
             {
                 pathLabels = new[]
                 {
@@ -238,10 +237,42 @@ namespace OpenSage.Content
             return new Waypoint(waypointID, waypointName, mapObject.Position, pathLabels);
         }
 
+        private static GameObject CreateGameObject(MapObject mapObject, Team[] teams, ContentManager contentManager)
+        {
+            var gameObject = contentManager.InstantiateObject(mapObject.TypeName);
+
+            // TODO: Is there any valid case where we'd want to return null instead of throwing an exception?
+            if (gameObject == null)
+            {
+                return null;
+            }
+
+            // TODO: If the object doesn't have a health value, how do we initialise it?
+            if (gameObject.Definition.Body is ActiveBodyModuleData body)
+            {
+                var healthMultiplier = mapObject.Properties.TryGetValue("objectInitialHealth", out var health)
+                    ? (uint) health.Value / 100.0f
+                    : 1.0f;
+
+                // TODO: Should we use InitialHealth or MaximumHealth here?
+                var initialHealth = body.InitialHealth * healthMultiplier;
+                gameObject.Health = (decimal) initialHealth;
+            }
+
+            if (mapObject.Properties.TryGetValue("originalOwner", out var teamName))
+            {
+                var team = teams.First(t => t.Name == (string) teamName.Value);
+                gameObject.Owner = team;
+            }
+
+            return gameObject;
+        }
+
         private static void LoadObjects(
             ContentManager contentManager,
             HeightMap heightMap,
             MapObject[] mapObjects,
+            Team[] teams,
             out WaypointCollection waypointCollection,
             out GameObjectCollection gameObjects)
         {
@@ -265,16 +296,16 @@ namespace OpenSage.Content
                                 // TODO: Handle locomotors when they're implemented.
                                 position.Z += heightMap.GetHeight(position.X, position.Y);
 
-                                var gameObject = gameObjects.Add(mapObject.TypeName);
+                                var gameObject = CreateGameObject(mapObject, teams, contentManager);
+
                                 if (gameObject != null)
                                 {
                                     gameObject.Transform.Translation = position;
                                     gameObject.Transform.Rotation = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, mapObject.Angle);
+
+                                    gameObjects.Add(gameObject);
                                 }
-                                else
-                                {
-                                    // TODO
-                                }
+
                                 break;
                         }
                         break;

--- a/src/OpenSage.Game/Content/MapLoader.cs
+++ b/src/OpenSage.Game/Content/MapLoader.cs
@@ -157,7 +157,9 @@ namespace OpenSage.Content
                 gameObjects,
                 waypoints,
                 waypointPaths,
-                lighting);
+                lighting,
+                players,
+                teams);
         }
 
         private MapScriptCollection CreateScripts(ScriptList scriptList)

--- a/src/OpenSage.Game/Content/MapLoader.cs
+++ b/src/OpenSage.Game/Content/MapLoader.cs
@@ -113,25 +113,12 @@ namespace OpenSage.Content
                 out var gameObjects);
 
             // TODO: Store this somewhere.
-            var teams = new List<Team>();
-
-            foreach (var team in mapFile.SidesList.Teams ?? mapFile.Teams.Items)
-            {
-                var name = (string) team.Properties["teamName"].Value;
-                var owner = (string) team.Properties["teamOwner"].Value;
-                var isSingleton = (bool) team.Properties["teamIsSingleton"].Value;
-
-                teams.Add(new Team(name, owner, isSingleton));
-            }
+            var players = Player.FromMapData(mapFile.SidesList.Players, contentManager).ToList();
 
             // TODO: Store this somewhere.
-            var players = new List<Player>();
-
-            foreach (var player in mapFile.SidesList.Players)
-            {
-                // TODO: Parse properties
-                players.Add(new Player() { });
-            }
+            var teams = (mapFile.SidesList.Teams ?? mapFile.Teams.Items)
+                .Select(team => Team.FromMapData(team, players))
+                .ToList();
 
             var lighting = new WorldLighting(
                 mapFile.GlobalLighting.LightingConfigurations.ToLightSettingsDictionary(),

--- a/src/OpenSage.Game/Content/MapLoader.cs
+++ b/src/OpenSage.Game/Content/MapLoader.cs
@@ -105,10 +105,8 @@ namespace OpenSage.Content
                 macroTexture,
                 contentManager.SolidWhiteTexture);
 
-            // TODO: Store this somewhere.
             var players = Player.FromMapData(mapFile.SidesList.Players, contentManager).ToArray();
 
-            // TODO: Store this somewhere.
             var teams = (mapFile.SidesList.Teams ?? mapFile.Teams.Items)
                 .Select(team => Team.FromMapData(team, players))
                 .ToArray();

--- a/src/OpenSage.Game/Content/MapLoader.cs
+++ b/src/OpenSage.Game/Content/MapLoader.cs
@@ -19,7 +19,9 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing;
 using Veldrid;
 using Veldrid.ImageSharp;
+using Player = OpenSage.Logic.Player;
 using Rectangle = OpenSage.Mathematics.Rectangle;
+using Team = OpenSage.Logic.Team;
 
 namespace OpenSage.Content
 {
@@ -110,13 +112,25 @@ namespace OpenSage.Content
                 out var waypoints,
                 out var gameObjects);
 
+            // TODO: Store this somewhere.
+            var teams = new List<Team>();
+
             foreach (var team in mapFile.SidesList.Teams ?? mapFile.Teams.Items)
             {
                 var name = (string) team.Properties["teamName"].Value;
                 var owner = (string) team.Properties["teamOwner"].Value;
                 var isSingleton = (bool) team.Properties["teamIsSingleton"].Value;
 
-                // TODO
+                teams.Add(new Team(name, owner, isSingleton));
+            }
+
+            // TODO: Store this somewhere.
+            var players = new List<Player>();
+
+            foreach (var player in mapFile.SidesList.Players)
+            {
+                // TODO: Parse properties
+                players.Add(new Player() { });
             }
 
             var lighting = new WorldLighting(

--- a/src/OpenSage.Game/Content/Util/ConversionExtensions.cs
+++ b/src/OpenSage.Game/Content/Util/ConversionExtensions.cs
@@ -354,5 +354,10 @@ namespace OpenSage.Content.Util
                 value.B / 255.0f,
                 value.A / 255.0f);
         }
+
+        public static ColorRgb ToColorRgb(this IniColorRgb value)
+        {
+            return new ColorRgb(value.R, value.G, value.B);
+        }
     }
 }

--- a/src/OpenSage.Game/Data/Map/AssetPropertyCollection.cs
+++ b/src/OpenSage.Game/Data/Map/AssetPropertyCollection.cs
@@ -1,11 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
-using System.Linq;
 
 namespace OpenSage.Data.Map
 {
-    public sealed class AssetPropertyCollection : Collection<AssetProperty>
+    public sealed class AssetPropertyCollection : KeyedCollection<string, AssetProperty>
     {
         internal static AssetPropertyCollection Parse(BinaryReader reader, MapParseContext context)
         {
@@ -20,12 +19,28 @@ namespace OpenSage.Data.Map
             return new AssetPropertyCollection(result);
         }
 
-        public AssetProperty this[string name] => this.FirstOrDefault(x => x.Key.Name == name);
-
         internal AssetPropertyCollection(IList<AssetProperty> list)
-            : base(list)
         {
+            foreach (var property in list)
+            {
+                Add(property);
+            }
+        }
 
+        protected override string GetKeyForItem(AssetProperty item)
+        {
+            return item.Key.Name;
+        }
+
+        // TODO: Remove this if we retarget the library to .NET Core 2.0
+        public bool TryGetValue(string key, out AssetProperty value)
+        {
+            return Dictionary.TryGetValue(key, out value);
+        }
+
+        public AssetProperty GetPropOrNull(string key)
+        {
+            return TryGetValue(key, out var value) ? value : null;
         }
 
         internal void WriteTo(BinaryWriter writer, AssetNameCollection assetNames)

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -323,6 +323,12 @@ namespace OpenSage
         {
             // TODO: Loading screen.
             Scene3D = ContentManager.Load<Scene3D>(mapFileName);
+
+            if (Scene3D == null)
+            {
+                throw new Exception($"Failed to load Scene3D \"{mapFileName}\"");
+            }
+
             NetworkMessageBuffer = new NetworkMessageBuffer(this, connection);
 
             // TODO: This is not the right place for this.

--- a/src/OpenSage.Game/Graphics/Util/ConversionExtensions.cs
+++ b/src/OpenSage.Game/Graphics/Util/ConversionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System.Numerics;
 using OpenSage.Data.Ini;
-using OpenSage.Mathematics;
 
 namespace OpenSage.Graphics.Util
 {

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -22,6 +22,11 @@ namespace OpenSage.Logic.Object
 
         public Collider Collider { get; }
 
+        // TODO: This could use a smaller fixed point type.
+        public decimal Health { get; set; }
+
+        public Team Owner { get; set; }
+
         public GameObject(ObjectDefinition objectDefinition, ContentManager contentManager)
         {
             Definition = objectDefinition;

--- a/src/OpenSage.Game/Logic/Object/GameObjectCollection.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObjectCollection.cs
@@ -34,5 +34,12 @@ namespace OpenSage.Logic.Object
 
             return gameObject;
         }
+
+        public GameObject Add(GameObject gameObject)
+        {
+            AddDisposable(gameObject);
+            _items.Add(gameObject);
+            return gameObject;
+        }
     }
 }

--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -7,20 +7,12 @@ using OpenSage.Utilities.Extensions;
 
 namespace OpenSage.Logic
 {
-    // TODO: Abstract this out, or try to include all factions from every game?
-    public enum Side
-    {
-        Civilian,
-        Observer,
-        America,
-        China,
-        GLA
-    }
-
     public class Player
     {
         public string Name { get; private set; }
-        public Side Side { get; private set; }
+        public string DisplayName { get; private set; }
+
+        public string Side { get; private set; }
 
         public uint Money { get; set; }
 
@@ -54,16 +46,25 @@ namespace OpenSage.Logic
             // TODO: Use rest of the properties from the template
             return new Player
             {
-                Side = ParseSide(template.Side),
-                Name = content.TranslationManager.Lookup(template.DisplayName),
+                Side = template.Side,
+                Name = template.Name,
+                DisplayName = content.TranslationManager.Lookup(template.DisplayName),
                 Money = (uint) template.StartMoney
             };
         }
+    }
 
-        private static Side ParseSide(string side)
+    public class Team
+    {
+        public string Name { get; }
+        public string Owner { get; }
+        public bool IsSingleton { get; }
+
+        public Team(string name, string owner, bool isSingleton)
         {
-            // TODO: Validate.
-            return (Side) Enum.Parse(typeof(Side), side);
+            Name = name;
+            Owner = owner;
+            IsSingleton = isSingleton;
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -1,8 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Linq;
 using OpenSage.Content;
+using OpenSage.Content.Util;
 using OpenSage.Data.Ini;
 using OpenSage.Logic.Object;
+using OpenSage.Mathematics;
 using OpenSage.Utilities.Extensions;
 
 namespace OpenSage.Logic
@@ -14,19 +16,30 @@ namespace OpenSage.Logic
 
         public string Side { get; private set; }
 
+        public bool IsHuman { get; private set; }
+
         public uint Money { get; set; }
 
         // TODO: Should this be derived from the player's buildings so that it doesn't get out of sync?
         public uint Energy { get; set; }
 
-        public IReadOnlyCollection<GameObject> SelectedUnits => _selectedUnits;
+        public ColorRgb Color { get; private set; }
+
+        private HashSet<Player> _allies;
+        public IReadOnlyCollection<Player> Allies => _allies;
+
+        private HashSet<Player> _enemies;
+        public IReadOnlyCollection<Player> Enemies => _enemies;
 
         // TODO: Does the order matter? Is it ever visible in UI?
         private HashSet<GameObject> _selectedUnits;
+        public IReadOnlyCollection<GameObject> SelectedUnits => _selectedUnits;
 
         public Player()
         {
             _selectedUnits = new HashSet<GameObject>();
+            _allies = new HashSet<Player>();
+            _enemies = new HashSet<Player>();
         }
 
         public void SelectUnits(IEnumerable<GameObject> units, bool additive = false)
@@ -39,6 +52,71 @@ namespace OpenSage.Logic
             {
                 _selectedUnits = units.ToSet();
             }
+        }
+
+        private static Player FromMapData(Data.Map.Player mapPlayer, ContentManager content)
+        {
+            var side = mapPlayer.Properties["playerFaction"].Value as string;
+
+            // We need the template for default values
+            var template = content.IniDataContext.PlayerTemplates.Find(t => t.Side == side);
+
+            var name = mapPlayer.Properties["playerName"].Value as string;
+            var displayName = mapPlayer.Properties["playerDisplayName"].Value as string;
+            var translatedDisplayName = content.TranslationManager.Lookup(displayName);
+
+            var isHuman = (bool) mapPlayer.Properties["playerIsHuman"].Value;
+
+            var colorRgb = mapPlayer.Properties["playerColor"]?.Value as uint?;
+
+            ColorRgb color;
+
+            if (colorRgb != null)
+            {
+                color = ColorRgb.FromUInt32(colorRgb.Value);
+            }
+            else if (template != null) // Template is null for the neutral faction
+            {
+                color = template.PreferredColor.ToColorRgb();
+            }
+            else
+            {
+                color = new ColorRgb(0, 0, 0);
+            }
+
+            return new Player
+            {
+                Side = side,
+                Name = name,
+                DisplayName = translatedDisplayName,
+                Color = color,
+                IsHuman = isHuman
+            };
+        }
+
+        // This needs to operate on the entire player list, because players have references to each other
+        // (allies and enemies).
+        public static IEnumerable<Player> FromMapData(Data.Map.Player[] mapPlayers, ContentManager content)
+        {
+            var players = new Dictionary<string, Player>();
+            var allies = new Dictionary<string, string[]>();
+            var enemies = new Dictionary<string, string[]>();
+
+            foreach (var mapPlayer in mapPlayers)
+            {
+                var player = FromMapData(mapPlayer, content);
+                players[player.Name] = player;
+                allies[player.Name] = (mapPlayer.Properties["playerAllies"].Value as string)?.Split(' ');
+                enemies[player.Name] = (mapPlayer.Properties["playerEnemies"].Value as string)?.Split(' ');
+            }
+
+            foreach (var (name, player) in players)
+            {
+                player._allies = allies[name].Select(ally => players[ally]).ToSet();
+                player._enemies = enemies[name].Select(enemy => players[enemy]).ToSet();
+            }
+
+            return players.Values;
         }
 
         public static Player FromTemplate(PlayerTemplate template, ContentManager content)
@@ -57,14 +135,26 @@ namespace OpenSage.Logic
     public class Team
     {
         public string Name { get; }
-        public string Owner { get; }
+        public Player Owner { get; }
         public bool IsSingleton { get; }
 
-        public Team(string name, string owner, bool isSingleton)
+        public Team(string name, Player owner, bool isSingleton)
         {
             Name = name;
             Owner = owner;
             IsSingleton = isSingleton;
+        }
+
+        public static Team FromMapData(Data.Map.Team mapTeam, IList<Player> players)
+        {
+            var name = mapTeam.Properties["teamName"].Value as string;
+
+            var ownerName = mapTeam.Properties["teamOwner"].Value as string;
+            var owner = players.FirstOrDefault(player => player.Name == ownerName);
+
+            var isSingleton = (bool) mapTeam.Properties["teamIsSingleton"].Value;
+
+            return new Team(name, owner, isSingleton);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -67,7 +67,7 @@ namespace OpenSage.Logic
 
             var isHuman = (bool) mapPlayer.Properties["playerIsHuman"].Value;
 
-            var colorRgb = mapPlayer.Properties["playerColor"]?.Value as uint?;
+            var colorRgb = mapPlayer.Properties.GetPropOrNull("playerColor")?.Value as uint?;
 
             ColorRgb color;
 
@@ -106,8 +106,10 @@ namespace OpenSage.Logic
             {
                 var player = FromMapData(mapPlayer, content);
                 players[player.Name] = player;
-                allies[player.Name] = (mapPlayer.Properties["playerAllies"].Value as string)?.Split(' ');
-                enemies[player.Name] = (mapPlayer.Properties["playerEnemies"].Value as string)?.Split(' ');
+                allies[player.Name] =
+                    (mapPlayer.Properties.GetPropOrNull("playerAllies")?.Value as string)?.Split(' ');
+                enemies[player.Name] =
+                    (mapPlayer.Properties.GetPropOrNull("playerEnemies")?.Value as string)?.Split(' ');
             }
 
             foreach (var (name, player) in players)

--- a/src/OpenSage.Game/Mathematics/ColorRgb.cs
+++ b/src/OpenSage.Game/Mathematics/ColorRgb.cs
@@ -1,4 +1,6 @@
-﻿namespace OpenSage.Mathematics
+﻿using System;
+
+namespace OpenSage.Mathematics
 {
     public struct ColorRgb
     {
@@ -11,6 +13,15 @@
             R = r;
             G = g;
             B = b;
+        }
+
+        public static ColorRgb FromUInt32(uint rgb)
+        {
+            var r = (byte) (rgb >> 16 & 0xFF);
+            var g = (byte) (rgb >> 8 & 0xFF);
+            var b = (byte) (rgb & 0xFF);
+
+            return new ColorRgb(r, g, b);
         }
     }
 }

--- a/src/OpenSage.Game/Mathematics/ColorRgb.cs
+++ b/src/OpenSage.Game/Mathematics/ColorRgb.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace OpenSage.Mathematics
+﻿namespace OpenSage.Mathematics
 {
     public struct ColorRgb
     {

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -10,6 +10,7 @@ using OpenSage.Scripting;
 using OpenSage.Settings;
 
 using Player = OpenSage.Logic.Player;
+using Team = OpenSage.Logic.Team;
 
 namespace OpenSage
 {
@@ -36,6 +37,9 @@ namespace OpenSage
         public WaypointPathCollection WaypointPaths { get; set; }
 
         public WorldLighting Lighting { get; }
+
+        public IReadOnlyList<Team> Teams => _teams;
+        private List<Team> _teams;
 
         // TODO: Move these to a World class?
         // TODO: Encapsulate this into a custom collection?
@@ -82,6 +86,7 @@ namespace OpenSage
 
             _particleSystemManager = AddDisposable(new ParticleSystemManager(game, this));
 
+            _teams = new List<Team>();
             _players = new List<Player>();
         }
 

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -67,7 +67,9 @@ namespace OpenSage
             GameObjectCollection gameObjects,
             WaypointCollection waypoints,
             WaypointPathCollection waypointPaths,
-            WorldLighting lighting)
+            WorldLighting lighting,
+            Player[] players,
+            Team[] teams)
         {
             Camera = new CameraComponent(game);
             CameraController = cameraController;
@@ -86,8 +88,10 @@ namespace OpenSage
 
             _particleSystemManager = AddDisposable(new ParticleSystemManager(game, this));
 
-            _teams = new List<Team>();
-            _players = new List<Player>();
+            _players = players.ToList();
+            _teams = teams.ToList();
+            // TODO: This is completely wrong.
+            LocalPlayer = _players[0];
         }
 
         public void SetPlayers(IEnumerable<Player> players, Player localPlayer)
@@ -102,6 +106,10 @@ namespace OpenSage
             }
 
             LocalPlayer = localPlayer;
+
+            // TODO: What to do with teams?
+            // Teams refer to old Players and therefore they will not be collected by GC
+            // (+ objects will have invalid owners)
         }
 
         internal void Update(GameTime gameTime)


### PR DESCRIPTION
Do not merge yet.

* Adds `Team` and parses them from the map file. A team is a group of objects owned by a player.
* Parses `Player`s from the map file.
* Expands `Player` with new properties, including allies and enemies.
* Adds `Owner` and `Health` to `GameObject`. These are now parsed from the `MapObject`.
* Adds an overload to `GameObjectCollection.Add` which takes a `GameObject`.