### PR TITLE
Increase ImageSharp version to beta 4

### DIFF
--- a/src/OpenSage.Game/OpenSage.Game.csproj
+++ b/src/OpenSage.Game/OpenSage.Game.csproj
@@ -19,8 +19,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
     <PackageReference Include="OpenAL-CS" Version="1.0.11" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0003" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0003" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0004" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0004" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="ShaderGen.Primitives" Version="$(ShaderGenVersion)" />


### PR DESCRIPTION
I recgnized a bug in the linux version of OpenSAGE. 

> Unhandled Exception: System.MissingMethodException: Method not found: 'System.Span`1<!!1> System.MemoryExtensions.NonPortableCast(System.Span`1<SixLabors.ImageSharp.PixelFormats.Rgba32>)'.
   at SixLabors.ImageSharp.Image.LoadPixelData[TPixel](Configuration config, Byte[] data, Int32 width, Int32 height)
   at OpenSage.Content.TextureLoader.CreateTextureFromTga(GraphicsDevice graphicsDevice, TgaFile tgaFile, Boolean generateMipMaps) in /home/patrick/Workspace/OpenSAGE/src/OpenSage.Game/Content/TextureLoader.cs:line 93
   at OpenSage.Content.TextureLoader.LoadEntry(FileSystemEntry entry, ContentManager contentManager, Game game, LoadOptions loadOptions) in /home/patrick/Workspace/OpenSAGE/src/OpenSage.Game/Content/TextureLoader.cs:line 62
   at OpenSage.Content.ContentLoader`1.Load(FileSystemEntry entry, ContentManager contentManager, Game game, LoadOptions loadOptions) in /home/patrick/Workspace/OpenSAGE/src/OpenSage.Game/Content/ContentLoader`1.cs:line 9
   at OpenSage.Content.ContentManager.Load[T](String filePath, LoadOptions options, Boolean fallbackToPlaceholder) in /home/patrick/Workspace/OpenSAGE/src/OpenSage.Game/Content/ContentManager.cs:line 214
   at OpenSage.Viewer.UI.Views.TgaView.GetTexture(AssetViewContext context) in /home/patrick/Workspace/OpenSAGE/src/OpenSage.Viewer/UI/Views/TgaView.cs:line 15
   at OpenSage.Viewer.UI.Views.ImageView..ctor(AssetViewContext context) in /home/patrick/Workspace/OpenSAGE/src/OpenSage.Viewer/UI/Views/ImageView.cs:line 22
   at OpenSage.Viewer.UI.Views.TgaView..ctor(AssetViewContext context) in /home/patrick/Workspace/OpenSAGE/src/OpenSage.Viewer/UI/Views/TgaView.cs:line 8
   at OpenSage.Viewer.UI.ContentView.CreateViewForFileSystemEntry(AssetViewContext context) in /home/patrick/Workspace/OpenSAGE/src/OpenSage.Viewer/UI/ContentView.cs:line 55
   at OpenSage.Viewer.UI.ContentView..ctor(AssetViewContext context) in /home/patrick/Workspace/OpenSAGE/src/OpenSage.Viewer/UI/ContentView.cs:line 16
   at OpenSage.Viewer.UI.MainForm.DrawMainUi(Boolean& isGameViewFocused) in /home/patrick/Workspace/OpenSAGE/src/OpenSage.Viewer/UI/MainForm.cs:line 109
   at OpenSage.Viewer.UI.MainForm.Draw(Boolean& isGameViewFocused) in /home/patrick/Workspace/OpenSAGE/src/OpenSage.Viewer/UI/MainForm.cs:line 222
   at OpenSage.Viewer.Program.Main(String[] args) in /home/patrick/Workspace/OpenSAGE/src/OpenSage.Viewer/Program.cs:line 87

An increase of the ImageSharp version to beta 4 should fix this.