### PR TITLE
Parse shader material ids, skip corrupted and unreferenced file

### DIFF
--- a/src/OpenSage.Game.Tests/Data/W3d/W3dFileTests.cs
+++ b/src/OpenSage.Game.Tests/Data/W3d/W3dFileTests.cs
@@ -42,6 +42,7 @@ namespace OpenSage.Tests.Data.W3d
                     case "lwbanhnazgul.w3d":
                     case "lwbanhwtchkng.w3d":
                     case "psupplies04.w3d":
+                    case "readonly-0-rev-2-lwbanhwitchk.w3d":
                     case "wbcave_d2a.w3d":
                     case "wbcave_d2c.w3d":
                         return; // Corrupt, or unreferenced and contain chunks that don't exist elsewhere.
@@ -74,7 +75,7 @@ namespace OpenSage.Tests.Data.W3d
 
                     Assert.True(mesh.MaterialPasses.Length <= 3);
 
-                    Assert.True(mesh.ShaderMaterials == null || mesh.ShaderMaterials.Materials.Count == 1);
+                    Assert.True(mesh.ShaderMaterials == null || mesh.ShaderMaterials.Materials.Count >= 1);
 
                     if (mesh.ShaderMaterials != null)
                     {

--- a/src/OpenSage.Game.Tests/Data/W3d/W3dFileTests.cs
+++ b/src/OpenSage.Game.Tests/Data/W3d/W3dFileTests.cs
@@ -38,6 +38,8 @@ namespace OpenSage.Tests.Data.W3d
                     case "gugandalfcrstl.w3d":
                     case "guhbtshfb_cinb.w3d":
                     case "guhbtshfb_cinc.w3d":
+                    case "kbpostgaten_al.w3d":
+                    case "kbpostgaten_am.w3d":
                     case "lwbanhfllbst.w3d":
                     case "lwbanhnazgul.w3d":
                     case "lwbanhwtchkng.w3d":
@@ -75,7 +77,7 @@ namespace OpenSage.Tests.Data.W3d
 
                     Assert.True(mesh.MaterialPasses.Length <= 3);
 
-                    Assert.True(mesh.ShaderMaterials == null || mesh.ShaderMaterials.Materials.Count >= 1);
+                    Assert.True(mesh.ShaderMaterials == null || mesh.ShaderMaterials.Materials.Count == 1);
 
                     if (mesh.ShaderMaterials != null)
                     {

--- a/src/OpenSage.Game/Data/W3d/W3dMaterialPass.cs
+++ b/src/OpenSage.Game/Data/W3d/W3dMaterialPass.cs
@@ -12,7 +12,6 @@ namespace OpenSage.Data.W3d
         public uint[] ShaderIds { get; private set; }
 
         public uint? ShaderMaterialId { get; private set; }
-        public uint[] ShaderMaterialIds { get; private set; }
 
         /// <summary>
         /// per-vertex diffuse color values
@@ -89,12 +88,11 @@ namespace OpenSage.Data.W3d
                         break;
 
                     case W3dChunkType.W3D_CHUNK_SHADER_MATERIAL_ID:
-                        result.ShaderMaterialIds = new uint[header.ChunkSize / sizeof(uint)];
-                        for (var count = 0; count < result.ShaderMaterialIds.Length; count++)
+                        if(header.ChunkSize != sizeof(uint))
                         {
-                            result.ShaderMaterialIds[count] = reader.ReadUInt32();
+                            throw new InvalidDataException();
                         }
-                        result.ShaderMaterialId = result.ShaderMaterialIds[0];
+                        result.ShaderMaterialId = reader.ReadUInt32();
                         break;
 
                     // Normally this appears inside W3dTextureStage, but it can also

--- a/src/OpenSage.Game/Data/W3d/W3dMaterialPass.cs
+++ b/src/OpenSage.Game/Data/W3d/W3dMaterialPass.cs
@@ -88,8 +88,9 @@ namespace OpenSage.Data.W3d
                         break;
 
                     case W3dChunkType.W3D_CHUNK_SHADER_MATERIAL_ID:
-                        if(header.ChunkSize != sizeof(uint))
+                        if (header.ChunkSize != sizeof(uint))
                         {
+                            // TODO: If this is thrown: this is an array of IDs
                             throw new InvalidDataException();
                         }
                         result.ShaderMaterialId = reader.ReadUInt32();

--- a/src/OpenSage.Game/Data/W3d/W3dMaterialPass.cs
+++ b/src/OpenSage.Game/Data/W3d/W3dMaterialPass.cs
@@ -12,6 +12,7 @@ namespace OpenSage.Data.W3d
         public uint[] ShaderIds { get; private set; }
 
         public uint? ShaderMaterialId { get; private set; }
+        public uint[] ShaderMaterialIds { get; private set; }
 
         /// <summary>
         /// per-vertex diffuse color values
@@ -88,12 +89,12 @@ namespace OpenSage.Data.W3d
                         break;
 
                     case W3dChunkType.W3D_CHUNK_SHADER_MATERIAL_ID:
-                        if (header.ChunkSize != sizeof(uint))
+                        result.ShaderMaterialIds = new uint[header.ChunkSize / sizeof(uint)];
+                        for (var count = 0; count < result.ShaderMaterialIds.Length; count++)
                         {
-                            // TODO: If this is thrown: this is probably an array of IDs?
-                            throw new InvalidDataException();
+                            result.ShaderMaterialIds[count] = reader.ReadUInt32();
                         }
-                        result.ShaderMaterialId = reader.ReadUInt32();
+                        result.ShaderMaterialId = result.ShaderMaterialIds[0];
                         break;
 
                     // Normally this appears inside W3dTextureStage, but it can also


### PR DESCRIPTION
Parse shader material ids. Skip file "readonly-0-rev-2-lwbanhwitchk.w3d" in unit tests, since it is corrupted and not referenced by any ini file. 
![image](https://user-images.githubusercontent.com/10086882/48431892-27377000-e773-11e8-835e-23e62891b990.png)
