### PR TITLE
Support for mono DVI ADPCM compressed .wav files

### DIFF
--- a/src/OpenSage.Game/Audio/AudioBuffer.cs
+++ b/src/OpenSage.Game/Audio/AudioBuffer.cs
@@ -22,43 +22,48 @@ namespace OpenSage.Audio
         public AudioBuffer(WavFile wavFile) : this()
         {
             int format = 0;
-
-            switch (wavFile.Channels)
+            if ((AudioFormatType) wavFile.AudioFormat != AudioFormatType.Microsoft)
             {
-                case 1:
-                    {
-                        switch (wavFile.BitsPerSample)
+                format = AL10.AL_FORMAT_MONO16;
+            }
+            else
+            {
+                switch (wavFile.Channels)
+                {
+                    case 1:
                         {
-                            case 8:
-                                format = AL10.AL_FORMAT_MONO8;
-                                break;
-                            case 16:
-                                format = AL10.AL_FORMAT_MONO16;
-                                break;
-                            default:
-                                throw new NotSupportedException("Invalid audio format!");
+                            switch (wavFile.BitsPerSample)
+                            {
+                                case 8:
+                                    format = AL10.AL_FORMAT_MONO8;
+                                    break;
+                                case 16:
+                                    format = AL10.AL_FORMAT_MONO16;
+                                    break;
+                                default:
+                                    throw new NotSupportedException("Invalid audio format!");
+                            }
                         }
-                    }
-                    break;
-                case 2:
-                    {
-                        switch (wavFile.BitsPerSample)
+                        break;
+                    case 2:
                         {
-                            case 8:
-                                format = AL10.AL_FORMAT_STEREO8;
-                                break;
-                            case 16:
-                                format = AL10.AL_FORMAT_STEREO16;
-                                break;
-                            default:
-                                throw new NotSupportedException("Invalid audio format!");
+                            switch (wavFile.BitsPerSample)
+                            {
+                                case 8:
+                                    format = AL10.AL_FORMAT_STEREO8;
+                                    break;
+                                case 16:
+                                    format = AL10.AL_FORMAT_STEREO16;
+                                    break;
+                                default:
+                                    throw new NotSupportedException("Invalid audio format!");
+                            }
                         }
-                    }
-                    break;
+                        break;
+                }
             }
 
-
-            AL10.alBufferData(_handle, format, wavFile.Buffer, wavFile.Size, wavFile.Fequency);
+            AL10.alBufferData(_handle, format, wavFile.Buffer, wavFile.Size, wavFile.Frequency);
             AudioSystem.alCheckError();
         }
 

--- a/src/OpenSage.Game/Audio/AudioBuffer.cs
+++ b/src/OpenSage.Game/Audio/AudioBuffer.cs
@@ -22,45 +22,38 @@ namespace OpenSage.Audio
         public AudioBuffer(WavFile wavFile) : this()
         {
             int format = 0;
-            if ((AudioFormatType) wavFile.AudioFormat != AudioFormatType.Microsoft)
+            switch (wavFile.Channels)
             {
-                format = AL10.AL_FORMAT_MONO16;
-            }
-            else
-            {
-                switch (wavFile.Channels)
-                {
-                    case 1:
+                case 1:
+                    {
+                        switch (wavFile.BitsPerSample)
                         {
-                            switch (wavFile.BitsPerSample)
-                            {
-                                case 8:
-                                    format = AL10.AL_FORMAT_MONO8;
-                                    break;
-                                case 16:
-                                    format = AL10.AL_FORMAT_MONO16;
-                                    break;
-                                default:
-                                    throw new NotSupportedException("Invalid audio format!");
-                            }
+                            case 8:
+                                format = AL10.AL_FORMAT_MONO8;
+                                break;
+                            case 16:
+                                format = AL10.AL_FORMAT_MONO16;
+                                break;
+                            default:
+                                throw new NotSupportedException("Invalid audio format!");
                         }
-                        break;
-                    case 2:
+                    }
+                    break;
+                case 2:
+                    {
+                        switch (wavFile.BitsPerSample)
                         {
-                            switch (wavFile.BitsPerSample)
-                            {
-                                case 8:
-                                    format = AL10.AL_FORMAT_STEREO8;
-                                    break;
-                                case 16:
-                                    format = AL10.AL_FORMAT_STEREO16;
-                                    break;
-                                default:
-                                    throw new NotSupportedException("Invalid audio format!");
-                            }
+                            case 8:
+                                format = AL10.AL_FORMAT_STEREO8;
+                                break;
+                            case 16:
+                                format = AL10.AL_FORMAT_STEREO16;
+                                break;
+                            default:
+                                throw new NotSupportedException("Invalid audio format!");
                         }
-                        break;
-                }
+                    }
+                    break;
             }
 
             AL10.alBufferData(_handle, format, wavFile.Buffer, wavFile.Size, wavFile.Frequency);

--- a/src/OpenSage.Game/Data/Wav/WavFile.cs
+++ b/src/OpenSage.Game/Data/Wav/WavFile.cs
@@ -180,7 +180,7 @@ namespace OpenSage.Data.Wav
                 throw new InvalidDataException("Invalid .wav DVI ADPCM data!");
             }
             int numBlocks = size / blockSize;
-            var buffer = new byte[samplesPerBlock * 4 * numBlocks];
+            var buffer = new byte[samplesPerBlock * 2 * numBlocks];
             using (var memoryStream = new MemoryStream(buffer))
             using (var writer = new BinaryWriter(memoryStream))
             {

--- a/src/OpenSage.Game/Data/Wav/WavFile.cs
+++ b/src/OpenSage.Game/Data/Wav/WavFile.cs
@@ -5,6 +5,13 @@ using System.Text;
 
 namespace OpenSage.Data.Wav
 {
+    // Supported WAV compression formats
+    enum AudioFormatType : UInt16
+    {
+        Microsoft = 0x01,
+        DviAdpcm  = 0x11,
+    }
+
     struct RiffHeader
     {
         public char[] ChunkId;
@@ -17,6 +24,11 @@ namespace OpenSage.Data.Wav
             header.ChunkId = reader.ReadChars(4);
             header.ChunkSize = reader.ReadUInt32();
             header.Format = reader.ReadChars(4);
+            if (new string(header.ChunkId) != "RIFF" ||
+                new string(header.Format) != "WAVE")
+            {
+                throw new InvalidDataException("Invalid or missing .wav file header!");
+            }
             return header;
         }
     }
@@ -31,11 +43,17 @@ namespace OpenSage.Data.Wav
         public UInt32 ByteRate;
         public UInt16 BlockAlign;
         public UInt16 BitsPerSample;
+        public UInt16 ExtraBytesSize; // Only used in certain compressed formats
+        public byte[] ExtraBytes; // Only used in certain compressed formats
 
         public static WaveFormat Parse(BinaryReader reader)
         {
             var format = new WaveFormat();
             format.SubChunkID = reader.ReadChars(4);
+            if (new string(format.SubChunkID) != "fmt ")
+            {
+                throw new InvalidDataException("Invalid or missing .wav file format chunk!");
+            }
             format.SubChunkSize = reader.ReadUInt32();
             format.AudioFormat = reader.ReadUInt16();
             format.NumChannels = reader.ReadUInt16();
@@ -43,9 +61,57 @@ namespace OpenSage.Data.Wav
             format.ByteRate = reader.ReadUInt32();
             format.BlockAlign = reader.ReadUInt16();
             format.BitsPerSample = reader.ReadUInt16();
+            switch ((AudioFormatType) format.AudioFormat)
+            {
+                case AudioFormatType.Microsoft:
+                    format.ExtraBytesSize = 0;
+                    format.ExtraBytes = new byte[0];
+                    break;
+                case AudioFormatType.DviAdpcm:
+                    if (format.NumChannels != 1)
+                    {
+                        throw new NotSupportedException("Only single channel DVI ADPCM compressed .wavs are supported.");
+                    }
+                    format.ExtraBytesSize = reader.ReadUInt16();
+                    if (format.ExtraBytesSize != 2)
+                    {
+                        throw new InvalidDataException("Invalid .wav DVI ADPCM format!");
+                    }
+                    format.ExtraBytes = reader.ReadBytes(format.ExtraBytesSize);
+                    break;
+                default:
+                    throw new NotSupportedException("Invalid or unknown .wav compression format!");
+            }
             return format;
         }
     };
+
+    struct WaveFact
+    {
+        public char[] SubChunkID;
+        public UInt32 SubChunkSize;
+        // Technically this chunk could contain arbitrary data. But in practice
+        // it only ever contains a single UInt32 representing the number of
+        // samples.
+        public UInt32 NumSamples;
+
+        public static WaveFact Parse(BinaryReader reader)
+        {
+            var fact = new WaveFact();
+            fact.SubChunkID = reader.ReadChars(4);
+            if (new string(fact.SubChunkID) != "fact")
+            {
+                throw new InvalidDataException("Invalid or missing .wav file fact chunk!");
+            }
+            fact.SubChunkSize = reader.ReadUInt32();
+            if (fact.SubChunkSize != 4)
+            {
+                throw new NotSupportedException("Invalid or unknown .wav compression format!");
+            }
+            fact.NumSamples = reader.ReadUInt32();
+            return fact;
+        }
+    }
 
     struct WaveData
     {
@@ -56,6 +122,10 @@ namespace OpenSage.Data.Wav
         {
             var data = new WaveData();
             data.SubChunkID = reader.ReadChars(4);
+            if (new string(data.SubChunkID) != "data")
+            {
+                throw new InvalidDataException("Invalid or missing .wav file data chunk!");
+            }
             data.SubChunkSize = reader.ReadUInt32();
             return data;
         }
@@ -65,51 +135,118 @@ namespace OpenSage.Data.Wav
     {
         private RiffHeader _header;
         private WaveFormat _format;
+        private WaveFact _fact;
         private WaveData _data;
         private byte[] _buffer;
 
-        public int Size =>  (int)_data.SubChunkSize;
-        public int Fequency => (int)_format.SampleRate;
+        public int Size => _buffer.Length;
+        public int Frequency => (int)_format.SampleRate;
+        public int AudioFormat => _format.AudioFormat;
         public int Channels => _format.NumChannels;
         public int BitsPerSample => _format.BitsPerSample;
         public byte[] Buffer => _buffer;
 
+        private int ByteToInt16(byte[] packed)
+        {
+            // This is always little endian, unlike the C# builtin for unpacking a byte array.
+            return (packed[1] << 8) | packed[0];
+        }
+
+        private byte[] ParseMicrosoft(BinaryReader reader, int size)
+        {
+            return reader.ReadBytes(size);
+        }
+        
+        private byte[] ParseDviAdpcm(BinaryReader reader, int size, int samplesPerBlock)
+        {
+            var imaIndexTable = new int[16] {
+              -1, -1, -1, -1, 2, 4, 6, 8,
+              -1, -1, -1, -1, 2, 4, 6, 8
+            };
+            var imaStepTable = new int[89] {
+              7, 8, 9, 10, 11, 12, 13, 14, 16, 17,
+              19, 21, 23, 25, 28, 31, 34, 37, 41, 45,
+              50, 55, 60, 66, 73, 80, 88, 97, 107, 118,
+              130, 143, 157, 173, 190, 209, 230, 253, 279, 307,
+              337, 371, 408, 449, 494, 544, 598, 658, 724, 796,
+              876, 963, 1060, 1166, 1282, 1411, 1552, 1707, 1878, 2066,
+              2272, 2499, 2749, 3024, 3327, 3660, 4026, 4428, 4871, 5358,
+              5894, 6484, 7132, 7845, 8630, 9493, 10442, 11487, 12635, 13899,
+              15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767
+            };
+            int blockSize = (4 + (samplesPerBlock - 1) / 2);
+            if (size % blockSize != 0)
+            {
+                throw new InvalidDataException("Invalid .wav DVI ADPCM data!");
+            }
+            int numBlocks = size / blockSize;
+            var buffer = new byte[samplesPerBlock * 4 * numBlocks];
+            using (var memoryStream = new MemoryStream(buffer))
+            using (var writer = new BinaryWriter(memoryStream))
+            {
+                for (int i = 0; i < numBlocks; i++)
+                {
+                    int sample = reader.ReadInt16();
+                    int stepTableIndex = reader.ReadByte();
+                    byte reserved = reader.ReadByte(); // unused, commonly 0
+                    int step = imaStepTable[stepTableIndex];
+                    writer.Write((Int16) sample);
+                    for (int j = 0; j < (samplesPerBlock - 1) / 2; j++)
+                    {
+                        byte packed = reader.ReadByte();
+                        byte nibble_low = (byte) (packed & 0xF);
+                        byte nibble_high = (byte) (packed >> 4);
+                        foreach (var nibble in new byte[] { nibble_low , nibble_high })
+                        {
+                            stepTableIndex += imaIndexTable[nibble];
+                            if (stepTableIndex > 88) stepTableIndex = 88;
+                            if (stepTableIndex < 0) stepTableIndex = 0;
+                            byte sign = (byte) (nibble & 8);
+                            byte delta = (byte) (nibble & 7);
+                            int diff = step >> 3;
+                            if ((delta & 4) != 0) diff += step;
+                            if ((delta & 2) != 0) diff += (step >> 1);
+                            if ((delta & 1) != 0) diff += (step >> 2);
+                            if (sign != 0) sample -= diff;
+                            else sample += diff;
+                            step = imaStepTable[stepTableIndex];
+                            if (sample > 0xFFFF) sample = 0xFFFF;
+                            if (sample < -0xFFFF) sample = -0xFFFF;
+                            writer.Write((Int16) sample);
+                        }
+                    }
+                }
+            }
+            return buffer;
+        }
+
         public void Parse(BinaryReader reader)
         {
             _header = RiffHeader.Parse(reader);
-
-            if (new string(_header.ChunkId) != "RIFF" ||
-                new string(_header.Format) != "WAVE")
-            {
-                throw new InvalidDataException("Invalid .wav file!");
-            }
-
             _format = WaveFormat.Parse(reader);
 
-            if (new string(_format.SubChunkID)!="fmt ")
+            // Every format except the original Microsoft format must have a fact chunk
+            if ((AudioFormatType) _format.AudioFormat != AudioFormatType.Microsoft)
             {
-                throw new InvalidDataException("Invalid .wav file!");
+                _fact = WaveFact.Parse(reader);
             }
 
-            if(_format.AudioFormat!=1)
-            {
-                throw new NotSupportedException("Invalid .wav compression!");
-            }
-
-            //probably a compressed format
-            if (_format.SubChunkSize > 16)
-            {
-                reader.BaseStream.Seek(_format.SubChunkSize - 16, SeekOrigin.Current);
-            }
-                
             _data = WaveData.Parse(reader);
-
-            if (new string(_data.SubChunkID) != "data")
+            switch ((AudioFormatType) _format.AudioFormat)
             {
-                throw new InvalidDataException("Invalid .wav file!");
+                case AudioFormatType.Microsoft:
+                    _buffer = ParseMicrosoft(reader, (int) _data.SubChunkSize);
+                    break;
+                case AudioFormatType.DviAdpcm:
+                    _buffer = ParseDviAdpcm(reader,
+                                            (int) _data.SubChunkSize,
+                                            ByteToInt16(_format.ExtraBytes));
+                    break;
+                default:
+                    // Should never happen (since it should throw on parse)
+                    _buffer = new byte[0];
+                    throw new NotSupportedException("Invalid or unknown .wav compression format!");
             }
-
-            _buffer = reader.ReadBytes((int)_data.SubChunkSize);
         }
 
         public static WavFile FromFileSystemEntry(FileSystemEntry entry)

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -13,7 +13,7 @@ namespace OpenSage.Launcher
         public static void Main(string[] args)
         {
             var noShellMap = false;
-            var definition = GameDefinition.FromGame(SageGame.CncGenerals);
+            var definition = GameDefinition.FromGame(SageGame.CncGeneralsZeroHour);
             string mapName = null;
             GraphicsBackend? preferredBackend = null;
 

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -13,7 +13,7 @@ namespace OpenSage.Launcher
         public static void Main(string[] args)
         {
             var noShellMap = false;
-            var definition = GameDefinition.FromGame(SageGame.CncGeneralsZeroHour);
+            var definition = GameDefinition.FromGame(SageGame.CncGenerals);
             string mapName = null;
             GraphicsBackend? preferredBackend = null;
 


### PR DESCRIPTION
Some C&C Generals sounds are stored in a compressed format known as DVI (or IMA) ADPCM. One such example is `Data\Audio\Sounds\ctrustaa.wav`, which would previously cause a crash in the viewer when played. Since OpenAL does not support the format, we implement an on-the-fly decoder to unpack the compression into a linear PCM format that OpenAL can play. Note this commit only supports single channel files of this type, although supporting multiple channels should not be too hard (I haven't found any of these types of sounds yet though).

Uses
https://icculus.org/SDL_sound/downloads/external_documentation/wavecomp.htm
https://wiki.multimedia.cx/index.php/IMA_ADPCM
as references.