### PR TITLE
Controlbar improvements

### DIFF
--- a/src/OpenSage.Game/Content/ContentManager.cs
+++ b/src/OpenSage.Game/Content/ContentManager.cs
@@ -53,7 +53,7 @@ namespace OpenSage.Content
 
         public TranslationManager TranslationManager { get; }
 
-        internal WndImageLoader WndImageLoader { get; }
+        public WndImageLoader WndImageLoader { get; }
 
         public ContentManager(
             Game game,

--- a/src/OpenSage.Game/Data/Ini/ControlBarScheme.cs
+++ b/src/OpenSage.Game/Data/Ini/ControlBarScheme.cs
@@ -29,7 +29,7 @@ namespace OpenSage.Data.Ini
 
         private static readonly IniParseTable<ControlBarScheme> FieldParseTable = new IniParseTable<ControlBarScheme>
         {
-            { "ScreenCreationRes", (parser, x) => x.ScreenCreationRes = parser.ParsePoint() },
+            { "ScreenCreationRes", (parser, x) => x.ScreenCreationRes = parser.ParseSize() },
             { "Side", (parser, x) => x.Side = parser.ParseAssetReference() },
             { "QueueButtonImage", (parser, x) => x.QueueButtonImage = parser.ParseFileName() },
             { "RightHUDImage", (parser, x) => x.RightHudImage = parser.ParseAssetReference() },
@@ -124,7 +124,7 @@ namespace OpenSage.Data.Ini
 
         public string Name { get; private set; }
 
-        public Point2D ScreenCreationRes { get; private set; }
+        public Size ScreenCreationRes { get; private set; }
         public string Side { get; private set; }
         public string QueueButtonImage { get; private set; }
         public string RightHudImage { get; private set; }
@@ -223,13 +223,13 @@ namespace OpenSage.Data.Ini
         private static readonly IniParseTable<ControlBarImagePart> FieldParseTable = new IniParseTable<ControlBarImagePart>
         {
             { "Position", (parser, x) => x.Position = parser.ParsePoint() },
-            { "Size", (parser, x) => x.Size = parser.ParsePoint() },
+            { "Size", (parser, x) => x.Size = parser.ParseSize() },
             { "ImageName", (parser, x) => x.ImageName = parser.ParseAssetReference() },
             { "Layer", (parser, x) => x.Layer = parser.ParseInteger() }
         };
 
         public Point2D Position { get; private set; }
-        public Point2D Size { get; private set; }
+        public Size Size { get; private set; }
         public string ImageName { get; private set; }
         public int Layer { get; private set; }
     }

--- a/src/OpenSage.Game/Data/Ini/Parser/IniParser.cs
+++ b/src/OpenSage.Game/Data/Ini/Parser/IniParser.cs
@@ -344,6 +344,15 @@ namespace OpenSage.Data.Ini.Parser
             };
         }
 
+        public Size ParseSize()
+        {
+            return new Size
+            {
+                Width = ParseAttributeInteger("X"),
+                Height = ParseAttributeInteger("Y")
+            };
+        }
+
         public IniToken GetNextToken(char[] separators = null)
         {
             var result = GetNextTokenOptional(separators);

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -317,7 +317,6 @@ namespace OpenSage
             NetworkMessageBuffer = new NetworkMessageBuffer(this, connection);
 
             // TODO: This is not the right place for this.
-            ContentManager.IniDataContext.LoadIniFile(@"Data\INI\ControlBarScheme.ini");
             ContentManager.IniDataContext.LoadIniFile(@"Data\INI\PlayerTemplate.ini");
 
             var players = new Player[sides.Length];
@@ -344,9 +343,11 @@ namespace OpenSage
 
             Scene3D.SetPlayers(players, players[localPlayerIndex]);
 
-            var controlBar = WndControlBar.Create(sides[localPlayerIndex], ContentManager);
-            Scene2D.ControlBar = controlBar;
-            Scene2D.ControlBar.PushWindows(Scene2D.WndWindowManager);
+            if (Definition.ControlBar != null)
+            {
+                Scene2D.ControlBar = Definition.ControlBar.Create(sides[localPlayerIndex], ContentManager);
+                Scene2D.ControlBar.AddToScene(Scene2D);
+            }
         }
 
         public void EndGame()

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -344,8 +344,9 @@ namespace OpenSage
 
             Scene3D.SetPlayers(players, players[localPlayerIndex]);
 
-            var controlBar = WndControlBar.Create(sides[localPlayerIndex], Scene2D.WndWindowManager, ContentManager);
+            var controlBar = WndControlBar.Create(sides[localPlayerIndex], ContentManager);
             Scene2D.ControlBar = controlBar;
+            Scene2D.ControlBar.Display(Scene2D.WndWindowManager);
         }
 
         public void EndGame()

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -326,8 +326,7 @@ namespace OpenSage
                 var playerTemplate = ContentManager.IniDataContext.PlayerTemplates.Find(t => t.Side == sides[i]);
                 players[i] = Player.FromTemplate(playerTemplate, ContentManager);
 
-                var playerIndex = 2; // TODO
-                var player1StartPosition = Scene3D.Waypoints[$"Player_{playerIndex}_Start"].Position;
+                var player1StartPosition = Scene3D.Waypoints[$"Player_{i + 1}_Start"].Position;
                 player1StartPosition.Z += Scene3D.Terrain.HeightMap.GetHeight(player1StartPosition.X, player1StartPosition.Y);
 
                 if (playerTemplate.StartingBuilding != null)
@@ -345,17 +344,8 @@ namespace OpenSage
 
             Scene3D.SetPlayers(players, players[localPlayerIndex]);
 
-            var controlBarWindow = Scene2D.WndWindowManager.SetWindow("ControlBar.wnd");
-
-            // TODO: Move the following code to a ControlBar class.
-            var controlBarScheme = ContentManager.IniDataContext.ControlBarSchemes.FindBySide(sides[localPlayerIndex]);
-
-            // TODO: I don't think this is how it works. The "Munkee" control is probably just for design-time preview.
-            // I think we should use ImagePart.Position and ImagePart.Size to render the control bar background image,
-            // probably not as part of the wnd control tree.
-            var munkee = controlBarWindow.Controls.FindControl("ControlBar.wnd:Munkee");
-            munkee.DrawCallback = munkee.DefaultDraw;
-            munkee.BackgroundImage = ContentManager.WndImageLoader.CreateNormalImage(controlBarScheme.ImageParts[0].ImageName);
+            var controlBar = WndControlBar.Create(sides[localPlayerIndex], Scene2D.WndWindowManager, ContentManager);
+            Scene2D.ControlBar = controlBar;
         }
 
         public void EndGame()

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -346,7 +346,7 @@ namespace OpenSage
 
             var controlBar = WndControlBar.Create(sides[localPlayerIndex], ContentManager);
             Scene2D.ControlBar = controlBar;
-            Scene2D.ControlBar.Display(Scene2D.WndWindowManager);
+            Scene2D.ControlBar.PushWindows(Scene2D.WndWindowManager);
         }
 
         public void EndGame()

--- a/src/OpenSage.Game/Gui/IControlBar.cs
+++ b/src/OpenSage.Game/Gui/IControlBar.cs
@@ -1,0 +1,16 @@
+﻿using OpenSage.Content;
+using OpenSage.Logic;
+
+namespace OpenSage.Gui
+{
+    public interface IControlBar
+    {
+        void AddToScene(Scene2D scene2D);
+        void Update(Player player);
+    }
+
+    public interface IControlBarSource
+    {
+        IControlBar Create(string side, ContentManager contentManager);
+    }
+}

--- a/src/OpenSage.Game/Gui/Wnd/Controls/Window.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Controls/Window.cs
@@ -1,8 +1,6 @@
 ﻿using System.Numerics;
 using OpenSage.Content;
-using OpenSage.Graphics;
 using OpenSage.Mathematics;
-using Veldrid;
 
 namespace OpenSage.Gui.Wnd.Controls
 {

--- a/src/OpenSage.Game/Gui/Wnd/Images/MappedImageLoader.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Images/MappedImageLoader.cs
@@ -6,7 +6,7 @@ using Veldrid;
 
 namespace OpenSage.Gui.Wnd.Images
 {
-    internal sealed class MappedImageLoader
+    public sealed class MappedImageLoader
     {
         private readonly ContentManager _contentManager;
 

--- a/src/OpenSage.Game/Gui/Wnd/Images/WndImageLoader.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Images/WndImageLoader.cs
@@ -9,7 +9,7 @@ using Rectangle = OpenSage.Mathematics.Rectangle;
 
 namespace OpenSage.Gui.Wnd.Images
 {
-    internal sealed class WndImageLoader : DisposableBase
+    public sealed class WndImageLoader : DisposableBase
     {
         private struct WndImageKey
         {

--- a/src/OpenSage.Game/Gui/Wnd/WndControlBar.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndControlBar.cs
@@ -1,0 +1,123 @@
+﻿using OpenSage.Content;
+using OpenSage.Gui.Wnd.Controls;
+using OpenSage.Gui.Wnd.Images;
+using OpenSage.Logic;
+using OpenSage.Mathematics;
+
+namespace OpenSage.Gui.Wnd
+{
+    public sealed class WndControlBar
+    {
+        private readonly Window _window;
+
+        private readonly Label _moneyDisplay;
+        private readonly Control _powerBar;
+        private readonly Control _expBar;
+
+        private WndControlBar(Window window, Label moneyDisplay, Control powerBar, Control expBar)
+        {
+            _window = window;
+            _moneyDisplay = moneyDisplay;
+            _powerBar = powerBar;
+            _expBar = expBar;
+        }
+
+        public void UpdateState(Player player)
+        {
+            _moneyDisplay.Text = $"$ {player.Money}";
+        }
+
+        public static WndControlBar Create(string side, WndWindowManager windowManager, ContentManager contentManager)
+        {
+            var scheme = contentManager.IniDataContext.ControlBarSchemes.FindBySide(side);
+
+            var background = new Control();
+            background.Name = "OpenSAGE:ControlBarBackground";
+
+            // TODO: Support multiple image parts?
+            var imagePart = scheme.ImageParts[0];
+            background.Bounds = new Rectangle(imagePart.Position, imagePart.Size);
+            background.BackgroundImage = CreateImage(imagePart.ImageName);
+
+            var backgroundWindow = new Window(scheme.ScreenCreationRes, background, contentManager);
+            windowManager.PushWindow(backgroundWindow);
+
+            var controlBarWindow = windowManager.PushWindow("ControlBar.wnd");
+
+            Control FindControl(string name) => controlBarWindow.Controls.FindControl($"ControlBar.wnd:{name}");
+            Image CreateImage(string path) => contentManager.WndImageLoader.CreateNormalImage(path);
+
+            var center = FindControl("CenterBackground");
+
+            foreach (var control in center.Controls)
+            {
+                control.Hide();
+            }
+
+            // TODO: Implement under attack indicator.
+            FindControl("WinUAttack").Hide();
+
+            // TODO: What is this?
+            FindControl("OnTopDraw").Hide();
+
+            var windowOrigin = controlBarWindow.Bounds.Location;
+            var schemeType = scheme.GetType();
+
+            Control ApplyBounds(string name, string coordPrefix)
+            {
+                var control = FindControl(name);
+
+                var ul = (Point2D) schemeType.GetProperty($"{coordPrefix}UL").GetValue(scheme);
+                var lr = (Point2D) schemeType.GetProperty($"{coordPrefix}LR").GetValue(scheme);
+                control.Bounds = Rectangle.FromCorners(ul - windowOrigin, lr - windowOrigin);
+
+                return control;
+            }
+
+            Button ApplyButtonScheme(string name, string coordPrefix, string texturePrefix)
+            {
+                var button = ApplyBounds(name, coordPrefix) as Button;
+
+                Image LoadImage(string state) =>
+                    CreateImage(
+                        (string) schemeType.GetProperty($"{texturePrefix}{state}")?.GetValue(scheme));
+
+                button.BackgroundImage = LoadImage("Enable");
+                button.DisabledBackgroundImage = LoadImage("Disabled");
+                button.HoverBackgroundImage = LoadImage("Highlighted");
+                button.PushedBackgroundImage = LoadImage("Pushed");
+
+                return button;
+            }
+
+            var money = ApplyBounds("MoneyDisplay", "Money") as Label;
+            money.Text = "$ 0";
+
+            var power = ApplyBounds("PowerWindow", "PowerBar");
+
+            ApplyButtonScheme("ButtonOptions", "Options", "OptionsButton");
+            ApplyButtonScheme("ButtonGeneral", "General", "GeneralButton");
+            ApplyButtonScheme("ButtonPlaceBeacon", "Beacon", "BeaconButton");
+            ApplyButtonScheme("PopupCommunicator", "Chat", "BuddyButton");
+
+            ApplyButtonScheme("ButtonIdleWorker", "Worker", "IdleWorkerButton");
+            ApplyButtonScheme("ButtonLarge", "MinMax", "MinMaxButton");
+
+            var rightHud = FindControl("RightHUD");
+            rightHud.BorderWidth = 0;
+            rightHud.BackgroundColor = ColorRgbaF.Transparent;
+            rightHud.BackgroundImage = CreateImage(scheme.RightHudImage);
+
+            foreach (var control in rightHud.Controls)
+            {
+                control.Hide();
+            }
+
+            var expBar = FindControl("GeneralsExp");
+            var expBarForeground = FindControl("ExpBarForeground");
+            expBarForeground.BackgroundImage = CreateImage(scheme.ExpBarForegroundImage);
+
+            return new WndControlBar(controlBarWindow, money, power, expBar);
+        }
+    }
+}

--- a/src/OpenSage.Game/Gui/Wnd/WndControlBar.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndControlBar.cs
@@ -155,7 +155,7 @@ namespace OpenSage.Gui.Wnd
             };
 
             var backgroundWindow = new Window(scheme.ScreenCreationRes, background, contentManager);
-            var controlBarWindow = contentManager.Load<Window>("Window/ControlBar.wnd");
+            var controlBarWindow = contentManager.Load<Window>("Window/ControlBar.wnd", new LoadOptions { CacheAsset = false});
 
             Control FindControl(string name) => controlBarWindow.Controls.FindControl($"ControlBar.wnd:{name}");
             Image CreateImage(string path) => contentManager.WndImageLoader.CreateNormalImage(path);

--- a/src/OpenSage.Game/Gui/Wnd/WndControlBar.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndControlBar.cs
@@ -22,11 +22,28 @@ namespace OpenSage.Gui.Wnd
 
         private readonly ControlBarScheme _scheme;
 
+        private ControlBarState _state;
+
+        private ControlBarState State
+        {
+            get => _state;
+            set
+            {
+                _state = value;
+                _state.OnEnterState(this);
+            }
+        }
+
         private readonly Window _background;
         private readonly Window _window;
 
+        private readonly Control _center;
+        private readonly Control _right;
+
         private readonly Label _moneyDisplay;
+        // TODO: Change this to a ProgressBar when they are implemented.
         private readonly Control _powerBar;
+        // TODO: Change this to a ProgressBar when they are implemented.
         private readonly Control _expBar;
 
         private readonly Button _resize;
@@ -51,6 +68,9 @@ namespace OpenSage.Gui.Wnd
             _scheme = scheme;
             _contentManager = contentManager;
 
+            _center = FindControl("CenterBackground");
+            _right = FindControl("RightHUD");
+
             _moneyDisplay = FindControl("MoneyDisplay") as Label;
             _moneyDisplay.Text = "$ 0";
             _powerBar = FindControl("PowerWindow");
@@ -67,11 +87,16 @@ namespace OpenSage.Gui.Wnd
             _resizeUpPushed = LoadImage(_scheme.ToggleButtonUpPushed);
 
             UpdateResizeButtonStyle();
+
+            State = ControlBarState.Default;
         }
 
-        public void UpdateState(Player player)
+        // TODO: This should be called at every logic tick.
+        // TODO: This takes a player as the state information. Do we need any other state?
+        public void Update(Player player)
         {
             _moneyDisplay.Text = $"$ {player.Money}";
+            State.Update(player, this);
         }
 
         public void ToggleSize()
@@ -108,7 +133,7 @@ namespace OpenSage.Gui.Wnd
             }
         }
 
-        public void Display(WndWindowManager windowManager)
+        public void PushWindows(WndWindowManager windowManager)
         {
             windowManager.PushWindow(_background);
             windowManager.PushWindow(_window);
@@ -119,7 +144,7 @@ namespace OpenSage.Gui.Wnd
             var scheme = contentManager.IniDataContext.ControlBarSchemes.FindBySide(side);
 
             // TODO: Support multiple image parts?
-            // Generals only uses one image part.
+            // Generals always uses exactly one image part.
             var imagePart = scheme.ImageParts[0];
 
             var background = new Control
@@ -134,13 +159,6 @@ namespace OpenSage.Gui.Wnd
 
             Control FindControl(string name) => controlBarWindow.Controls.FindControl($"ControlBar.wnd:{name}");
             Image CreateImage(string path) => contentManager.WndImageLoader.CreateNormalImage(path);
-
-            var center = FindControl("CenterBackground");
-
-            foreach (var control in center.Controls)
-            {
-                control.Hide();
-            }
 
             // TODO: Implement under attack indicator.
             FindControl("WinUAttack").Hide();
@@ -196,14 +214,64 @@ namespace OpenSage.Gui.Wnd
             rightHud.BackgroundColor = ColorRgbaF.Transparent;
             rightHud.BackgroundImage = CreateImage(scheme.RightHudImage);
 
-            foreach (var control in rightHud.Controls)
-            {
-                control.Hide();
-            }
-
             FindControl("ExpBarForeground").BackgroundImage = CreateImage(scheme.ExpBarForegroundImage);
 
             return new WndControlBar(backgroundWindow, controlBarWindow, scheme, contentManager);
+        }
+
+        private abstract class ControlBarState
+        {
+            public abstract void OnEnterState(WndControlBar controlBar);
+            public abstract void Update(Player player, WndControlBar controlBar);
+
+            public static ControlBarState Default { get; } = new DefaultControlBarState();
+        }
+
+        private sealed class DefaultControlBarState : ControlBarState
+        {
+            public override void OnEnterState(WndControlBar controlBar)
+            {
+                foreach (var control in controlBar._center.Controls)
+                {
+                    control.Hide();
+                }
+
+                foreach (var control in controlBar._right.Controls)
+                {
+                    control.Hide();
+                }
+            }
+
+            public override void Update(Player player, WndControlBar controlBar)
+            {
+
+            }
+        }
+
+        private sealed class SelectedControlBarState : ControlBarState
+        {
+            public override void OnEnterState(WndControlBar controlBar)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public override void Update(Player player, WndControlBar controlBar)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        private sealed class UnderConstructionControlBarState : ControlBarState
+        {
+            public override void OnEnterState(WndControlBar controlBar)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public override void Update(Player player, WndControlBar controlBar)
+            {
+                throw new System.NotImplementedException();
+            }
         }
     }
 }

--- a/src/OpenSage.Game/Gui/Wnd/WndInputMessageHandler.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndInputMessageHandler.cs
@@ -118,16 +118,6 @@ namespace OpenSage.Gui.Wnd
                         ? InputMessageResult.Handled
                         : InputMessageResult.NotHandled;
                 }
-
-                case InputMessageType.KeyDown:
-                    {
-                        if (message.Value.Key == Key.Escape && _windowManager.OpenWindowCount > 1)
-                        {
-                            _windowManager.PopWindow();
-                            return InputMessageResult.Handled;
-                        }
-                        break;
-                    }
             }
 
             return InputMessageResult.NotHandled;

--- a/src/OpenSage.Game/IGameDefinition.cs
+++ b/src/OpenSage.Game/IGameDefinition.cs
@@ -15,6 +15,8 @@ namespace OpenSage
         IEnumerable<RegistryKeyPath> RegistryKeys { get; }
 
         IMainMenuSource MainMenu { get; }
+        IControlBarSource ControlBar { get; }
+
         string Identifier { get; }
     }
 }

--- a/src/OpenSage.Game/Mathematics/Point2D.cs
+++ b/src/OpenSage.Game/Mathematics/Point2D.cs
@@ -29,6 +29,21 @@ namespace OpenSage.Mathematics
                 (int) Math.Round(result.Y));
         }
 
+        public Size ToSize()
+        {
+            return new Size(X, Y);
+        }
+
+        public static Point2D operator+(in Point2D a, in Point2D b)
+        {
+            return new Point2D(a.X + b.X, a.Y + b.Y);
+        }
+
+        public static Point2D operator-(in Point2D a, in Point2D b)
+        {
+            return new Point2D(a.X - b.X, a.Y - b.Y);
+        }
+
         public static Point2D Min(in Point2D a, in Point2D b)
         {
             return new Point2D(Math.Min(a.X, b.X), Math.Min(a.Y, b.Y));

--- a/src/OpenSage.Game/Mathematics/Point2D.cs
+++ b/src/OpenSage.Game/Mathematics/Point2D.cs
@@ -34,12 +34,12 @@ namespace OpenSage.Mathematics
             return new Size(X, Y);
         }
 
-        public static Point2D operator+(in Point2D a, in Point2D b)
+        public static Point2D operator+(Point2D a, Point2D b)
         {
             return new Point2D(a.X + b.X, a.Y + b.Y);
         }
 
-        public static Point2D operator-(in Point2D a, in Point2D b)
+        public static Point2D operator-(Point2D a, Point2D b)
         {
             return new Point2D(a.X - b.X, a.Y - b.Y);
         }

--- a/src/OpenSage.Game/Mathematics/Rectangle.cs
+++ b/src/OpenSage.Game/Mathematics/Rectangle.cs
@@ -57,6 +57,11 @@ namespace OpenSage.Mathematics
             }
         }
 
+        public static Rectangle FromCorners(in Point2D topLeft, in Point2D bottomRight)
+        {
+            return new Rectangle(topLeft, (bottomRight - topLeft).ToSize());
+        }
+
         public bool Contains(in Point2D point)
         {
             return point.X >= X

--- a/src/OpenSage.Game/Mathematics/Rectangle.cs
+++ b/src/OpenSage.Game/Mathematics/Rectangle.cs
@@ -57,7 +57,7 @@ namespace OpenSage.Mathematics
             }
         }
 
-        public static Rectangle FromCorners(in Point2D topLeft, in Point2D bottomRight)
+        public static Rectangle FromCorners(Point2D topLeft, Point2D bottomRight)
         {
             return new Rectangle(topLeft, (bottomRight - topLeft).ToSize());
         }

--- a/src/OpenSage.Game/Scene2D.cs
+++ b/src/OpenSage.Game/Scene2D.cs
@@ -8,6 +8,7 @@ namespace OpenSage
     {
         public WndWindowManager WndWindowManager { get; }
         public AptWindowManager AptWindowManager { get; }
+        public WndControlBar ControlBar { get; set; }
 
         public Scene2D(Game game)
         {

--- a/src/OpenSage.Game/Scene2D.cs
+++ b/src/OpenSage.Game/Scene2D.cs
@@ -8,7 +8,7 @@ namespace OpenSage
     {
         public WndWindowManager WndWindowManager { get; }
         public AptWindowManager AptWindowManager { get; }
-        public WndControlBar ControlBar { get; set; }
+        public IControlBar ControlBar { get; set; }
 
         public Scene2D(Game game)
         {

--- a/src/OpenSage.Mods.Bfme/BfmeDefinition.cs
+++ b/src/OpenSage.Mods.Bfme/BfmeDefinition.cs
@@ -17,10 +17,11 @@ namespace OpenSage.Mods.BFME
         {
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\EA Games\The Battle for Middle-earth", "InstallPath")
         };
-        
+
         public string Identifier { get; } = "bfme";
 
         public IMainMenuSource MainMenu { get; }
+        public IControlBarSource ControlBar { get; }
 
         public static BfmeDefinition Instance { get; } = new BfmeDefinition();
     }

--- a/src/OpenSage.Mods.Bfme2/Bfme2Definition.cs
+++ b/src/OpenSage.Mods.Bfme2/Bfme2Definition.cs
@@ -18,10 +18,11 @@ namespace OpenSage.Mods.Bfme2
         {
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\The Battle for Middle-earth II", "InstallPath")
         };
-        
+
         public string Identifier { get; } = "bfme2";
 
         public IMainMenuSource MainMenu { get; } = new AptMainMenuSource("MainMenu.apt");
+        public IControlBarSource ControlBar { get; }
 
         public static Bfme2Definition Instance { get; } = new Bfme2Definition();
     }

--- a/src/OpenSage.Mods.Bfme2/Bfme2RotwkDefinition.cs
+++ b/src/OpenSage.Mods.Bfme2/Bfme2RotwkDefinition.cs
@@ -18,10 +18,11 @@ namespace OpenSage.Mods.Bfme2
         {
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\The Lord of the Rings, The Rise of the Witch-king", "InstallPath") 
         };
-        
+
         public string Identifier { get; } = "bfme2_rotwk";
 
         public IMainMenuSource MainMenu { get; } = new AptMainMenuSource("MainMenu.apt");
+        public IControlBarSource ControlBar { get; }
 
         public static Bfme2RotwkDefinition Instance { get; } = new Bfme2RotwkDefinition();
     }

--- a/src/OpenSage.Mods.Cnc3/Cnc3Definition.cs
+++ b/src/OpenSage.Mods.Cnc3/Cnc3Definition.cs
@@ -16,10 +16,11 @@ namespace OpenSage.Mods.CnC3
         {
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Command and Conquer 3", "InstallPath")
         };
-        
+
         public string Identifier { get; } = "cnc3";
 
         public IMainMenuSource MainMenu { get; }
+        public IControlBarSource ControlBar { get; }
 
         public static Cnc3Definition Instance { get; } = new Cnc3Definition();
     }

--- a/src/OpenSage.Mods.Cnc3/Cnc3KanesWrathDefinition.cs
+++ b/src/OpenSage.Mods.Cnc3/Cnc3KanesWrathDefinition.cs
@@ -16,10 +16,11 @@ namespace OpenSage.Mods.CnC3
         {
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Command and Conquer 3 Kanes Wrath", "InstallPath")
         };
-        
+
         public string Identifier { get; } = "cnc3_kw";
 
         public IMainMenuSource MainMenu { get; }
+        public IControlBarSource ControlBar { get; }
 
         public static Cnc3KanesWrathDefinition Instance { get; } = new Cnc3KanesWrathDefinition();
     }

--- a/src/OpenSage.Mods.Cnc4/Cnc4Definition.cs
+++ b/src/OpenSage.Mods.Cnc4/Cnc4Definition.cs
@@ -17,10 +17,11 @@ namespace OpenSage.Mods.Cnc4
             new RegistryKeyPath(@"SOFTWARE\EA Games\Command Conquer 4 Tiberian Twilight", "Install Dir"), // Origin
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\command and conquer 4", "install dir") // Steam
         };
-        
+
         public string Identifier { get; } = "cnc4";
 
         public IMainMenuSource MainMenu { get; }
+        public IControlBarSource ControlBar { get; }
 
         public static Cnc4Definition Instance { get; } = new Cnc4Definition();
     }

--- a/src/OpenSage.Mods.Generals/GeneralsDefinition.cs
+++ b/src/OpenSage.Mods.Generals/GeneralsDefinition.cs
@@ -2,6 +2,7 @@
 using OpenSage.Data;
 using OpenSage.Gui;
 using OpenSage.Gui.Wnd;
+using OpenSage.Mods.Generals.Gui;
 
 namespace OpenSage.Mods.Generals
 {
@@ -17,10 +18,11 @@ namespace OpenSage.Mods.Generals
         {
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\EA Games\Generals", "InstallPath")
         };
-        
+
         public string Identifier { get; } = "cnc_generals";
 
         public IMainMenuSource MainMenu { get; } = new WndMainMenuSource(@"Menus\MainMenu.wnd");
+        public IControlBarSource ControlBar { get; } = new GeneralsControlBarSource();
 
         public static GeneralsDefinition Instance { get; } = new GeneralsDefinition();
     }

--- a/src/OpenSage.Mods.Generals/GeneralsZeroHourDefinition.cs
+++ b/src/OpenSage.Mods.Generals/GeneralsZeroHourDefinition.cs
@@ -2,6 +2,7 @@
 using OpenSage.Data;
 using OpenSage.Gui;
 using OpenSage.Gui.Wnd;
+using OpenSage.Mods.Generals.Gui;
 
 namespace OpenSage.Mods.Generals
 {
@@ -19,10 +20,11 @@ namespace OpenSage.Mods.Generals
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\EA Games\Command and Conquer Generals Zero Hour", "InstallPath"),
             new RegistryKeyPath(@"SOFTWARE\EA Games\Command and Conquer Generals Zero Hour", "Install Dir", "Command and Conquer Generals Zero Hour\\")
         };
-        
+
         public string Identifier { get; } = "cnc_generals_zh";
 
         public IMainMenuSource MainMenu { get; } = new WndMainMenuSource(@"Menus\MainMenu.wnd");
+        public IControlBarSource ControlBar { get; } = new GeneralsControlBarSource();
 
         public static GeneralsZeroHourDefinition Instance { get; } = new GeneralsZeroHourDefinition();
     }

--- a/src/OpenSage.Mods.Generals/Gui/ControlBarCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/ControlBarCallbacks.cs
@@ -22,6 +22,9 @@ namespace OpenSage.Mods.Generals.Gui
                         case "ControlBar.wnd:ButtonLarge":
                             context.Game.Scene2D.ControlBar.ToggleSize();
                             break;
+                        case "ControlBar.wnd:ButtonOptions":
+                            context.WindowManager.PushWindow("Menus/QuitMenu.wnd");
+                            break;
                     }
                     break;
             }

--- a/src/OpenSage.Mods.Generals/Gui/ControlBarCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/ControlBarCallbacks.cs
@@ -20,7 +20,7 @@ namespace OpenSage.Mods.Generals.Gui
                     switch (message.Element.Name)
                     {
                         case "ControlBar.wnd:ButtonLarge":
-                            context.Game.Scene2D.ControlBar.ToggleSize();
+                            ((GeneralsControlBar) context.Game.Scene2D.ControlBar).ToggleSize();
                             break;
                         case "ControlBar.wnd:ButtonOptions":
                             context.WindowManager.PushWindow("Menus/QuitMenu.wnd");

--- a/src/OpenSage.Mods.Generals/Gui/ControlBarCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/ControlBarCallbacks.cs
@@ -11,5 +11,20 @@ namespace OpenSage.Mods.Generals.Gui
         {
 
         }
+
+        public static void ControlBarSystem(Control control, WndWindowMessage message, ControlCallbackContext context)
+        {
+            switch (message.MessageType)
+            {
+                case WndWindowMessageType.SelectedButton:
+                    switch (message.Element.Name)
+                    {
+                        case "ControlBar.wnd:ButtonLarge":
+                            context.Game.Scene2D.ControlBar.ToggleSize();
+                            break;
+                    }
+                    break;
+            }
+        }
     }
 }

--- a/src/OpenSage.Mods.Generals/Gui/QuitMenuCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/QuitMenuCallbacks.cs
@@ -10,14 +10,13 @@ namespace OpenSage.Mods.Generals.Gui
         {
             switch (message.MessageType)
             {
-                case WndWindowMessageType.SelectedButton:
-                    switch (message.Element.Name)
-                    {
-                        case "QuitMenu.wnd:ButtonReturn":
-                            context.WindowManager.PopWindow();
-                            break;
-                    }
-
+                case WndWindowMessageType.SelectedButton when message.Element.Name == "QuitMenu.wnd:ButtonReturn":
+                    context.WindowManager.PopWindow();
+                    break;
+                case WndWindowMessageType.SelectedButton when message.Element.Name == "QuitMenu.wnd:ButtonExit":
+                    context.WindowManager.PopWindow();
+                    // TODO: Implement this when we can reset the game state and replace the Scene3D without crashing.
+                    // context.Game.EndGame();
                     break;
             }
         }

--- a/src/OpenSage.Mods.Generals/Gui/QuitMenuCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/QuitMenuCallbacks.cs
@@ -1,0 +1,25 @@
+﻿using OpenSage.Gui.Wnd;
+using OpenSage.Gui.Wnd.Controls;
+
+namespace OpenSage.Mods.Generals.Gui
+{
+    [WndCallbacks]
+    public static class QuitMenuCallbacks
+    {
+        public static void QuitMenuSystem(Control control, WndWindowMessage message, ControlCallbackContext context)
+        {
+            switch (message.MessageType)
+            {
+                case WndWindowMessageType.SelectedButton:
+                    switch (message.Element.Name)
+                    {
+                        case "QuitMenu.wnd:ButtonReturn":
+                            context.WindowManager.PopWindow();
+                            break;
+                    }
+
+                    break;
+            }
+        }
+    }
+}

--- a/src/OpenSage.Mods.Ra3/Ra3Definition.cs
+++ b/src/OpenSage.Mods.Ra3/Ra3Definition.cs
@@ -16,10 +16,11 @@ namespace OpenSage.Mods.Ra3
         {
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Red Alert 3", "Install Dir"),
         };
-        
+
         public string Identifier { get; } = "ra3";
 
         public IMainMenuSource MainMenu { get; }
+        public IControlBarSource ControlBar { get; }
 
         public static Ra3Definition Instance { get; } = new Ra3Definition();
     }

--- a/src/OpenSage.Mods.Ra3/Ra3UprisingDefinition.cs
+++ b/src/OpenSage.Mods.Ra3/Ra3UprisingDefinition.cs
@@ -16,10 +16,11 @@ namespace OpenSage.Mods.Ra3
         {
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Red Alert 3 Uprising", "Install Dir")
         };
-        
+
         public string Identifier { get; } = "ra3_uprising";
 
         public IMainMenuSource MainMenu { get; }
+        public IControlBarSource ControlBar { get; }
 
         public static Ra3UprisingDefinition Instance { get; } = new Ra3UprisingDefinition();
     }


### PR DESCRIPTION
* Implement control bar abstraction, with `IControlBar` and `IControlBarSource`.
* Move control bar to its own classes
* Apply the control bar theme from `ControlBarScheme.ini`
* Remove ESC as a window-closing hotkey. The exact reasons are outlined in 5b05fd95b1b2d20835322d59587a95d2df7ce877, but the gist of it is that it was a hack from the start, and it's not going to work properly outside of the main menu.
* **Bonus!** Fix starting building / unit positions.