### PR TITLE
skip unreferenced tga file in rise of the witch king

### DIFF
--- a/src/OpenSage.Game.Tests/Data/Tga/TgaFileTests.cs
+++ b/src/OpenSage.Game.Tests/Data/Tga/TgaFileTests.cs
@@ -1,4 +1,5 @@
-﻿using OpenSage.Data.Tga;
+﻿using System.IO;
+using OpenSage.Data.Tga;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,6 +19,12 @@ namespace OpenSage.Tests.Data.Tga
         {
             InstalledFilesTestData.ReadFiles(".tga", _output, entry =>
             {
+                switch (Path.GetFileName(entry.FilePath))
+                {
+                    case "map ang rhudaur.tga":
+                        return; // unreferenced
+                }
+
                 var tgaFile = TgaFile.FromFileSystemEntry(entry);
 
                 var imagePixelSize = tgaFile.Header.ImagePixelSize;


### PR DESCRIPTION
Skip "map ang rhudaur.tga" in unit-tests. This file is not referenced in any ini file of the rise of the witch king expansion and seems to be corrupted, since the image width is negative and the image type is 82, which is not mentioned in any documentation of the tga file format.