### PR TITLE
Replace commandline parser

### DIFF
--- a/src/OpenSage.Launcher/OpenSage.Launcher.csproj
+++ b/src/OpenSage.Launcher/OpenSage.Launcher.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-26228-01" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180220-2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.CommandLine;
 using System.Linq;
+using CommandLine;
 using OpenSage.Data;
 using OpenSage.Mods.BuiltIn;
 using OpenSage.Network;
@@ -10,45 +10,43 @@ namespace OpenSage.Launcher
 {
     public static class Program
     {
+        //must match Veldrid.GraphicsBackends. Can be removed once nullable enums work
+        public enum Renderer : byte
+        {
+            Direct3D11 = 0,
+            Vulkan = 1,
+            OpenGL = 2,
+            Metal = 3,
+            OpenGLES = 4,
+            Default
+        }
+
+        public class Options
+        {
+            //use a string since nullable enums aren't working yet
+            [Option('r', "renderer", Default = Renderer.Default, Required = false, HelpText = "Set the renderer backend.")]
+            public Renderer Renderer { get; set; }
+
+            [Option("noshellmap", Default = false, Required = false, HelpText = "Disables loading the shell map, speeding up startup time.")]
+            public bool NoShellmap { get; set; }
+
+            [Option('g', "game", Default = SageGame.CncGenerals, Required = false, HelpText = "Chooses which game to start.")]
+            public SageGame Game { get; set; }
+
+            [Option('m', "map", Required = false, HelpText = "Immediately starts a new skirmish with default settings in the specified map. The map file must be specified with the full pathf.")]
+            public string Map { get; set; }
+        }
+
         public static void Main(string[] args)
         {
-            var noShellMap = false;
-            var definition = GameDefinition.FromGame(SageGame.CncGenerals);
-            string mapName = null;
+            CommandLine.Parser.Default.ParseArguments<Options>(args)
+              .WithParsed<Options>(opts => Run(opts));
+        }
+
+        public static void Run(Options opts)
+        {
+            var definition = GameDefinition.FromGame(opts.Game);
             GraphicsBackend? preferredBackend = null;
-
-            ArgumentSyntax.Parse(args, syntax =>
-            {
-                string preferredBackendString = null;
-                syntax.DefineOption("renderer", ref preferredBackendString, false, $"Choose which renderer backend should be used. Valid options: {string.Join(",", Enum.GetNames(typeof(GraphicsBackend)))}");
-                if (preferredBackendString != null)
-                {
-                    if (Enum.TryParse<GraphicsBackend>(preferredBackendString, out var preferredBackendTemp))
-                    {
-                        preferredBackend = preferredBackendTemp;
-                    }
-                    else
-                    {
-                        syntax.ReportError($"Unknown renderer backend: {preferredBackendString}");
-                    }
-                }
-
-                syntax.DefineOption("noshellmap", ref noShellMap, false, "Disables loading the shell map, speeding up startup time.");
-
-                string gameName = null;
-                var availableGames = string.Join(", ", GameDefinition.All.Select(def => def.Game.ToString()));
-
-                syntax.DefineOption("game", ref gameName, false, $"Chooses which game to start. Valid options: {availableGames}");
-
-                // If a game has been specified, make sure it's valid.
-                if (gameName != null && !GameDefinition.TryGetByName(gameName, out definition))
-                {
-                    syntax.ReportError($"Unknown game: {gameName}");
-                }
-
-                syntax.DefineOption("map", ref mapName, false,
-                    "Immediately starts a new skirmish with default settings in the specified map. The map file must be specified with the full path.");
-            });
 
             var installation = GameInstallation
                 .FindAll(new[] { definition })
@@ -67,6 +65,11 @@ namespace OpenSage.Launcher
                 Environment.Exit(1);
             }
 
+            if (opts.Renderer != Renderer.Default)
+            {
+                preferredBackend = (GraphicsBackend) opts.Renderer;
+            }
+
             Platform.Start();
 
             // TODO: Read game version from assembly metadata or .git folder
@@ -75,15 +78,15 @@ namespace OpenSage.Launcher
             using (var gamePanel = GamePanel.FromGameWindow(window))
             using (var game = GameFactory.CreateGame(installation, installation.CreateFileSystem(), gamePanel))
             {
-                game.Configuration.LoadShellMap = !noShellMap;
+                game.Configuration.LoadShellMap = !opts.NoShellmap;
 
-                if (mapName == null)
+                if (opts.Map == null)
                 {
                     game.ShowMainMenu();
                 }
                 else
                 {
-                    game.StartGame(mapName, new EchoConnection(), new[] { "America", "GLA" }, 0);
+                    game.StartGame(opts.Map, new EchoConnection(), new[] { "America", "GLA" }, 0);
                 }
 
                 while (game.IsRunning)

--- a/src/OpenSage.Viewer/OpenSage.Viewer.csproj
+++ b/src/OpenSage.Viewer/OpenSage.Viewer.csproj
@@ -18,9 +18,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Microsoft.Packaging.Tools.Trimming" Version="1.1.0-preview1-26228-01" />
     <PackageReference Include="Veldrid.ImGui" Version="$(VeldridVersion)" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180220-2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The commandline parser we used previously was declared as "System.Commandline" parser, but was actually a private project (see [here](https://www.nuget.org/packages/System.CommandLine/1.0.0.4)). The project is still available [here](https://github.com/deniszykov/commandline).

Instead of changing to the new repository i decided to switch to the much more used commandline parser. It has a much nicer api and allows short/long options etc. It can directly parse Enums from the arguments. Overall i think it's the better choice for future development.