### PR TITLE
Mount user data

### DIFF
--- a/src/OpenSage.Game/Content/ContentManager.cs
+++ b/src/OpenSage.Game/Content/ContentManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenSage.Data;
 using OpenSage.Data.Ini;
+using OpenSage.Data.Rep;
 using OpenSage.Data.Wav;
 using OpenSage.Graphics;
 using OpenSage.Graphics.Effects;
@@ -89,6 +90,7 @@ namespace OpenSage.Content
                 { typeof(Window), AddDisposable(new WindowLoader(this, wndCallbackResolver)) },
                 { typeof(AptWindow), AddDisposable(new AptLoader()) },
                 { typeof(WavFile), AddDisposable(new WavLoader()) },
+                { typeof(ReplayFile), AddDisposable(new ReplayLoader()) }
             };
 
             _cachedObjects = new Dictionary<string, object>();

--- a/src/OpenSage.Game/Content/ContentManager.cs
+++ b/src/OpenSage.Game/Content/ContentManager.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenSage.Audio;
 using OpenSage.Data;
 using OpenSage.Data.Ini;
 using OpenSage.Data.Wav;
@@ -28,7 +27,7 @@ namespace OpenSage.Content
 
         private readonly Dictionary<string, object> _cachedObjects;
 
-        private readonly FileSystem _fileSystem;
+        private FileSystem _fileSystem;
 
         private readonly Dictionary<FontKey, Font> _cachedFonts;
 
@@ -47,7 +46,15 @@ namespace OpenSage.Content
 
         public Texture SolidWhiteTexture { get; }
 
-        public FileSystem FileSystem => _fileSystem;
+        public FileSystem FileSystem
+        {
+            get => _fileSystem;
+            set
+            {
+                _fileSystem = value;
+                IniDataContext.FileSystem = _fileSystem;
+            }
+        }
 
         public IniDataContext IniDataContext { get; }
 
@@ -88,6 +95,9 @@ namespace OpenSage.Content
 
             EffectLibrary = AddDisposable(new EffectLibrary(graphicsDevice));
 
+            // NOTE: If one day TranslationManager starts storing the file system
+            // instead of reading everything in the constructor, we'd need to be
+            // able to update the reference.
             TranslationManager = new TranslationManager(fileSystem, sageGame);
 
             _cachedFonts = new Dictionary<FontKey, Font>();

--- a/src/OpenSage.Game/Content/ReplayLoader.cs
+++ b/src/OpenSage.Game/Content/ReplayLoader.cs
@@ -1,0 +1,13 @@
+﻿using OpenSage.Data;
+using OpenSage.Data.Rep;
+
+namespace OpenSage.Content
+{
+    internal sealed class ReplayLoader : ContentLoader<ReplayFile>
+    {
+        protected override ReplayFile LoadEntry(FileSystemEntry entry, ContentManager contentManager, Game game, LoadOptions loadOptions)
+        {
+            return ReplayFile.FromFileSystemEntry(entry);
+        }
+    }
+}

--- a/src/OpenSage.Game/Data/Ini/IniDataContext.cs
+++ b/src/OpenSage.Game/Data/Ini/IniDataContext.cs
@@ -8,7 +8,14 @@ namespace OpenSage.Data.Ini
 {
     public sealed class IniDataContext
     {
-        private readonly FileSystem _fileSystem;
+        private FileSystem _fileSystem;
+
+        // Note that this is set-only.
+        // We want ContentManager to be able to update this, but there's no valid reason to read this from outside.
+        internal FileSystem FileSystem
+        {
+            set => _fileSystem = value;
+        }
 
         // TODO: Remove this once we can load all INI files upfront.
         private readonly List<string> _alreadyLoaded = new List<string>();

--- a/src/OpenSage.Game/IGameDefinition.cs
+++ b/src/OpenSage.Game/IGameDefinition.cs
@@ -18,5 +18,8 @@ namespace OpenSage
         IControlBarSource ControlBar { get; }
 
         string Identifier { get; }
+
+        // This is used as the fallback if UserDataLeafName is not present in GameData.ini.
+        string UserDataLeafNameFallback { get; }
     }
 }

--- a/src/OpenSage.Mods.Bfme/BfmeDefinition.cs
+++ b/src/OpenSage.Mods.Bfme/BfmeDefinition.cs
@@ -20,6 +20,8 @@ namespace OpenSage.Mods.BFME
 
         public string Identifier { get; } = "bfme";
 
+        public string UserDataLeafNameFallback { get; }
+
         public IMainMenuSource MainMenu { get; }
         public IControlBarSource ControlBar { get; }
 

--- a/src/OpenSage.Mods.Bfme2/Bfme2Definition.cs
+++ b/src/OpenSage.Mods.Bfme2/Bfme2Definition.cs
@@ -21,6 +21,8 @@ namespace OpenSage.Mods.Bfme2
 
         public string Identifier { get; } = "bfme2";
 
+        public string UserDataLeafNameFallback { get; }
+
         public IMainMenuSource MainMenu { get; } = new AptMainMenuSource("MainMenu.apt");
         public IControlBarSource ControlBar { get; }
 

--- a/src/OpenSage.Mods.Bfme2/Bfme2RotwkDefinition.cs
+++ b/src/OpenSage.Mods.Bfme2/Bfme2RotwkDefinition.cs
@@ -21,6 +21,8 @@ namespace OpenSage.Mods.Bfme2
 
         public string Identifier { get; } = "bfme2_rotwk";
 
+        public string UserDataLeafNameFallback { get; }
+
         public IMainMenuSource MainMenu { get; } = new AptMainMenuSource("MainMenu.apt");
         public IControlBarSource ControlBar { get; }
 

--- a/src/OpenSage.Mods.Cnc3/Cnc3Definition.cs
+++ b/src/OpenSage.Mods.Cnc3/Cnc3Definition.cs
@@ -19,6 +19,8 @@ namespace OpenSage.Mods.CnC3
 
         public string Identifier { get; } = "cnc3";
 
+        public string UserDataLeafNameFallback { get; }
+
         public IMainMenuSource MainMenu { get; }
         public IControlBarSource ControlBar { get; }
 

--- a/src/OpenSage.Mods.Cnc3/Cnc3KanesWrathDefinition.cs
+++ b/src/OpenSage.Mods.Cnc3/Cnc3KanesWrathDefinition.cs
@@ -19,6 +19,8 @@ namespace OpenSage.Mods.CnC3
 
         public string Identifier { get; } = "cnc3_kw";
 
+        public string UserDataLeafNameFallback { get; }
+
         public IMainMenuSource MainMenu { get; }
         public IControlBarSource ControlBar { get; }
 

--- a/src/OpenSage.Mods.Cnc4/Cnc4Definition.cs
+++ b/src/OpenSage.Mods.Cnc4/Cnc4Definition.cs
@@ -20,6 +20,8 @@ namespace OpenSage.Mods.Cnc4
 
         public string Identifier { get; } = "cnc4";
 
+        public string UserDataLeafNameFallback { get; }
+
         public IMainMenuSource MainMenu { get; }
         public IControlBarSource ControlBar { get; }
 

--- a/src/OpenSage.Mods.Generals/GeneralsDefinition.cs
+++ b/src/OpenSage.Mods.Generals/GeneralsDefinition.cs
@@ -21,6 +21,8 @@ namespace OpenSage.Mods.Generals
 
         public string Identifier { get; } = "cnc_generals";
 
+        public string UserDataLeafNameFallback { get; } = "Command and Conquer Generals Data";
+
         public IMainMenuSource MainMenu { get; } = new WndMainMenuSource(@"Menus\MainMenu.wnd");
         public IControlBarSource ControlBar { get; } = new GeneralsControlBarSource();
 

--- a/src/OpenSage.Mods.Generals/GeneralsZeroHourDefinition.cs
+++ b/src/OpenSage.Mods.Generals/GeneralsZeroHourDefinition.cs
@@ -23,6 +23,8 @@ namespace OpenSage.Mods.Generals
 
         public string Identifier { get; } = "cnc_generals_zh";
 
+        public string UserDataLeafNameFallback { get; } = "Command and Conquer Generals Zero Hour Data";
+
         public IMainMenuSource MainMenu { get; } = new WndMainMenuSource(@"Menus\MainMenu.wnd");
         public IControlBarSource ControlBar { get; } = new GeneralsControlBarSource();
 

--- a/src/OpenSage.Mods.Ra3/Ra3Definition.cs
+++ b/src/OpenSage.Mods.Ra3/Ra3Definition.cs
@@ -19,6 +19,8 @@ namespace OpenSage.Mods.Ra3
 
         public string Identifier { get; } = "ra3";
 
+        public string UserDataLeafNameFallback { get; }
+
         public IMainMenuSource MainMenu { get; }
         public IControlBarSource ControlBar { get; }
 

--- a/src/OpenSage.Mods.Ra3/Ra3UprisingDefinition.cs
+++ b/src/OpenSage.Mods.Ra3/Ra3UprisingDefinition.cs
@@ -19,6 +19,8 @@ namespace OpenSage.Mods.Ra3
 
         public string Identifier { get; } = "ra3_uprising";
 
+        public string UserDataLeafNameFallback { get; }
+
         public IMainMenuSource MainMenu { get; }
         public IControlBarSource ControlBar { get; }
 


### PR DESCRIPTION
This PR makes OpenSAGE mount the user data folder (under Documents). This requires a short bootstrapping procedure, which mounts the installation folder, reads `UserDataLeafName` from `GameData.ini` and wraps the base file system into a new file system, which is then updated to `ContentManager`. All of this happens in the `Game` constructor.

If `UserDataLeafName` is not present, OpenSAGE will use the new property`UserDataLeafNameFallback` from the `IGameDefinition`. This PR defines the default directory names for Generals & ZH, but not yet for other games. This should fail gracefully - if the fallback hasn't been defined, the engine will not mount anything other than the base installation folder.

If the folder does not exist, it's not created. Usually this is not a problem, but if we want to e.g load replays on macOS and Linux, the user has to create the directory structure themselves (wherever `Environment.SpecialFolder.MyDocuments` points on those systems).

Since the user folder is now mounted like all the other content, replay loading is now simpler and no longer involves creating new file systems in click handlers. 😄 

(This also unintentionally enables a form of mod support - files added to the user folder will override files in the installation folder and `.big` files.)
