### PR TITLE
Fix ImageSharp warnings

### DIFF
--- a/src/OpenSage.Game/Content/MapLoader.cs
+++ b/src/OpenSage.Game/Content/MapLoader.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using OpenSage.Content.Util;
 using OpenSage.Data;
 using OpenSage.Data.Map;
@@ -797,7 +798,7 @@ namespace OpenSage.Content
             for (uint level = 0; level < texture.MipLevels; level++)
             {
                 var image = texture.Images[level];
-                fixed (void* pin = &image.DangerousGetPinnableReferenceToPixelBuffer())
+                fixed (void* pin = &MemoryMarshal.GetReference(image.GetPixelSpan()))
                 {
                     var map = gd.Map(staging, MapMode.Write, level);
                     var rowWidth = (uint) (image.Width * 4);

--- a/src/OpenSage.Game/Gui/TextCache.cs
+++ b/src/OpenSage.Game/Gui/TextCache.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using OpenSage.Content;
 using OpenSage.Mathematics;
 using OpenSage.Utilities;
@@ -79,10 +80,7 @@ namespace OpenSage.Gui
 
             // Clear image to transparent.
             // TODO: Don't need to do this for a newly created image.
-            fixed (void* pin = &image.DangerousGetPinnableReferenceToPixelBuffer())
-            {
-                Unsafe.InitBlock(pin, 0, (uint) (image.Width * image.Height * 4));
-            }
+            image.GetPixelSpan().Clear();
 
             image.Mutate(x =>
             {
@@ -115,7 +113,7 @@ namespace OpenSage.Gui
             Texture texture;
 
             // Draw image to texture.
-            fixed (void* pin = &image.DangerousGetPinnableReferenceToPixelBuffer())
+            fixed (void* pin = &MemoryMarshal.GetReference(image.GetPixelSpan()))
             {
                 texture = _graphicsDevice.ResourceFactory.CreateTexture(
                     TextureDescription.Texture2D(


### PR DESCRIPTION
Replace calls to `DangerousGetPinnableReferenceToPixelBuffer` with `MemoryMarshal.GetReference(image.GetPixelSpan()))` as pointed out by the deprecation warning message.

Replace call to `Unsafe.InitBlock` with `Span.Clear`.