### PR TITLE
Input handler priority

### DIFF
--- a/src/OpenSage.Game/Graphics/Cameras/CameraInputMessageHandler.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/CameraInputMessageHandler.cs
@@ -17,7 +17,10 @@ namespace OpenSage.Graphics.Cameras
 
         private int _scrollWheelValue;
 
-        public override HandlingPriority Priority => HandlingPriority.CameraPriority;
+        public override HandlingPriority Priority =>
+            _rightMouseDown || _middleMouseDown || (_leftMouseDown && _pressedKeys.Contains(Key.AltLeft))
+                ? HandlingPriority.MoveCameraPriority
+                : HandlingPriority.CameraPriority;
 
         public override InputMessageResult HandleMessage(InputMessage message)
         {

--- a/src/OpenSage.Game/Graphics/Cameras/CameraInputMessageHandler.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/CameraInputMessageHandler.cs
@@ -17,6 +17,8 @@ namespace OpenSage.Graphics.Cameras
 
         private int _scrollWheelValue;
 
+        public override HandlingPriority Priority => HandlingPriority.CameraPriority;
+
         public override InputMessageResult HandleMessage(InputMessage message)
         {
             switch (message.MessageType)

--- a/src/OpenSage.Game/Graphics/Cameras/CameraInputMessageHandler.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/CameraInputMessageHandler.cs
@@ -18,7 +18,7 @@ namespace OpenSage.Graphics.Cameras
         private int _scrollWheelValue;
 
         public override HandlingPriority Priority =>
-            _rightMouseDown || _middleMouseDown || (_leftMouseDown && _pressedKeys.Contains(Key.AltLeft))
+            _rightMouseDown || _middleMouseDown || _pressedKeys.Contains(Key.AltLeft)
                 ? HandlingPriority.MoveCameraPriority
                 : HandlingPriority.CameraPriority;
 

--- a/src/OpenSage.Game/Gui/Wnd/WndInputMessageHandler.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndInputMessageHandler.cs
@@ -13,6 +13,8 @@ namespace OpenSage.Gui.Wnd
 
         private readonly List<Control> _lastMouseOverControls = new List<Control>();
 
+        public override HandlingPriority Priority => HandlingPriority.UIPriority;
+
         public WndInputMessageHandler(WndWindowManager windowManager, Game game)
         {
             _windowManager = windowManager;

--- a/src/OpenSage.Game/Gui/Wnd/WndInputMessageHandler.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndInputMessageHandler.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using OpenSage.Gui.Wnd.Controls;
 using OpenSage.Input;
+using OpenSage.Mathematics;
 using Veldrid;
 
 namespace OpenSage.Gui.Wnd
@@ -23,6 +24,20 @@ namespace OpenSage.Gui.Wnd
 
         public override InputMessageResult HandleMessage(InputMessage message)
         {
+            bool GetControlAtPoint(in Point2D mousePosition, out Control control, out Point2D controlRelativePosition)
+            {
+                control = _windowManager.GetControlAtPoint(mousePosition);
+
+                if (control != null)
+                {
+                    controlRelativePosition = control.PointToClient(mousePosition);
+                    return true;
+                }
+
+                controlRelativePosition = Point2D.Zero;;
+                return false;
+            }
+
             var context = new ControlCallbackContext(_windowManager, _game);
 
             switch (message.MessageType)
@@ -69,10 +84,8 @@ namespace OpenSage.Gui.Wnd
 
                 case InputMessageType.MouseLeftButtonDown:
                     {
-                        var element = _windowManager.GetControlAtPoint(message.Value.MousePosition);
-                        if (element != null)
+                        if (GetControlAtPoint(message.Value.MousePosition, out var element, out var mousePosition))
                         {
-                            var mousePosition = element.PointToClient(message.Value.MousePosition);
                             element.InputCallback.Invoke(
                                 element,
                                 new WndWindowMessage(WndWindowMessageType.MouseDown, element, mousePosition),
@@ -84,10 +97,8 @@ namespace OpenSage.Gui.Wnd
 
                 case InputMessageType.MouseLeftButtonUp:
                     {
-                        var element = _windowManager.GetControlAtPoint(message.Value.MousePosition);
-                        if (element != null)
+                        if (GetControlAtPoint(message.Value.MousePosition, out var element, out var mousePosition))
                         {
-                            var mousePosition = element.PointToClient(message.Value.MousePosition);
                             element.InputCallback.Invoke(
                                 element,
                                 new WndWindowMessage(WndWindowMessageType.MouseUp, element, mousePosition),
@@ -96,6 +107,17 @@ namespace OpenSage.Gui.Wnd
                         }
                         break;
                     }
+
+                // For the time being, just consume right and middle click events so that they don't go through controls:
+                case InputMessageType.MouseRightButtonUp:
+                case InputMessageType.MouseRightButtonDown:
+                case InputMessageType.MouseMiddleButtonDown:
+                case InputMessageType.MouseMiddleButtonUp:
+                {
+                    return GetControlAtPoint(message.Value.MousePosition, out var _, out var _)
+                        ? InputMessageResult.Handled
+                        : InputMessageResult.NotHandled;
+                }
 
                 case InputMessageType.KeyDown:
                     {

--- a/src/OpenSage.Game/Gui/Wnd/WndWindowManager.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndWindowManager.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using OpenSage.Graphics;
 using OpenSage.Gui.Wnd.Controls;
 using OpenSage.Gui.Wnd.Transitions;
 using OpenSage.Mathematics;
@@ -23,7 +22,7 @@ namespace OpenSage.Gui.Wnd
             _game = game;
             _windowStack = new Stack<Window>();
 
-            game.InputMessageBuffer.Handlers.Insert(0, new WndInputMessageHandler(this, _game));
+            game.InputMessageBuffer.Handlers.Add(new WndInputMessageHandler(this, _game));
 
             switch (game.SageGame)
             {

--- a/src/OpenSage.Game/Input/HandlingPriority.cs
+++ b/src/OpenSage.Game/Input/HandlingPriority.cs
@@ -5,6 +5,7 @@
         CameraPriority,
         SelectionPriority,
         UIPriority,
+        MoveCameraPriority,
         BoxSelectionPriority
     }
 }

--- a/src/OpenSage.Game/Input/HandlingPriority.cs
+++ b/src/OpenSage.Game/Input/HandlingPriority.cs
@@ -5,7 +5,7 @@
         CameraPriority,
         SelectionPriority,
         UIPriority,
-        MoveCameraPriority,
-        BoxSelectionPriority
+        BoxSelectionPriority,
+        MoveCameraPriority
     }
 }

--- a/src/OpenSage.Game/Input/HandlingPriority.cs
+++ b/src/OpenSage.Game/Input/HandlingPriority.cs
@@ -1,0 +1,10 @@
+﻿namespace OpenSage.Input
+{
+    public enum HandlingPriority
+    {
+        CameraPriority,
+        SelectionPriority,
+        UIPriority,
+        BoxSelectionPriority
+    }
+}

--- a/src/OpenSage.Game/Input/InputMessageHandler.cs
+++ b/src/OpenSage.Game/Input/InputMessageHandler.cs
@@ -2,6 +2,8 @@
 {
     public abstract class InputMessageHandler
     {
+        public abstract HandlingPriority Priority { get; }
+
         public abstract InputMessageResult HandleMessage(InputMessage message);
     }
 }

--- a/src/OpenSage.Game/Logic/SelectionMessageHandler.cs
+++ b/src/OpenSage.Game/Logic/SelectionMessageHandler.cs
@@ -1,6 +1,5 @@
 ﻿using OpenSage.Input;
 using OpenSage.Mathematics;
-using Veldrid;
 
 namespace OpenSage.Logic
 {
@@ -9,7 +8,6 @@ namespace OpenSage.Logic
         private readonly SelectionSystem _system;
 
         private Point2D _mousePos;
-        private bool _altDown;
 
         public override HandlingPriority Priority => _system.Status == SelectionSystem.SelectionStatus.MultiSelecting
             ? HandlingPriority.BoxSelectionPriority
@@ -34,33 +32,12 @@ namespace OpenSage.Logic
 
                     break;
                 case InputMessageType.MouseLeftButtonDown:
-                    // HACK?: If the camera is being rotated using ALT+Mouse1, don't handle the event.
-                    // This check shouldn't really be here.
-                    if (_altDown)
-                    {
-                        break;
-                    }
-
                     _system.OnStartDragSelection(_mousePos);
                     return InputMessageResult.Handled;
                 case InputMessageType.MouseLeftButtonUp:
                     if (_system.Selecting)
                     {
                         _system.OnEndDragSelection();
-                    }
-
-                    break;
-                case InputMessageType.KeyDown:
-                    if (message.Value.Key == Key.LAlt)
-                    {
-                        _altDown = true;
-                    }
-
-                    break;
-                case InputMessageType.KeyUp:
-                    if (message.Value.Key == Key.LAlt)
-                    {
-                        _altDown = false;
                     }
 
                     break;

--- a/src/OpenSage.Game/Logic/SelectionMessageHandler.cs
+++ b/src/OpenSage.Game/Logic/SelectionMessageHandler.cs
@@ -11,6 +11,10 @@ namespace OpenSage.Logic
         private Point2D _mousePos;
         private bool _altDown;
 
+        public override HandlingPriority Priority => _system.Status == SelectionSystem.SelectionStatus.MultiSelecting
+            ? HandlingPriority.BoxSelectionPriority
+            : HandlingPriority.SelectionPriority;
+
         public SelectionMessageHandler(SelectionSystem system)
         {
             _system = system;

--- a/src/OpenSage.Game/Logic/SelectionMessageHandler.cs
+++ b/src/OpenSage.Game/Logic/SelectionMessageHandler.cs
@@ -4,14 +4,14 @@ using Veldrid;
 
 namespace OpenSage.Logic
 {
-    public class SelectionInputHandler : InputMessageHandler
+    public class SelectionMessageHandler : InputMessageHandler
     {
         private readonly SelectionSystem _system;
 
         private Point2D _mousePos;
         private bool _altDown;
 
-        public SelectionInputHandler(SelectionSystem system)
+        public SelectionMessageHandler(SelectionSystem system)
         {
             _system = system;
         }

--- a/src/OpenSage.Game/Logic/SelectionSystem.cs
+++ b/src/OpenSage.Game/Logic/SelectionSystem.cs
@@ -9,7 +9,7 @@ namespace OpenSage.Logic
 {
     public sealed class SelectionSystem : GameSystem
     {
-        private enum SelectionStatus
+        public enum SelectionStatus
         {
             NotSelecting,
             SingleSelecting,
@@ -26,8 +26,9 @@ namespace OpenSage.Logic
 
         private Point2D _startPoint;
         private Point2D _endPoint;
-        private SelectionStatus _status = SelectionStatus.NotSelecting;
-        public bool Selecting => _status != SelectionStatus.NotSelecting;
+
+        public SelectionStatus Status { get; private set; } = SelectionStatus.NotSelecting;
+        public bool Selecting => Status != SelectionStatus.NotSelecting;
 
         private Rectangle SelectionRect
         {
@@ -48,7 +49,7 @@ namespace OpenSage.Logic
 
         public void OnStartDragSelection(Point2D startPoint)
         {
-            _status = SelectionStatus.SingleSelecting;
+            Status = SelectionStatus.SingleSelecting;
             _startPoint = startPoint;
             _endPoint = startPoint;
             SelectionGui.SelectionRectangle = SelectionRect;
@@ -61,9 +62,9 @@ namespace OpenSage.Logic
             var rect = SelectionRect;
 
             // If either dimension is under 50 pixels, don't show the box selector.
-            if (_status != SelectionStatus.MultiSelecting && UseBoxSelection(rect))
+            if (Status != SelectionStatus.MultiSelecting && UseBoxSelection(rect))
             {
-                _status = SelectionStatus.MultiSelecting;
+                Status = SelectionStatus.MultiSelecting;
                 // Note that the box can be scaled down after this.
                 SelectionGui.SelectionBoxVisible = true;
             }
@@ -76,7 +77,7 @@ namespace OpenSage.Logic
             _selectedObjects.Clear();
             SelectionGui.SelectedObjects.Clear();
 
-            if (_status == SelectionStatus.SingleSelecting)
+            if (Status == SelectionStatus.SingleSelecting)
             {
                 SingleSelect();
             }
@@ -86,7 +87,7 @@ namespace OpenSage.Logic
             }
 
             SelectionGui.SelectionBoxVisible = false;
-            _status = SelectionStatus.NotSelecting;
+            Status = SelectionStatus.NotSelecting;
         }
 
         private void SingleSelect()

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -21,7 +21,7 @@ namespace OpenSage
         private readonly CameraInputMessageHandler _cameraInputMessageHandler;
         private CameraInputState _cameraInputState;
 
-        private readonly SelectionInputHandler _selectionInputHandler;
+        private readonly SelectionMessageHandler _selectionMessageHandler;
         public SelectionGui SelectionGui { get; }
 
         private readonly ParticleSystemManager _particleSystemManager;
@@ -88,9 +88,9 @@ namespace OpenSage
             Lighting = lighting;
 
             SelectionGui = new SelectionGui();
-            _selectionInputHandler = new SelectionInputHandler(game.Selection);
-            game.InputMessageBuffer.Handlers.Add(_selectionInputHandler);
-            AddDisposeAction(() => game.InputMessageBuffer.Handlers.Remove(_selectionInputHandler));
+            _selectionMessageHandler = new SelectionMessageHandler(game.Selection);
+            game.InputMessageBuffer.Handlers.Add(_selectionMessageHandler);
+            AddDisposeAction(() => game.InputMessageBuffer.Handlers.Remove(_selectionMessageHandler));
 
             _cameraInputMessageHandler = new CameraInputMessageHandler();
             game.InputMessageBuffer.Handlers.Add(_cameraInputMessageHandler);


### PR DESCRIPTION
* Go through `InputMessageHandler`s in the priority order instead of registration order. This uses the `HandlingPriority` enum and the abstract `Priority` property in `InputMessageHandler`. The algorithm is implemented as an iterator: for each message, the handlers are looped through starting with the highest possible priority. If there is a handler matching the priority level, yield it. Decrease the priority threshold by one, and go through the handlers again.
* Prioritise selection system over UI when a selection box is being dragged
* Prioritise camera system over UI when the camera is being moved or rotated.
* Consume right click and middle click events when the cursor is over a control.