### PR TITLE
[WIP] Compile launcher and viewer into native binaries

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/OpenSage.Game.Tests/bin/Debug/netcoreapp2.0/OpenSage.Game.Tests.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/OpenSage.Game.Tests",
+            // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ,]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/OpenSage.Game.Tests/OpenSage.Game.Tests.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/OpenSage.Game.Shaders.Shared/OpenSage.Game.Shaders.Shared.csproj
+++ b/src/OpenSage.Game.Shaders.Shared/OpenSage.Game.Shaders.Shared.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>OpenSage.Graphics.Shaders</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Veldrid" Version="$(VeldridVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/OpenSage.Game/Data/Ini/BitArray`1.cs
+++ b/src/OpenSage.Game/Data/Ini/BitArray`1.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 namespace OpenSage.Data.Ini
 {
     public sealed class BitArrayEqualityComparer<TEnum> : IEqualityComparer<BitArray<TEnum>>
-        where TEnum : struct
+        where TEnum : Enum
     {
         public bool Equals(BitArray<TEnum> x, BitArray<TEnum> y)
         {
@@ -20,7 +20,7 @@ namespace OpenSage.Data.Ini
 
     // TODO: Don't use .NET's BitArray as the internal implementation.
     public sealed class BitArray<TEnum>
-        where TEnum : struct
+        where TEnum : Enum
     {
         private static readonly int NumValues = Enum.GetValues(typeof(TEnum)).Length;
 

--- a/src/OpenSage.Game/Data/Ini/Parser/IniParser.Attributes.cs
+++ b/src/OpenSage.Game/Data/Ini/Parser/IniParser.Attributes.cs
@@ -58,7 +58,7 @@ namespace OpenSage.Data.Ini.Parser
         }
 
         public T ParseAttributeEnum<T>(string label)
-            where T : struct
+            where T : struct, IConvertible
         {
             return ParseAttribute(label, x => ParseEnum<T>(x));
         }

--- a/src/OpenSage.Game/Data/Ini/Parser/IniParser.Attributes.cs
+++ b/src/OpenSage.Game/Data/Ini/Parser/IniParser.Attributes.cs
@@ -58,7 +58,7 @@ namespace OpenSage.Data.Ini.Parser
         }
 
         public T ParseAttributeEnum<T>(string label)
-            where T : struct, IConvertible
+            where T : Enum
         {
             return ParseAttribute(label, x => ParseEnum<T>(x));
         }

--- a/src/OpenSage.Game/Data/Ini/Parser/IniParser.Enums.cs
+++ b/src/OpenSage.Game/Data/Ini/Parser/IniParser.Enums.cs
@@ -97,12 +97,15 @@ namespace OpenSage.Data.Ini.Parser
         }
 
         public static Dictionary<string, Enum> GetEnumMap<T>()
-            where T : struct, IConvertible
+            where T : Enum
         {
             var enumType = typeof(T);
 
             if (!CachedEnumMap.TryGetValue(enumType, out var stringToValueMap))
             {
+                Console.WriteLine("<Type Name=\"" + enumType.ToString() + "\" Dynamic=\"Required All\" />");
+                Console.WriteLine("<Type Name=\"" + enumType.ToString() + "[]\" Dynamic=\"Required All\" />");
+
                 lock (CachedEnumMap)
                 {
                     stringToValueMap = Enum.GetValues(enumType)
@@ -123,7 +126,7 @@ namespace OpenSage.Data.Ini.Parser
         }
 
         private T ParseEnum<T>(Dictionary<string, T> stringToValueMap)
-            where T : struct, IConvertible
+            where T : Enum
         {
             var token = GetNextToken();
 
@@ -134,13 +137,13 @@ namespace OpenSage.Data.Ini.Parser
         }
 
         public T ParseEnum<T>()
-            where T : struct, IConvertible
+            where T : Enum
         {
             return ParseEnum<T>(GetNextToken());
         }
 
         public static T ParseEnum<T>(IniToken token)
-            where T : struct, IConvertible
+            where T : Enum
         {
             var stringToValueMap = GetEnumMap<T>();
 
@@ -151,7 +154,7 @@ namespace OpenSage.Data.Ini.Parser
         }
 
         public T ParseEnumFlags<T>()
-            where T : struct, IConvertible
+            where T : Enum
         {
             var stringToValueMap = GetEnumMap<T>();
 
@@ -171,7 +174,7 @@ namespace OpenSage.Data.Ini.Parser
         }
 
         public BitArray<T> ParseEnumBitArray<T>()
-            where T : struct, IConvertible
+            where T : Enum
         {
             var stringToValueMap = GetEnumMap<T>();
 

--- a/src/OpenSage.Game/Data/Ini/Parser/IniParser.Enums.cs
+++ b/src/OpenSage.Game/Data/Ini/Parser/IniParser.Enums.cs
@@ -97,9 +97,10 @@ namespace OpenSage.Data.Ini.Parser
         }
 
         public static Dictionary<string, Enum> GetEnumMap<T>()
-            where T : struct
+            where T : struct, IConvertible
         {
             var enumType = typeof(T);
+
             if (!CachedEnumMap.TryGetValue(enumType, out var stringToValueMap))
             {
                 lock (CachedEnumMap)
@@ -122,7 +123,7 @@ namespace OpenSage.Data.Ini.Parser
         }
 
         private T ParseEnum<T>(Dictionary<string, T> stringToValueMap)
-            where T : struct
+            where T : struct, IConvertible
         {
             var token = GetNextToken();
 
@@ -133,13 +134,13 @@ namespace OpenSage.Data.Ini.Parser
         }
 
         public T ParseEnum<T>()
-            where T : struct
+            where T : struct, IConvertible
         {
             return ParseEnum<T>(GetNextToken());
         }
 
         public static T ParseEnum<T>(IniToken token)
-            where T : struct
+            where T : struct, IConvertible
         {
             var stringToValueMap = GetEnumMap<T>();
 
@@ -150,7 +151,7 @@ namespace OpenSage.Data.Ini.Parser
         }
 
         public T ParseEnumFlags<T>()
-            where T : struct
+            where T : struct, IConvertible
         {
             var stringToValueMap = GetEnumMap<T>();
 
@@ -170,7 +171,7 @@ namespace OpenSage.Data.Ini.Parser
         }
 
         public BitArray<T> ParseEnumBitArray<T>()
-            where T : struct
+            where T : struct, IConvertible
         {
             var stringToValueMap = GetEnumMap<T>();
 

--- a/src/OpenSage.Launcher/OpenSage.Launcher.csproj
+++ b/src/OpenSage.Launcher/OpenSage.Launcher.csproj
@@ -13,7 +13,7 @@
   
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
-    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-27102-02" />
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-27128-02" />
     <RdXmlFile Include="rd.xml" />
   </ItemGroup>
 

--- a/src/OpenSage.Launcher/OpenSage.Launcher.csproj
+++ b/src/OpenSage.Launcher/OpenSage.Launcher.csproj
@@ -5,8 +5,6 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;osx-64;ubuntu-x64</RuntimeIdentifiers>
     <ApplicationIcon>Resources\AppIcon.ico</ApplicationIcon>
-    <TrimUnusedDependencies>true</TrimUnusedDependencies>
-    <RootPackageReference>false</RootPackageReference>
   </PropertyGroup>
   
   <ItemGroup>
@@ -15,6 +13,8 @@
   
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-27102-02" />
+    <RdXmlFile Include="rd.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -8,35 +8,35 @@ using Veldrid;
 
 namespace OpenSage.Launcher
 {
+    //must match Veldrid.GraphicsBackends. Can be removed once nullable enums work
+    public enum Renderer : byte
+    {
+        Direct3D11 = 0,
+        Vulkan = 1,
+        OpenGL = 2,
+        Metal = 3,
+        OpenGLES = 4,
+        Default
+    }
+
+    public class Options
+    {
+        //use a string since nullable enums aren't working yet
+        [Option('r', "renderer", Default = Renderer.Default, Required = false, HelpText = "Set the renderer backend.")]
+        public Renderer Renderer { get; set; }
+
+        [Option("noshellmap", Default = false, Required = false, HelpText = "Disables loading the shell map, speeding up startup time.")]
+        public bool NoShellmap { get; set; }
+
+        [Option('g', "game", Default = SageGame.CncGenerals, Required = false, HelpText = "Chooses which game to start.")]
+        public SageGame Game { get; set; }
+
+        [Option('m', "map", Required = false, HelpText = "Immediately starts a new skirmish with default settings in the specified map. The map file must be specified with the full pathf.")]
+        public string Map { get; set; }
+    }
+
     public static class Program
     {
-        //must match Veldrid.GraphicsBackends. Can be removed once nullable enums work
-        public enum Renderer : byte
-        {
-            Direct3D11 = 0,
-            Vulkan = 1,
-            OpenGL = 2,
-            Metal = 3,
-            OpenGLES = 4,
-            Default
-        }
-
-        public class Options
-        {
-            //use a string since nullable enums aren't working yet
-            [Option('r', "renderer", Default = Renderer.Default, Required = false, HelpText = "Set the renderer backend.")]
-            public Renderer Renderer { get; set; }
-
-            [Option("noshellmap", Default = false, Required = false, HelpText = "Disables loading the shell map, speeding up startup time.")]
-            public bool NoShellmap { get; set; }
-
-            [Option('g', "game", Default = SageGame.CncGenerals, Required = false, HelpText = "Chooses which game to start.")]
-            public SageGame Game { get; set; }
-
-            [Option('m', "map", Required = false, HelpText = "Immediately starts a new skirmish with default settings in the specified map. The map file must be specified with the full pathf.")]
-            public string Map { get; set; }
-        }
-
         public static void Main(string[] args)
         {
             CommandLine.Parser.Default.ParseArguments<Options>(args)

--- a/src/OpenSage.Launcher/rd.xml
+++ b/src/OpenSage.Launcher/rd.xml
@@ -1,0 +1,131 @@
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+    <Application>
+        <Assembly Name="OpenSage.Launcher">
+            <Type Name="OpenSage.Launcher.Options" Dynamic="Required All" />
+        </Assembly>
+
+        <Assembly Name="SharpDX" >
+            <Type Name="SharpDX.ShadowAttribute" Dynamic="Required All" />
+            <Type Name="SharpDX.ShadowContainer" Dynamic="Required All" />
+            <Type Name="SharpDX.ComObjectShadow" Dynamic="Required All" />
+            <Type Name="SharpDX.CppObjectShadow" Dynamic="Required All" />
+            <Type Name="SharpDX.ComObject" Dynamic="Required All" />
+            <Type Name="SharpDX.CppObject" Dynamic="Required All" />
+            <Type Name="SharpDX.Win32.ComStreamProxy" Dynamic="Required All" />
+            <Type Name="SharpDX.Win32.ComStreamShadow" Dynamic="Required All" />
+        </Assembly>
+
+        <Assembly Name="SharpDX.DXGI">
+            <Type Name="SharpDX.DXGI.Device" Dynamic="Required All" />
+        </Assembly>
+
+        <Assembly Name="SharpDX.Direct3D11">
+            <Type Name="SharpDX.Direct3D11.Texture2D" Dynamic="Required All" />
+            <Type Name="SharpDX.Direct3D11.DeviceContext1" Dynamic="Required All" />
+            <Type Name="SharpDX.Direct3D11.DeviceDebug" Dynamic="Required All" />
+        </Assembly>
+
+        <Assembly Name="System.Linq.Expressions">
+            <Type Name="System.Linq.Expressions.ExpressionCreator`1[[Newtonsoft.Json.Serialization.ObjectConstructor`1[[System.Object,System.Private.CoreLib]],Newtonsoft.Json]]" Dynamic="Required All" />
+            <Type Name="System.Linq.Expressions.ExpressionCreator`1[[System.Func`2[[System.Object,System.Private.CoreLib],[System.Object,System.Private.CoreLib]],System.Private.CoreLib]]" Dynamic="Required All" />
+        </Assembly>
+
+        <Assembly Name="Newtonsoft.Json"  Dynamic="Required All" />
+        <Assembly Name="Commandline" Dynamic="Required All" />
+
+        <Assembly Name="OpenSage.Game">
+            <Type Name="OpenSage.Data.Ini.TerrainLod" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.TerrainLod[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Map.TimeOfDay" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Map.TimeOfDay[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Map.MapWeatherType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Map.MapWeatherType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.BodyDamageType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.BodyDamageType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.WeaponBonusType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.WeaponBonusType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.WeaponBonusAttributeType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.WeaponBonusAttributeType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleSystemPriority" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleSystemPriority[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleSystemShader" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleSystemShader[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleSystemType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleSystemType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleVelocityType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleVelocityType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleVolumeType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleVolumeType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleSystemWindMotion" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleSystemWindMotion[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectBuildableType" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectBuildableType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectEditorSortingFlags" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectEditorSortingFlags[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.WeaponSetConditions" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.WeaponSetConditions[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.WeaponSlot" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.WeaponSlot[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ArmorSetCondition" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ArmorSetCondition[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.RadarPriority" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.RadarPriority[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ObjectKinds" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ObjectKinds[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectGeometry" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectGeometry[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectShadowType" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectShadowType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ObjectDisposition" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ObjectDisposition[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.RadiusDecalStyle" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.RadiusDecalStyle[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ModelConditionFlag" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ModelConditionFlag[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.AnimationMode" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.AnimationMode[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.DeathType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.DeathType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.AnimationFlags" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.AnimationFlags[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.StructureCollapsePhase" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.StructureCollapsePhase[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.DamageType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.DamageType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.SlowDeathPhase" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.SlowDeathPhase[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.AutoAcquireEnemiesType" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.AutoAcquireEnemiesType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.LocomotorSet" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.LocomotorSet[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.OCLCreateLocation" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.OCLCreateLocation[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ModelLevelOfDetail" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ModelLevelOfDetail[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectStatus" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectStatus[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.CommandSourceTypes" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.CommandSourceTypes[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ChangeType" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ChangeType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.DisabledType" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.DisabledType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.VeterancyLevel" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.VeterancyLevel[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectFilterRelationship" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectFilterRelationship[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.MaxHealthChangeType" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.MaxHealthChangeType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.MappedImageStatus" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.MappedImageStatus[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.AudioPriority" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.AudioPriority[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.AudioControlFlags" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.AudioControlFlags[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.AudioTypeFlags" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.AudioTypeFlags[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.WindowTransitionStyle" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.WindowTransitionStyle[]" Dynamic="Required All" />
+        </Assembly>
+    </Application>
+</Directives>

--- a/src/OpenSage.Launcher/rd.xml
+++ b/src/OpenSage.Launcher/rd.xml
@@ -33,7 +33,7 @@
         <Assembly Name="Newtonsoft.Json"  Dynamic="Required All" />
         <Assembly Name="Commandline" Dynamic="Required All" />
 
-        <Assembly Name="OpenSage.Game">
+                <Assembly Name="OpenSage.Game">
             <Type Name="OpenSage.Data.Ini.TerrainLod" Dynamic="Required All" />
             <Type Name="OpenSage.Data.Ini.TerrainLod[]" Dynamic="Required All" />
             <Type Name="OpenSage.Data.Map.TimeOfDay" Dynamic="Required All" />
@@ -96,8 +96,8 @@
             <Type Name="OpenSage.Logic.Object.SlowDeathPhase[]" Dynamic="Required All" />
             <Type Name="OpenSage.Logic.Object.AutoAcquireEnemiesType" Dynamic="Required All" />
             <Type Name="OpenSage.Logic.Object.AutoAcquireEnemiesType[]" Dynamic="Required All" />
-            <Type Name="OpenSage.Logic.Object.LocomotorSet" Dynamic="Required All" />
-            <Type Name="OpenSage.Logic.Object.LocomotorSet[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.LocomotorSetCondition" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.LocomotorSetCondition[]" Dynamic="Required All" />
             <Type Name="OpenSage.Logic.Object.OCLCreateLocation" Dynamic="Required All" />
             <Type Name="OpenSage.Logic.Object.OCLCreateLocation[]" Dynamic="Required All" />
             <Type Name="OpenSage.Logic.Object.ModelLevelOfDetail" Dynamic="Required All" />

--- a/src/OpenSage.Viewer/OpenSage.Viewer.csproj
+++ b/src/OpenSage.Viewer/OpenSage.Viewer.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Veldrid.ImGui" Version="$(ImGuiVersion)" />
-    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-27102-02" />
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-27128-02" />
     <RdXmlFile Include="rd.xml" />
   </ItemGroup>
 

--- a/src/OpenSage.Viewer/OpenSage.Viewer.csproj
+++ b/src/OpenSage.Viewer/OpenSage.Viewer.csproj
@@ -5,13 +5,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationIcon>Resources\AppIcon.ico</ApplicationIcon>
-    <TrimUnusedDependencies>true</TrimUnusedDependencies>
-    <RootPackageReference>false</RootPackageReference>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Remove="Resources\AppIcon.ico" />
-  </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\AppIcon.ico" />
@@ -20,6 +14,8 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Veldrid.ImGui" Version="$(ImGuiVersion)" />
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-27102-02" />
+    <RdXmlFile Include="rd.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenSage.Viewer/Program.cs
+++ b/src/OpenSage.Viewer/Program.cs
@@ -8,26 +8,26 @@ using Veldrid;
 
 namespace OpenSage.Viewer
 {
-    public static class Program
+    //must match Veldrid.GraphicsBackends. Can be removed once nullable enums work
+    public enum Renderer : byte
     {
-        //must match Veldrid.GraphicsBackends. Can be removed once nullable enums work
-        public enum Renderer : byte
-        {
-            Direct3D11 = 0,
-            Vulkan = 1,
-            OpenGL = 2,
-            Metal = 3,
-            OpenGLES = 4,
-            Default
-        }
+        Direct3D11 = 0,
+        Vulkan = 1,
+        OpenGL = 2,
+        Metal = 3,
+        OpenGLES = 4,
+        Default
+    }
 
-        public class Options
-        {
-            //use a string since nullable enums aren't working yet
-            [Option('r', "renderer", Default = Renderer.Default, Required = false, HelpText = "Set the renderer backend.")]
-            public Renderer Renderer { get; set; }
-        }
+    public class Options
+    {
+        //use a string since nullable enums aren't working yet
+        [Option('r', "renderer", Default = Renderer.Default, Required = false, HelpText = "Set the renderer backend.")]
+        public Renderer Renderer { get; set; }
+    }
 
+    public static class Program
+    {   
         public static void Main(string[] args)
         {
             CommandLine.Parser.Default.ParseArguments<Options>(args)

--- a/src/OpenSage.Viewer/rd.xml
+++ b/src/OpenSage.Viewer/rd.xml
@@ -1,0 +1,131 @@
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+    <Application>
+        <Assembly Name="OpenSage.Viewer">
+            <Type Name="OpenSage.Viewer.Options" Dynamic="Required All" />
+        </Assembly>
+
+        <Assembly Name="SharpDX" >
+            <Type Name="SharpDX.ShadowAttribute" Dynamic="Required All" />
+            <Type Name="SharpDX.ShadowContainer" Dynamic="Required All" />
+            <Type Name="SharpDX.ComObjectShadow" Dynamic="Required All" />
+            <Type Name="SharpDX.CppObjectShadow" Dynamic="Required All" />
+            <Type Name="SharpDX.ComObject" Dynamic="Required All" />
+            <Type Name="SharpDX.CppObject" Dynamic="Required All" />
+            <Type Name="SharpDX.Win32.ComStreamProxy" Dynamic="Required All" />
+            <Type Name="SharpDX.Win32.ComStreamShadow" Dynamic="Required All" />
+        </Assembly>
+
+        <Assembly Name="SharpDX.DXGI">
+            <Type Name="SharpDX.DXGI.Device" Dynamic="Required All" />
+        </Assembly>
+
+        <Assembly Name="SharpDX.Direct3D11">
+            <Type Name="SharpDX.Direct3D11.Texture2D" Dynamic="Required All" />
+            <Type Name="SharpDX.Direct3D11.DeviceContext1" Dynamic="Required All" />
+            <Type Name="SharpDX.Direct3D11.DeviceDebug" Dynamic="Required All" />
+        </Assembly>
+
+        <Assembly Name="System.Linq.Expressions">
+            <Type Name="System.Linq.Expressions.ExpressionCreator`1[[Newtonsoft.Json.Serialization.ObjectConstructor`1[[System.Object,System.Private.CoreLib]],Newtonsoft.Json]]" Dynamic="Required All" />
+            <Type Name="System.Linq.Expressions.ExpressionCreator`1[[System.Func`2[[System.Object,System.Private.CoreLib],[System.Object,System.Private.CoreLib]],System.Private.CoreLib]]" Dynamic="Required All" />
+        </Assembly>
+
+        <Assembly Name="Newtonsoft.Json"  Dynamic="Required All" />
+        <Assembly Name="Commandline" Dynamic="Required All" />
+
+        <Assembly Name="OpenSage.Game">
+            <Type Name="OpenSage.Data.Ini.TerrainLod" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.TerrainLod[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Map.TimeOfDay" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Map.TimeOfDay[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Map.MapWeatherType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Map.MapWeatherType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.BodyDamageType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.BodyDamageType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.WeaponBonusType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.WeaponBonusType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.WeaponBonusAttributeType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.WeaponBonusAttributeType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleSystemPriority" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleSystemPriority[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleSystemShader" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleSystemShader[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleSystemType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleSystemType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleVelocityType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleVelocityType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleVolumeType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleVolumeType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleSystemWindMotion" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ParticleSystemWindMotion[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectBuildableType" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectBuildableType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectEditorSortingFlags" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectEditorSortingFlags[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.WeaponSetConditions" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.WeaponSetConditions[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.WeaponSlot" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.WeaponSlot[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ArmorSetCondition" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ArmorSetCondition[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.RadarPriority" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.RadarPriority[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ObjectKinds" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ObjectKinds[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectGeometry" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectGeometry[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectShadowType" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectShadowType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ObjectDisposition" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.ObjectDisposition[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.RadiusDecalStyle" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.RadiusDecalStyle[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ModelConditionFlag" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ModelConditionFlag[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.AnimationMode" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.AnimationMode[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.DeathType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.DeathType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.AnimationFlags" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.AnimationFlags[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.StructureCollapsePhase" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.StructureCollapsePhase[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.DamageType" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.DamageType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.SlowDeathPhase" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.SlowDeathPhase[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.AutoAcquireEnemiesType" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.AutoAcquireEnemiesType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.LocomotorSet" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.LocomotorSet[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.OCLCreateLocation" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.OCLCreateLocation[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ModelLevelOfDetail" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ModelLevelOfDetail[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectStatus" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectStatus[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.CommandSourceTypes" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.CommandSourceTypes[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ChangeType" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ChangeType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.DisabledType" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.DisabledType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.VeterancyLevel" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.VeterancyLevel[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectFilterRelationship" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.ObjectFilterRelationship[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.MaxHealthChangeType" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.MaxHealthChangeType[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.MappedImageStatus" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.MappedImageStatus[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.AudioPriority" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.AudioPriority[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.AudioControlFlags" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.AudioControlFlags[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.AudioTypeFlags" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.AudioTypeFlags[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.WindowTransitionStyle" Dynamic="Required All" />
+            <Type Name="OpenSage.Data.Ini.WindowTransitionStyle[]" Dynamic="Required All" />
+        </Assembly>
+    </Application>
+</Directives>

--- a/src/OpenSage.Viewer/rd.xml
+++ b/src/OpenSage.Viewer/rd.xml
@@ -96,8 +96,8 @@
             <Type Name="OpenSage.Logic.Object.SlowDeathPhase[]" Dynamic="Required All" />
             <Type Name="OpenSage.Logic.Object.AutoAcquireEnemiesType" Dynamic="Required All" />
             <Type Name="OpenSage.Logic.Object.AutoAcquireEnemiesType[]" Dynamic="Required All" />
-            <Type Name="OpenSage.Logic.Object.LocomotorSet" Dynamic="Required All" />
-            <Type Name="OpenSage.Logic.Object.LocomotorSet[]" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.LocomotorSetCondition" Dynamic="Required All" />
+            <Type Name="OpenSage.Logic.Object.LocomotorSetCondition[]" Dynamic="Required All" />
             <Type Name="OpenSage.Logic.Object.OCLCreateLocation" Dynamic="Required All" />
             <Type Name="OpenSage.Logic.Object.OCLCreateLocation[]" Dynamic="Required All" />
             <Type Name="OpenSage.Logic.Object.ModelLevelOfDetail" Dynamic="Required All" />


### PR DESCRIPTION
Use CoreRT to compile the Viewer and the Launcher into a single native executable for publishing. This reduces the overall size of the binaries and should allow greater speed. There are still some open issues though:

- [ ] Evaluate if the `rd.xml` (used for reflection) can be put into a shared project (OpenSage.Game).
- [ ] Try building OpenSage.Game as a shared native library and reuse that for the Viewer and Launcher
- [ ] Measure if there are any performance benefits
- [ ] Try to avoid reflection as much as possible
- [ ] Fix shader loading
- [ ] Fix SharpDx reflection issue

This PR compiles the project so far, but gives a runtime error when we are trying to load the embedded shaders:
```
Unhandled Exception: System.ArgumentNullException: Value cannot be null.
Parameter name: key
   at OpenSage.Launcher!<BaseAddress>+0x290a79
   at OpenSage.Launcher!<BaseAddress>+0x8902f7
   at OpenSage.Graphics.Effects.Effect..ctor(GraphicsDevice, String, VertexLayoutDescription[]) + 0x25d
   at OpenSage.Graphics.Effects.EffectLibrary..ctor(GraphicsDevice) + 0x7b
   at OpenSage.Content.ContentManager..ctor(Game, FileSystem, GraphicsDevice, SageGame, WndCallbackResolver) + 0x80e
   at OpenSage.Game..ctor(IGameDefinition, FileSystem, GamePanel) + 0x222
   at OpenSage.Launcher.Program.Run(Options) + 0x1da
   at CommandLine.ParserResultExtensions.WithParsed[T](ParserResult`1, Action`1) + 0x33
   at OpenSage.Launcher.Program.Main(String[]) + 0x7e
   at OpenSage.Launcher!<BaseAddress>+0x9455de
```