### PR TITLE
Viewer improvements

### DIFF
--- a/src/OpenSage.Viewer/UI/MainForm.cs
+++ b/src/OpenSage.Viewer/UI/MainForm.cs
@@ -174,6 +174,13 @@ namespace OpenSage.Viewer.UI
 
                 ImGui.Text(_contentView.DisplayName);
 
+                if (isGameViewFocused)
+                {
+                    var message = "Press [ESC] to unfocus the 3D view.";
+                    ImGui.SameLine(ImGui.GetWindowWidth() - ImGui.CalcTextSize(message).X);
+                    ImGui.TextColored(new Vector4(1.0f, 0.0f, 0.0f, 1.0f), message);
+                }
+
                 ImGui.BeginChild("content view");
 
                 _contentView.Draw(ref isGameViewFocused);

--- a/src/OpenSage.Viewer/UI/Views/GameView.cs
+++ b/src/OpenSage.Viewer/UI/Views/GameView.cs
@@ -30,6 +30,13 @@ namespace OpenSage.Viewer.UI.Views
         {
             var windowPos = ImGui.GetCursorScreenPos();
             var availableSize = ImGui.GetContentRegionAvail();
+
+            // If there's not enough space for the game view, don't draw anything.
+            if (availableSize.X <= 0 || availableSize.Y <= 0)
+            {
+                return;
+            }
+
             _context.GamePanel.EnsureFrame(
                 new Mathematics.Rectangle(
                     (int) windowPos.X,

--- a/src/OpenSage.Viewer/UI/Views/IniView.cs
+++ b/src/OpenSage.Viewer/UI/Views/IniView.cs
@@ -10,7 +10,7 @@ namespace OpenSage.Viewer.UI.Views
 {
     internal sealed class IniView : AssetView
     {
-        private ViewMode _currentView = ViewMode.ObjectView;
+        private ViewMode _currentView;
 
         private readonly List<IniEntry> _subObjects;
         private IniEntry _selectedSubObject;
@@ -42,6 +42,9 @@ namespace OpenSage.Viewer.UI.Views
             {
                 _subObjects.Add(new IniEntry(particleSystem.Name, () => new ParticleSystemView(context, particleSystem)));
             }
+
+            // If we can't show this file in object view, default to text view.
+            _currentView = _subObjects.Count == 0 ? ViewMode.TextView : ViewMode.ObjectView;
         }
 
         private void DrawObjectMode(ref bool isGameViewFocused)
@@ -88,16 +91,20 @@ namespace OpenSage.Viewer.UI.Views
 
         public override void Draw(ref bool isGameViewFocused)
         {
-            if (ImGui.RadioButton("Object view", _currentView == ViewMode.ObjectView))
+            // Only show mode selection when there are objects to show.
+            if (_subObjects.Count > 0)
             {
-                _currentView = ViewMode.ObjectView;
-            }
+                if (ImGui.RadioButton("Object view", _currentView == ViewMode.ObjectView))
+                {
+                    _currentView = ViewMode.ObjectView;
+                }
 
-            ImGui.SameLine();
+                ImGui.SameLine();
 
-            if (ImGui.RadioButton("Text view", _currentView == ViewMode.TextView))
-            {
-                _currentView = ViewMode.TextView;
+                if (ImGui.RadioButton("Text view", _currentView == ViewMode.TextView))
+                {
+                    _currentView = ViewMode.TextView;
+                }
             }
 
             ImGui.BeginChild("mode view", ImGui.GetContentRegionAvail(), false, ImGuiWindowFlags.AlwaysAutoResize);

--- a/src/OpenSage.Viewer/UI/Views/IniView.cs
+++ b/src/OpenSage.Viewer/UI/Views/IniView.cs
@@ -75,6 +75,15 @@ namespace OpenSage.Viewer.UI.Views
         private void DrawTextMode()
         {
             ImGui.TextUnformatted(_iniString);
+
+            if (ImGui.BeginPopupContextItem())
+            {
+                if (ImGui.Selectable("Copy to clipboard"))
+                {
+                    ImGui.SetClipboardText(_iniString);
+                }
+                ImGui.EndPopup();
+            }
         }
 
         public override void Draw(ref bool isGameViewFocused)


### PR DESCRIPTION
* Don't draw the game view when there's not enough space. Fixes a crash when the viewer window is really small.
* Implement a text view for INI files.
  * This currently uses a normal unformatted text control. This means the text cannot be highlighted or copied. We'll migrate to a readonly multiline input when ImGui.NET has solved [this issue](https://github.com/mellinoe/ImGui.NET/issues/82).

![image](https://user-images.githubusercontent.com/803180/48673771-a18a3a80-eb4d-11e8-9587-1fcdbf4b9dc9.png)

* Show a notification when a game view has input focus

![image](https://user-images.githubusercontent.com/803180/48673810-0b0a4900-eb4e-11e8-8149-85750150ea9d.png)

* Add a context menu option to copy INI contents to clipboard.
* Default to text view when the file doesn't contain any known objects (and hide the view selector).


