### PR TITLE
Use the Invariant version of ToUpper and ToLower (and fix Turkish locale)

### DIFF
--- a/src/OpenSage.Game.Tests/Data/InstalledFilesTestData.cs
+++ b/src/OpenSage.Game.Tests/Data/InstalledFilesTestData.cs
@@ -37,7 +37,7 @@ namespace OpenSage.Tests.Data
                 {
                     foreach (var file in fileSystem.Files)
                     {
-                        if (Path.GetExtension(file.FilePath).ToLower() != fileExtension)
+                        if (Path.GetExtension(file.FilePath).ToLowerInvariant() != fileExtension)
                         {
                             continue;
                         }

--- a/src/OpenSage.Game/Content/TextureLoader.cs
+++ b/src/OpenSage.Game/Content/TextureLoader.cs
@@ -45,7 +45,7 @@ namespace OpenSage.Content
                 return texture;
             }
 
-            switch (Path.GetExtension(entry.FilePath).ToLower())
+            switch (Path.GetExtension(entry.FilePath).ToLowerInvariant())
             {
                 case ".dds":
                     if (!DdsFile.IsDdsFile(entry))

--- a/src/OpenSage.Game/Data/FileSystem.cs
+++ b/src/OpenSage.Game/Data/FileSystem.cs
@@ -31,7 +31,7 @@ namespace OpenSage.Data
 
             foreach (var file in Directory.GetFiles(rootDirectory, "*.*", SearchOption.AllDirectories))
             {
-                var ext = Path.GetExtension(file).ToLower();
+                var ext = Path.GetExtension(file).ToLowerInvariant();
                 if (ext == ".big")
                 {
                     var archive = new BigArchive(file);

--- a/src/OpenSage.Game/Data/Ini/ChallengeGenerals.cs
+++ b/src/OpenSage.Game/Data/Ini/ChallengeGenerals.cs
@@ -19,7 +19,7 @@ namespace OpenSage.Data.Ini
                 {
                     continue;
                 }
-                else if (token.Value.Text.ToUpper() == IniParser.EndToken)
+                else if (token.Value.Text.ToUpperInvariant() == IniParser.EndToken)
                 {
                     break;
                 }

--- a/src/OpenSage.Game/Data/Ini/ObjectFilter.cs
+++ b/src/OpenSage.Game/Data/Ini/ObjectFilter.cs
@@ -12,7 +12,7 @@ namespace OpenSage.Data.Ini
             IniToken? token;
             if ((token = parser.GetNextTokenOptional()) != null)
             {
-                var stringValue = token.Value.Text.ToUpper();
+                var stringValue = token.Value.Text.ToUpperInvariant();
                 switch (stringValue)
                 {
                     case "ALL":
@@ -39,7 +39,7 @@ namespace OpenSage.Data.Ini
 
             while ((token = parser.GetNextTokenOptional()) != null)
             {
-                var stringValue = token.Value.Text.ToUpper();
+                var stringValue = token.Value.Text.ToUpperInvariant();
                 
                 bool isInclude;
                 switch (stringValue[0])

--- a/src/OpenSage.Game/Data/Ini/Parser/IniParser.Enums.cs
+++ b/src/OpenSage.Game/Data/Ini/Parser/IniParser.Enums.cs
@@ -126,7 +126,7 @@ namespace OpenSage.Data.Ini.Parser
         {
             var token = GetNextToken();
 
-            if (stringToValueMap.TryGetValue(token.Text.ToUpper(), out var enumValue))
+            if (stringToValueMap.TryGetValue(token.Text.ToUpperInvariant(), out var enumValue))
                 return enumValue;
 
             throw new IniParseException($"Invalid value for type '{typeof(T).Name}': '{token.Text}'", token.Position);
@@ -143,7 +143,7 @@ namespace OpenSage.Data.Ini.Parser
         {
             var stringToValueMap = GetEnumMap<T>();
 
-            if (stringToValueMap.TryGetValue(token.Text.ToUpper(), out var enumValue))
+            if (stringToValueMap.TryGetValue(token.Text.ToUpperInvariant(), out var enumValue))
                 return (T)(object)enumValue;
 
             throw new IniParseException($"Invalid value for type '{typeof(T).Name}': '{token.Text}'", token.Position);
@@ -159,7 +159,7 @@ namespace OpenSage.Data.Ini.Parser
             IniToken? token;
             while ((token = GetNextTokenOptional()) != null)
             {
-                if (!stringToValueMap.TryGetValue(token.Value.Text.ToUpper(), out var enumValue))
+                if (!stringToValueMap.TryGetValue(token.Value.Text.ToUpperInvariant(), out var enumValue))
                     throw new IniParseException($"Invalid value for type '{typeof(T).Name}': '{token.Value.Text}'", token.Value.Position);
 
                 // Ugh.
@@ -179,7 +179,7 @@ namespace OpenSage.Data.Ini.Parser
             IniToken? token;
             while ((token = GetNextTokenOptional()) != null)
             {
-                var stringValue = token.Value.Text.ToUpper();
+                var stringValue = token.Value.Text.ToUpperInvariant();
                 switch (stringValue)
                 {
                     case "ALL":

--- a/src/OpenSage.Game/Data/Ini/Parser/IniParser.cs
+++ b/src/OpenSage.Game/Data/Ini/Parser/IniParser.cs
@@ -276,7 +276,7 @@ namespace OpenSage.Data.Ini.Parser
 
         private bool ScanBoolean(IniToken token)
         {
-            switch (token.Text.ToUpper())
+            switch (token.Text.ToUpperInvariant())
             {
                 case "YES":
                     return true;

--- a/src/OpenSage.Game/Data/Ini/Weapon.cs
+++ b/src/OpenSage.Game/Data/Ini/Weapon.cs
@@ -203,7 +203,7 @@ namespace OpenSage.Data.Ini
                 };
             }
 
-            if (token.Text.ToUpper() != "MIN")
+            if (token.Text.ToUpperInvariant() != "MIN")
             {
                 throw new IniParseException($"Unexpected range duration: {token.Text}", token.Position);
             }

--- a/src/OpenSage.Game/Data/InstallationLocator.cs
+++ b/src/OpenSage.Game/Data/InstallationLocator.cs
@@ -66,7 +66,7 @@ namespace OpenSage.Data
     {
         public IEnumerable<GameInstallation> FindInstallations(IGameDefinition game)
         {
-            String path = Environment.GetEnvironmentVariable(game.Identifier.ToUpper() + "_PATH");
+            String path = Environment.GetEnvironmentVariable(game.Identifier.ToUpperInvariant() + "_PATH");
 
             if (path == null)            
                 return new GameInstallation[]{};

--- a/src/OpenSage.Viewer/UI/ContentView.cs
+++ b/src/OpenSage.Viewer/UI/ContentView.cs
@@ -19,7 +19,7 @@ namespace OpenSage.Viewer.UI
 
         private static AssetView CreateViewForFileSystemEntry(AssetViewContext context)
         {
-            switch (Path.GetExtension(context.Entry.FilePath).ToLower())
+            switch (Path.GetExtension(context.Entry.FilePath).ToLowerInvariant())
             {
                 case ".ani":
                     return new AniView(context);


### PR DESCRIPTION
Fixes issues with Turkish locale. This was just a find-and-replace job - some calls could work just fine without these changes, but it's good to be consistent.