### PR TITLE
Fix for issue #174: installation locator

### DIFF
--- a/src/OpenSage.Game/Data/InstallationLocator.cs
+++ b/src/OpenSage.Game/Data/InstallationLocator.cs
@@ -67,10 +67,17 @@ namespace OpenSage.Data
     {
         public IEnumerable<GameInstallation> FindInstallations(IGameDefinition game)
         {
-            String path = Environment.GetEnvironmentVariable(game.Identifier.ToUpperInvariant() + "_PATH");
+            var identifier = game.Identifier.ToUpperInvariant() + "_PATH";
+            var path = Environment.GetEnvironmentVariable(identifier);
 
-            if (path == null)            
+            if (path == null)
+            {
+                path = Environment.GetEnvironmentVariable(identifier, EnvironmentVariableTarget.User);
+            }
+            if (path == null || !Directory.Exists(path))
+            {
                 return new GameInstallation[]{};
+            }
 
             var installations = new GameInstallation[]{new GameInstallation(game, path)};
 


### PR DESCRIPTION
I only use windows, but dont do always a clean new installation of the games on my various systems, I simply copy them over. So it would be neat to simply set the installation path as on linux.
Also added a check if the found path exists, so the viewer does not crash if the installation folder was moved or deleted.