### PR TITLE
Fix tile blending in BFME

### DIFF
--- a/src/OpenSage.Game.Tests/Data/Map/MapFileTests.cs
+++ b/src/OpenSage.Game.Tests/Data/Map/MapFileTests.cs
@@ -215,14 +215,14 @@ namespace OpenSage.Tests.Data.Map
 
                     if (y == 2 && (x == 1 || x == 2 || x == 3 || x == 4))
                     {
-                        Assert.NotEqual(0, mapFile.BlendTileData.ThreeWayBlends[x, y]);
+                        Assert.NotEqual(0u, mapFile.BlendTileData.ThreeWayBlends[x, y]);
                     }
                     else
                     {
-                        Assert.Equal(0, mapFile.BlendTileData.ThreeWayBlends[x, y]);
+                        Assert.Equal(0u, mapFile.BlendTileData.ThreeWayBlends[x, y]);
                     }
 
-                    Assert.Equal(0, mapFile.BlendTileData.CliffTextures[x, y]);
+                    Assert.Equal(0u, mapFile.BlendTileData.CliffTextures[x, y]);
                 }
             }
 

--- a/src/OpenSage.Game/Content/MapLoader.cs
+++ b/src/OpenSage.Game/Content/MapLoader.cs
@@ -601,7 +601,7 @@ namespace OpenSage.Content
         private static BlendData GetBlendData(
             MapFile mapFile,
             int x, int y,
-            ushort blendIndex,
+            uint blendIndex,
             byte baseTextureIndex)
         {
             if (blendIndex > 0)

--- a/src/OpenSage.Game/Data/Utilities/Extensions/BinaryReaderExtensions.cs
+++ b/src/OpenSage.Game/Data/Utilities/Extensions/BinaryReaderExtensions.cs
@@ -149,6 +149,36 @@ namespace OpenSage.Data.Utilities.Extensions
             return result;
         }
 
+        public static uint[,] ReadUIntArray2D(this BinaryReader reader, uint width, uint height, uint bitSize)
+        {
+            var result = new uint[width, height];
+
+            for (var y = 0; y < height; y++)
+            {
+                for (var x = 0; x < width; x++)
+                {
+                    uint value;
+                    switch (bitSize)
+                    {
+                        case 16:
+                            value = reader.ReadUInt16();
+                            break;
+
+                        case 32:
+                            value = reader.ReadUInt32();
+                            break;
+
+                        default:
+                            throw new ArgumentOutOfRangeException(nameof(bitSize));
+                    }
+
+                    result[x, y] = value;
+                }
+            }
+
+            return result;
+        }
+
         public static TEnum[,] ReadByteArray2DAsEnum<TEnum>(this BinaryReader reader, uint width, uint height)
             where TEnum : struct
         {

--- a/src/OpenSage.Game/Data/Utilities/Extensions/BinaryWriterExtensions.cs
+++ b/src/OpenSage.Game/Data/Utilities/Extensions/BinaryWriterExtensions.cs
@@ -63,6 +63,33 @@ namespace OpenSage.Data.Utilities.Extensions
             }
         }
 
+        public static void WriteUIntArray2D(this BinaryWriter writer, uint[,] values, uint bitSize)
+        {
+            var width = values.GetLength(0);
+            var height = values.GetLength(1);
+
+            for (var y = 0; y < height; y++)
+            {
+                for (var x = 0; x < width; x++)
+                {
+                    var value = values[x, y];
+                    switch (bitSize)
+                    {
+                        case 16:
+                            writer.Write((ushort) value);
+                            break;
+
+                        case 32:
+                            writer.Write(value);
+                            break;
+
+                        default:
+                            throw new ArgumentOutOfRangeException(nameof(bitSize));
+                    }
+                }
+            }
+        }
+
         public static void WriteByteArray2DAsEnum<TEnum>(this BinaryWriter writer, TEnum[,] values)
             where TEnum : struct
         {


### PR DESCRIPTION
I figured what the previous `Unknown` bytes were for. The `Blends`, `ThreeWayBlends`, and `CliffTextures` data seems to be 32-bit between versions 14 and 24. And then after version 24, oddly, went back to 16-bit.