### PR TITLE
Subsystems

### DIFF
--- a/src/OpenSage.Game/Content/ContentManager.cs
+++ b/src/OpenSage.Game/Content/ContentManager.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using OpenSage.Audio;
 using OpenSage.Data;
 using OpenSage.Data.Ini;
 using OpenSage.Data.Wav;
@@ -24,6 +23,8 @@ namespace OpenSage.Content
     public sealed class ContentManager : DisposableBase
     {
         private readonly Game _game;
+
+        public ISubsystemLoader SubsystemLoader { get; }
 
         private readonly Dictionary<Type, ContentLoader> _contentLoaders;
 
@@ -79,35 +80,23 @@ namespace OpenSage.Content
 
             IniDataContext = new IniDataContext(fileSystem);
 
-            // TODO: Add these into IGameDefinition? Should we preload all ini files?
+            SubsystemLoader = Content.SubsystemLoader.Create(game.Definition, _fileSystem, IniDataContext);
+            SubsystemLoader.Load(Subsystem.Core);
+
+            // TODO: Move this somewhere else.
+            // Subsystem.Core should load mouse config, but that isn't the case with at least BFME2.
+            IniDataContext.LoadIniFile(@"Data\INI\Mouse.ini");
+
+            // TODO: Defer subsystem loading until necessary
             switch (sageGame)
             {
-                case SageGame.Ra3:
-                case SageGame.Ra3Uprising:
-                case SageGame.Cnc4:
-                    // TODO
-                    break;
+                // Only load these INI files for Generals, because we can't parse them for others yet.
                 case SageGame.CncGenerals:
                 case SageGame.CncGeneralsZeroHour:
-                case SageGame.Bfme:
-                case SageGame.Bfme2:
-                case SageGame.Bfme2Rotwk:
-                    IniDataContext.LoadIniFile(@"Data\INI\GameData.ini");
-                    IniDataContext.LoadIniFile(@"Data\INI\Mouse.ini");
-                    IniDataContext.LoadIniFile(@"Data\INI\PlayerTemplate.ini");
-                    IniDataContext.LoadIniFile(@"Maps\MapCache.ini");
-                    IniDataContext.LoadIniFile(@"Data\INI\ParticleSystem.ini");
-                    IniDataContext.LoadIniFiles(@"Data\INI\Default\Object.ini");
-                    IniDataContext.LoadIniFiles(@"Data\INI\Object");
-                    IniDataContext.LoadIniFiles(@"Data\INI\Multiplayer.ini");
-                    break;
-                case SageGame.Cnc3:
-                case SageGame.Cnc3KanesWrath:
-                    IniDataContext.LoadIniFile(@"Data\INI\GameData.ini");
-                    IniDataContext.LoadIniFile(@"Data\INI\Mouse.ini");
-                    break;
-                default:
-
+                    SubsystemLoader.Load(Subsystem.Players);
+                    SubsystemLoader.Load(Subsystem.ParticleSystems);
+                    SubsystemLoader.Load(Subsystem.ObjectCreation);
+                    SubsystemLoader.Load(Subsystem.Multiplayer);
                     break;
             }
 

--- a/src/OpenSage.Game/Content/SubsystemLoader.cs
+++ b/src/OpenSage.Game/Content/SubsystemLoader.cs
@@ -1,0 +1,228 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenSage.Data;
+using OpenSage.Data.Ini;
+using OpenSage.Utilities.Extensions;
+
+namespace OpenSage.Content
+{
+    public interface ISubsystemLoader
+    {
+        void Load(Subsystem subsystem);
+    }
+
+    public class GeneralsSubsystemLoader : ISubsystemLoader
+    {
+        private readonly IniDataContext _iniDataContext;
+
+        public GeneralsSubsystemLoader(IniDataContext iniDataContext)
+        {
+            _iniDataContext = iniDataContext;
+        }
+
+        public void Load(Subsystem subsystem)
+        {
+            switch (subsystem)
+            {
+                case Subsystem.Core:
+                    LoadFiles(
+                        @"Data\INI\Default\GameData.ini",
+                        @"Data\INI\GameData.ini",
+                        @"Data\INI\Mouse.ini");
+                    break;
+                case Subsystem.ObjectCreation:
+                    LoadFiles(@"Data\INI\Default\Object.ini");
+                    _iniDataContext.LoadIniFiles(@"Data\INI\Object");
+                    break;
+                case Subsystem.Players:
+                    LoadFiles(
+                        @"Data\INI\Default\PlayerTemplate.ini",
+                        @"Data\INI\PlayerTemplate.ini");
+                    break;
+                case Subsystem.Terrain:
+                    LoadFiles(
+                        @"Data\INI\Default\Terrain.ini",
+                        @"Data\INI\Terrain.ini",
+                        @"Data\INI\Default\Roads.ini",
+                        @"Data\INI\Roads.ini");
+                    break;
+                case Subsystem.ParticleSystems:
+                    LoadFiles(@"Data\INI\ParticleSystem.ini");
+                    break;
+                case Subsystem.Wnd:
+                    LoadFiles(
+                        @"Data\INI\WindowTransitions.ini",
+                        @"Data\English\HeaderTemplate.ini",
+                        @"Data\INI\ControlBarScheme.ini");
+                    break;
+                case Subsystem.Multiplayer:
+                    LoadFiles(@"Data\INI\Multiplayer.ini");
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(subsystem), subsystem, null);
+            }
+        }
+
+        private void LoadFiles(params string[] files)
+        {
+            foreach (var file in files)
+            {
+                _iniDataContext.LoadIniFile(file);
+            }
+        }
+    }
+
+    public class ConfiguredSubsystemLoader : ISubsystemLoader
+    {
+        private readonly IniDataContext _iniDataContext;
+        private readonly IGameDefinition _gameDefinition;
+        private readonly FileSystem _fileSystem;
+        private readonly Dictionary<string, LoadSubsystem> _subsystems;
+
+        public ConfiguredSubsystemLoader(IGameDefinition gameDefinition, FileSystem fileSystem, IniDataContext iniDataContext)
+        {
+            _gameDefinition = gameDefinition;
+            _iniDataContext = iniDataContext;
+            _fileSystem = fileSystem;
+
+            _iniDataContext.LoadIniFile(@"Data\INI\Default\subsystemlegend.ini");
+            _subsystems = _iniDataContext.Subsystems.ToDictionary(subsystem => subsystem.Name);
+        }
+
+        public void Load(Subsystem subsystem)
+        {
+            foreach (var entry in GetFilesForSubsystem(subsystem))
+            {
+                _iniDataContext.LoadIniFile(entry);
+            }
+        }
+
+        private IEnumerable<string> GetSubsystemEntryName(Subsystem subsystem)
+        {
+            // TODO: This should be stored in IGameDefinition
+            switch (subsystem)
+            {
+                case Subsystem.Core:
+                    switch (_gameDefinition.Game)
+                    {
+                        case SageGame.Bfme2:
+                        case SageGame.Bfme2Rotwk:
+                            yield return "TheWritableGlobalData";
+                            yield break;
+                        case SageGame.Cnc3:
+                        case SageGame.Cnc3KanesWrath:
+                            yield return "GameEngine";
+                            yield return "TheGameClient";
+                            yield return "TheWritableGlobalData";
+                            yield break;
+                    }
+                    break;
+                case Subsystem.ObjectCreation:
+                    switch (_gameDefinition.Game)
+                    {
+                        case SageGame.Bfme2:
+                        case SageGame.Bfme2Rotwk:
+                            yield return "TheThingFactory";
+                            yield break;
+                        // TODO: Figure out how to load object config for C&C3 and later
+                        case SageGame.Cnc3:
+                        case SageGame.Cnc3KanesWrath:
+                            yield break;
+                    }
+                    break;
+                case Subsystem.Players:
+                    switch (_gameDefinition.Game)
+                    {
+                        case SageGame.Bfme2:
+                        case SageGame.Bfme2Rotwk:
+                        case SageGame.Cnc3:
+                        case SageGame.Cnc3KanesWrath:
+                            yield return "ThePlayerTemplateStore";
+                            yield break;
+                    }
+                    break;
+                case Subsystem.Terrain:
+                    switch (_gameDefinition.Game)
+                    {
+                        case SageGame.Bfme2:
+                        case SageGame.Bfme2Rotwk:
+                        case SageGame.Cnc3:
+                        case SageGame.Cnc3KanesWrath:
+                            yield return "TheTerrainTypes";
+                            yield return "TheTerrainRoads";
+                            yield break;
+                    }
+                    break;
+                case Subsystem.ParticleSystems:
+                    switch (_gameDefinition.Game)
+                    {
+                        case SageGame.Bfme2:
+                        case SageGame.Bfme2Rotwk:
+                            yield return "TheParticleSystemManager";
+                            yield break;
+                        // TODO: Figure out how to load particle systems for C&C3 and later
+                        case SageGame.Cnc3:
+                        case SageGame.Cnc3KanesWrath:
+                            yield break;
+                    }
+                    break;
+                case Subsystem.Wnd:
+                    break;
+                case Subsystem.Multiplayer:
+                    switch (_gameDefinition.Game)
+                    {
+                        case SageGame.Bfme2:
+                        case SageGame.Bfme2Rotwk:
+                            yield return "TheMultiplayerSettings";
+                            yield break;
+                    }
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(subsystem), subsystem, null);
+            }
+        }
+        
+        private IEnumerable<FileSystemEntry> GetFilesForSubsystem(Subsystem abstractSubsystem)
+        {
+            var subsystems = GetSubsystemEntryName(abstractSubsystem).Select(entryName => _subsystems[entryName]).ToList();
+
+            foreach (var subsystem in subsystems)
+            {
+                foreach (var entry in subsystem.Entries)
+                {
+                    // TODO: Handle other entries.
+                    switch (entry)
+                    {
+                        case InitFile file:
+                            yield return _fileSystem.GetFile(file.Value);
+                            break;
+                        case InitPath folder:
+                            // TODO: Validate that exclusions work.
+                            var entries = _fileSystem.GetFiles(folder.Value).WhereNot(c => subsystem.ExcludePath.Contains(c.FilePath));
+                            foreach (var file in entries)
+                            {
+                                yield return file;
+                            }
+                            break;
+                    }
+                }
+            }
+        }
+    }
+
+    public static class SubsystemLoader
+    {
+        public static ISubsystemLoader Create(IGameDefinition gameDefinition, FileSystem fileSystem, IniDataContext iniDataContext)
+        {
+            switch (gameDefinition.Game)
+            {
+                case SageGame.CncGenerals:
+                case SageGame.CncGeneralsZeroHour: return new GeneralsSubsystemLoader(iniDataContext);
+
+                // TODO: Do all the other games use configured subsystems?
+                default: return new ConfiguredSubsystemLoader(gameDefinition, fileSystem, iniDataContext);
+            }
+        }
+    }
+}

--- a/src/OpenSage.Game/Data/Ini/LoadSubsystem.cs
+++ b/src/OpenSage.Game/Data/Ini/LoadSubsystem.cs
@@ -3,6 +3,45 @@ using OpenSage.Data.Ini.Parser;
 
 namespace OpenSage.Data.Ini
 {
+    public abstract class LoadSubsystemEntry
+    {
+        public string Value { get; }
+
+        protected LoadSubsystemEntry(string value)
+        {
+            Value = value;
+        }
+    }
+
+    public sealed class InitFile : LoadSubsystemEntry
+    {
+        public InitFile(string value) : base(value)
+        {
+        }
+    }
+
+    public sealed class InitFileDebug : LoadSubsystemEntry
+    {
+        public InitFileDebug(string value) : base(value)
+        {
+        }
+    }
+
+    public sealed class InitPath : LoadSubsystemEntry
+    {
+        public InitPath(string value) : base(value)
+        {
+        }
+    }
+
+    [AddedIn(SageGame.Bfme2)]
+    public sealed class IncludePathCinematics : LoadSubsystemEntry
+    {
+        public IncludePathCinematics(string value) : base(value)
+        {
+        }
+    }
+
     [AddedIn(SageGame.Bfme)]
     public sealed class LoadSubsystem
     {
@@ -16,17 +55,19 @@ namespace OpenSage.Data.Ini
         private static readonly IniParseTable<LoadSubsystem> FieldParseTable = new IniParseTable<LoadSubsystem>
         {
             { "Loader", (parser, x) => x.Loader = parser.ParseEnum<SubsystemLoader>() },
-            { "InitFile", (parser, x) => x.InitFiles.Add(parser.ParseFileName()) },
-            { "InitFileDebug", (parser, x) => x.InitFilesDebug.Add(parser.ParseFileName()) },
-            { "InitPath", (parser, x) => x.InitPaths.Add(parser.ParseFileName()) },
+            { "InitFile", (parser, x) => x.Entries.Add(new InitFile(parser.ParseFileName())) },
+            { "InitFileDebug", (parser, x) => x.Entries.Add(new InitFileDebug(parser.ParseFileName())) },
+            { "InitPath", (parser, x) => x.Entries.Add(new InitPath(parser.ParseFileName())) },
+            { "IncludePathCinematics", (parser, x) => x.Entries.Add(new IncludePathCinematics(parser.ParseFileName())) },
+            { "ExcludePath", (parser, x) => x.ExcludePath.Add(parser.ParseFileName()) },
         };
 
         public string Name { get; private set; }
 
         public SubsystemLoader Loader { get; private set; }
-        public List<string> InitFiles { get; } = new List<string>();
-        public List<string> InitFilesDebug { get; } = new List<string>();
-        public List<string> InitPaths { get; } = new List<string>();
+        public List<LoadSubsystemEntry> Entries { get; } = new List<LoadSubsystemEntry>();
+        [AddedIn(SageGame.Bfme2)]
+        public HashSet<string> ExcludePath { get; } = new HashSet<string>();
     }
 
     public enum SubsystemLoader

--- a/src/OpenSage.Game/Subsystem.cs
+++ b/src/OpenSage.Game/Subsystem.cs
@@ -1,0 +1,44 @@
+﻿namespace OpenSage
+{
+    /// <summary>
+    /// Represents an abstract subsystem across different SAGE games.
+    /// Can map to multiple LoadSubsystem entries.
+    /// </summary>
+    public enum Subsystem
+    {
+        /// <summary>
+        /// Things that need to be loaded immediately on engine start, before loading any other assets.
+        /// </summary>
+        Core,
+
+        /// <summary>
+        /// Things that need to be loaded in order to load and spawn game objects.
+        /// </summary>
+        ObjectCreation,
+
+        /// <summary>
+        /// Things that need be loaded in order to spawn players or list them in menus.
+        /// </summary>
+        Players,
+
+        /// <summary>
+        /// Things that need to be loaded in order to load and render terrain and roads.
+        /// </summary>
+        Terrain,
+
+        /// <summary>
+        /// Things that need to be loaded in order to load and render particle systems.
+        /// </summary>
+        ParticleSystems,
+
+        /// <summary>
+        /// Things that need to be loaded in order to load and render Wnd-based GUIs.
+        /// </summary>
+        Wnd,
+
+        /// <summary>
+        /// Things that need to be loaded in order to start multiplayer (possibly including Skirmish).
+        /// </summary>
+        Multiplayer
+    }
+}


### PR DESCRIPTION
* Implement rudimentary subsystem support. Subsystems are a concept in BFME and newer games, which are used to load related configuration files.
* Tweak `LoadSubsystem` parsing to be order-preserving

This PR doesn't integrate subsystems properly into the engine yet. Most subsystems are immediately loaded in `ContentManager` and most manual INI loading calls still remain. Not every subsystem has been added yet, and I've only looked at BFME2 and C&C3 so far.