### PR TITLE
Resolve z fighting issues: Fixes #106

### DIFF
--- a/src/OpenSage.Game/Graphics/Cameras/CameraComponent.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/CameraComponent.cs
@@ -24,7 +24,7 @@ namespace OpenSage.Graphics.Cameras
             _game = game;
             _frustum = new BoundingFrustum(Matrix4x4.Identity);
 
-            NearPlaneDistance = 0.125f;
+            NearPlaneDistance = 4.0f;
             FarPlaneDistance = 10000.0f;
         }
 


### PR DESCRIPTION
The near clipping plane value was way too low, meaning that the depth buffer did not have enough precision to handle rendering everything correctly. Upping it to `4.0f` makes no discernible difference in gameplay; the only difference is if you zoom in very very close to a unit (to the point where you are almost on top of it), you may see the near polygons clipped. However you are never allowed to zoom in that far in practice. Here is what the `USA02.map` stadium looks like now:

![zfightfix](https://user-images.githubusercontent.com/10756469/42431861-315bb33a-838b-11e8-9280-1d581458a0f2.png)
