### PR TITLE
Viewer file search improvements

### DIFF
--- a/src/OpenSage.Viewer/Util/ImGuiUtility.cs
+++ b/src/OpenSage.Viewer/Util/ImGuiUtility.cs
@@ -13,5 +13,21 @@ namespace OpenSage.Viewer.Util
 
             return temp;
         }
+
+        /// <summary>
+        /// Trims a string to only contain the data before the first null terminator.
+        /// This is necessary because imgui optimizes input clearing by replacing the first character with a zero byte.
+        /// </summary>
+        public static string TrimToNullByte(string input)
+        {
+            if (input == null)
+            {
+                return null;
+            }
+
+            var nullIndex = input.IndexOf('\0');
+
+            return nullIndex >= 0 ? input.Substring(0, nullIndex) : input;
+        }
     }
 }


### PR DESCRIPTION
* Cache search results. They're now only computed when the search changes. This has a fairly major (positive) FPS impact.
* Fix null-terminator issues with input boxes (thanks @Qibbi!)
* Clear search box when installation changes.
* Small optimizations

![image](https://user-images.githubusercontent.com/803180/49178700-197c1000-f359-11e8-9738-01a69d708c8c.png)
