### PR TITLE
Update veldrid and shadergen

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <ShaderGenVersion>1.2.0-g180d185fd5</ShaderGenVersion>
-    <VeldridVersion>4.2.0-beta2-gea7187d0a5</VeldridVersion>
+    <ShaderGenVersion>1.2.0-gd30696efa8</ShaderGenVersion>
+    <VeldridVersion>4.2.0-beta2-g768a605ccd</VeldridVersion>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <ShaderGenVersion>1.2.0-gd30696efa8</ShaderGenVersion>
+    <ShaderGenVersion>1.2.0-g5adf8817a8</ShaderGenVersion>
     <VeldridVersion>4.2.0-beta2-g768a605ccd</VeldridVersion>
   </PropertyGroup>
 </Project>

--- a/src/OpenSage.Game/GameWindow.cs
+++ b/src/OpenSage.Game/GameWindow.cs
@@ -58,7 +58,7 @@ namespace OpenSage
             const bool debug = false;
 #endif
 
-            var graphicsDeviceOptions = new GraphicsDeviceOptions(debug, PixelFormat.D32_Float_S8_UInt, true)
+            var graphicsDeviceOptions = new GraphicsDeviceOptions(debug, PixelFormat.D24_UNorm_S8_UInt, true)
             {
                 ResourceBindingModel = ResourceBindingModel.Improved
             };

--- a/src/OpenSage.Game/Graphics/Rendering/RenderPipeline.cs
+++ b/src/OpenSage.Game/Graphics/Rendering/RenderPipeline.cs
@@ -11,7 +11,7 @@ namespace OpenSage.Graphics.Rendering
     internal sealed class RenderPipeline : DisposableBase
     {
         public static readonly OutputDescription GameOutputDescription = new OutputDescription(
-            new OutputAttachmentDescription(PixelFormat.D32_Float_S8_UInt),
+            new OutputAttachmentDescription(PixelFormat.D24_UNorm_S8_UInt),
             new OutputAttachmentDescription(PixelFormat.B8_G8_R8_A8_UNorm));
 
         private readonly RenderList _renderList;

--- a/src/OpenSage.Game/Graphics/Shaders/FixedFunction.cs
+++ b/src/OpenSage.Game/Graphics/Shaders/FixedFunction.cs
@@ -157,7 +157,7 @@ namespace OpenSage.Graphics.Shaders
         {
             VertexOutput output;
 
-            if (MeshConstants.SkinningEnabled == 1)
+            if (MeshConstants.SkinningEnabled == 1u)
             {
                 GetSkinnedVertexData(ref input, SkinningBuffer[input.BoneIndex]);
             }
@@ -284,7 +284,7 @@ namespace OpenSage.Graphics.Shaders
                 out var specularColor);
 
             Vector4 diffuseTextureColor;
-            if (MaterialConstants.Shading.TexturingEnabled == 1)
+            if (MaterialConstants.Shading.TexturingEnabled == 1u)
             {
                 var v = CalculateViewVector(GlobalConstantsShared.CameraPosition, input.WorldPosition);
 
@@ -294,7 +294,7 @@ namespace OpenSage.Graphics.Shaders
                     Texture0,
                     v);
 
-                if (MaterialConstants.NumTextureStages > 1)
+                if (MaterialConstants.NumTextureStages > 1u)
                 {
                     var secondaryTextureColor = SampleTexture(
                         input.WorldNormal, input.UV1, input.ScreenPosition.XY(),
@@ -346,7 +346,7 @@ namespace OpenSage.Graphics.Shaders
                     }
                 }
 
-                if (MaterialConstants.Shading.AlphaTest == 1)
+                if (MaterialConstants.Shading.AlphaTest == 1u)
                 {
                     if (FailsAlphaTest(diffuseTextureColor.W))
                     {
@@ -374,7 +374,7 @@ namespace OpenSage.Graphics.Shaders
                     break;
             }
 
-            if (MaterialConstants.Shading.SpecularEnabled == 1)
+            if (MaterialConstants.Shading.SpecularEnabled == 1u)
             {
                 objectColor += specularColor;
             }

--- a/src/OpenSage.Game/Graphics/Shaders/NormalMapped.cs
+++ b/src/OpenSage.Game/Graphics/Shaders/NormalMapped.cs
@@ -74,7 +74,7 @@ namespace OpenSage.Graphics.Shaders
         {
             VertexOutput output;
 
-            if (MeshConstants.SkinningEnabled == 1)
+            if (MeshConstants.SkinningEnabled == 1u)
             {
                 GetSkinnedVertexData(ref input, SkinningBuffer[input.BoneIndex]);
             }
@@ -131,7 +131,7 @@ namespace OpenSage.Graphics.Shaders
 
             var diffuseTextureColor = Sample(DiffuseTexture, Sampler, uv);
 
-            if (MaterialConstants.AlphaTestEnable == 1)
+            if (MaterialConstants.AlphaTestEnable == 1u)
             {
                 if (FailsAlphaTest(diffuseTextureColor.W))
                 {

--- a/src/OpenSage.Game/Graphics/Shaders/Particle.cs
+++ b/src/OpenSage.Game/Graphics/Shaders/Particle.cs
@@ -72,19 +72,19 @@ namespace OpenSage.Graphics.Shaders
             var vertexUVPos = Vector4.Zero;
             switch (quadVertexID)
             {
-                case 0:
+                case 0u:
                     vertexUVPos = new Vector4(0, 1, -1, -1);
                     break;
 
-                case 1:
+                case 1u:
                     vertexUVPos = new Vector4(0, 0, -1, 1);
                     break;
 
-                case 2:
+                case 2u:
                     vertexUVPos = new Vector4(1, 1, 1, -1);
                     break;
 
-                case 3:
+                case 3u:
                     vertexUVPos = new Vector4(1, 0, 1, 1);
                     break;
             }

--- a/src/OpenSage.Game/Graphics/Shaders/Simple.cs
+++ b/src/OpenSage.Game/Graphics/Shaders/Simple.cs
@@ -60,7 +60,7 @@ namespace OpenSage.Graphics.Shaders
         {
             VertexOutput output;
 
-            if (MeshConstants.SkinningEnabled == 1)
+            if (MeshConstants.SkinningEnabled == 1u)
             {
                 GetSkinnedVertexData(ref input, SkinningBuffer[input.BoneIndex]);
             }

--- a/src/OpenSage.Game/Graphics/Shaders/Terrain.cs
+++ b/src/OpenSage.Game/Graphics/Shaders/Terrain.cs
@@ -184,7 +184,7 @@ namespace OpenSage.Graphics.Shaders
             var fracUV = Frac(uv);
 
             var cliffTextureIndex = (uint) tileDatum.Z;
-            if (cliffTextureIndex != 0)
+            if (cliffTextureIndex != 0u)
             {
                 var cliffInfo = CliffDetails[cliffTextureIndex - 1];
 
@@ -227,7 +227,7 @@ namespace OpenSage.Graphics.Shaders
 
         private Vector2 GetMacroTextureUV(Vector3 worldPosition)
         {
-            if (TerrainMaterialConstants.IsMacroTextureStretched == 1)
+            if (TerrainMaterialConstants.IsMacroTextureStretched == 1u)
             {
                 return (worldPosition.XY() + TerrainMaterialConstants.MapBorderWidth) / new Vector2(TerrainMaterialConstants.MapSize.X, -TerrainMaterialConstants.MapSize.Y);
             }

--- a/src/OpenSage.Game/OpenSage.Game.csproj
+++ b/src/OpenSage.Game/OpenSage.Game.csproj
@@ -14,7 +14,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
-    <PackageReference Include="OpenAL-CS" Version="1.0.9" />
+    <PackageReference Include="OpenAL-CS" Version="1.0.10" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0003" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0003" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />

--- a/src/OpenSage.Launcher/OpenSage.Launcher.csproj
+++ b/src/OpenSage.Launcher/OpenSage.Launcher.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RuntimeIdentifiers>win-x64;osx-64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;osx-64;ubuntu-x64</RuntimeIdentifiers>
     <ApplicationIcon>Resources\AppIcon.ico</ApplicationIcon>
   </PropertyGroup>
   

--- a/src/OpenSage.Viewer/Framework/ImGuiGamePanel.cs
+++ b/src/OpenSage.Viewer/Framework/ImGuiGamePanel.cs
@@ -107,7 +107,7 @@ namespace OpenSage.Viewer.Framework
                     height,
                     1,
                     1,
-                    PixelFormat.D32_Float_S8_UInt,
+                    PixelFormat.D24_UNorm_S8_UInt,
                     TextureUsage.DepthStencil)));
 
             _gameFramebuffer = AddDisposable(_graphicsDevice.ResourceFactory.CreateFramebuffer(

--- a/src/OpenSage.Viewer/OpenSage.Viewer.csproj
+++ b/src/OpenSage.Viewer/OpenSage.Viewer.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Veldrid.ImGui" Version="$(VeldridVersion)" />
+    <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180220-2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenSage.Viewer/Program.cs
+++ b/src/OpenSage.Viewer/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.CommandLine;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -11,12 +12,31 @@ namespace OpenSage.Viewer
     {
         public static void Main(string[] args)
         {
+            GraphicsBackend? preferredBackend = null;
+
+            ArgumentSyntax.Parse(args, syntax =>
+            {
+                string preferredBackendString = null;
+                syntax.DefineOption("renderer", ref preferredBackendString, false, $"Choose which renderer backend should be used. Valid options: {string.Join(",", Enum.GetNames(typeof(GraphicsBackend)))}");
+                if (preferredBackendString != null)
+                {
+                    if (Enum.TryParse<GraphicsBackend>(preferredBackendString, out var preferredBackendTemp))
+                    {
+                        preferredBackend = preferredBackendTemp;
+                    }
+                    else
+                    {
+                        syntax.ReportError($"Unknown renderer backend: {preferredBackendString}");
+                    }
+                }              
+            });
+
             Platform.Start();
 
             const int initialWidth = 1024;
             const int initialHeight = 768;
 
-            using (var window = new GameWindow("OpenSAGE Viewer", 100, 100, initialWidth, initialHeight, null))
+            using (var window = new GameWindow("OpenSAGE Viewer", 100, 100, initialWidth, initialHeight, preferredBackend))
             using (var commandList = window.GraphicsDevice.ResourceFactory.CreateCommandList())
             using (var imGuiRenderer = new ImGuiRenderer(window.GraphicsDevice, window.GraphicsDevice.MainSwapchain.Framebuffer.OutputDescription, initialWidth, initialHeight))
             using (var gameTimer = new GameTimer())

--- a/src/OpenSage.Viewer/UI/Views/GameView.cs
+++ b/src/OpenSage.Viewer/UI/Views/GameView.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 using ImGuiNET;
+using Veldrid;
 
 namespace OpenSage.Viewer.UI.Views
 {
@@ -10,6 +11,19 @@ namespace OpenSage.Viewer.UI.Views
         protected GameView(AssetViewContext context)
         {
             _context = context;
+        }
+
+        private Vector2 GetTopLeftUV()
+        {
+            return _context.GraphicsDevice.BackendType == GraphicsBackend.OpenGL ?
+                new Vector2(0, 1) :
+                new Vector2(0, 0);
+        }
+        private Vector2 GetBottomRightUV()
+        {
+            return _context.GraphicsDevice.BackendType == GraphicsBackend.OpenGL ?
+                new Vector2(1, 0) :
+                new Vector2(1, 1);
         }
 
         public override void Draw(ref bool isGameViewFocused)
@@ -34,8 +48,8 @@ namespace OpenSage.Viewer.UI.Views
             if (ImGui.ImageButton(
                 imagePointer,
                 ImGui.GetContentRegionAvailable(),
-                Vector2.Zero,
-                Vector2.One,
+                GetTopLeftUV(),
+                GetBottomRightUV(),
                 0,
                 Vector4.Zero,
                 Vector4.One))


### PR DESCRIPTION
The updating is required because ShaderGen was producing invalid shaders for cultures that use ',' as float seperator