### PR TITLE
Allow invalid team references in map objects

### DIFF
--- a/src/OpenSage.Game/Content/MapLoader.cs
+++ b/src/OpenSage.Game/Content/MapLoader.cs
@@ -266,7 +266,7 @@ namespace OpenSage.Content
 
             if (mapObject.Properties.TryGetValue("originalOwner", out var teamName))
             {
-                var team = teams.First(t => t.Name == (string) teamName.Value);
+                var team = teams.FirstOrDefault(t => t.Name == (string) teamName.Value);
                 gameObject.Owner = team;
             }
 


### PR DESCRIPTION
Fixes `Training01.map` and possibly other maps by allowing invalid values for the `originalOwner` property in map objects. Invalid values will become nulls.

I don't know how these were originally introduced to the maps. In WorldBuilder an invalid team reference is shown as being empty.

![worldbuilder_2018-04-15_22-52-17](https://user-images.githubusercontent.com/803180/38782787-47446718-4101-11e8-9ac0-0df9bae0d2e0.png)
