### PR TITLE
Unit selection 1.5

### DIFF
--- a/src/OpenSage.Game/Audio/AudioSystem.cs
+++ b/src/OpenSage.Game/Audio/AudioSystem.cs
@@ -103,7 +103,8 @@ namespace OpenSage.Audio
 
             // TOOD: Check control flag before choosing at random?
             var soundFileName = $"{ev.Sounds[_random.Next(ev.Sounds.Length)]}.{_settings.SoundsExtension}";
-            var filePath = Path.Combine(ev.Type.Get(AudioTypeFlags.Voice) ? _localisedAudioRoot : _audioRoot, soundFileName);
+            var isLocalised = ev.Type?.Get(AudioTypeFlags.Voice) ?? false;
+            var filePath = Path.Combine(isLocalised ? _localisedAudioRoot : _audioRoot, soundFileName);
             return Game.ContentManager.FileSystem.GetFile(filePath);
         }
 

--- a/src/OpenSage.Game/Data/Ini/AudioEvent.cs
+++ b/src/OpenSage.Game/Data/Ini/AudioEvent.cs
@@ -58,9 +58,18 @@ namespace OpenSage.Data.Ini
     {
         internal static AudioEvent Parse(IniParser parser)
         {
-            return parser.ParseTopLevelNamedBlock(
+            var audioEvent = parser.ParseTopLevelNamedBlock(
                 (x, name) => x.Name = name,
                 FieldParseTable);
+
+            // HACK for Generals: In order to know which sounds to localise, we need to check if the event was loaded from Voice.ini.
+            // Most localised sounds have the Voice audio type flag, but many don't, so we need to make sure the flag is set.
+            if (parser.CurrentPosition.File.EndsWith("Voice.ini"))
+            {
+                audioEvent.Type?.Set(AudioTypeFlags.Voice, true);
+            }
+
+            return audioEvent;
         }
 
         private static new readonly IniParseTable<AudioEvent> FieldParseTable = BaseSingleSound.FieldParseTable

--- a/src/OpenSage.Game/Data/Rep/ReplayChunk.cs
+++ b/src/OpenSage.Game/Data/Rep/ReplayChunk.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using OpenSage.Data.Utilities.Extensions;
 using OpenSage.Logic.Orders;
 
 namespace OpenSage.Data.Rep
 {
+    [DebuggerDisplay("[{Header.Timecode}]: {Order.OrderType} ({Order.Arguments.Count})")]
     public sealed class ReplayChunk
     {
         public ReplayChunkHeader Header { get; private set; }
@@ -60,6 +62,10 @@ namespace OpenSage.Data.Rep
 
                         case OrderArgumentType.ScreenPosition:
                             order.AddScreenPositionArgument(reader.ReadPoint2D());
+                            break;
+
+                        case OrderArgumentType.ScreenRectangle:
+                            order.AddScreenRectangleArgument(reader.ReadRectangle());
                             break;
 
                         default:

--- a/src/OpenSage.Game/Data/Utilities/Extensions/BinaryReaderExtensions.cs
+++ b/src/OpenSage.Game/Data/Utilities/Extensions/BinaryReaderExtensions.cs
@@ -320,6 +320,15 @@ namespace OpenSage.Data.Utilities.Extensions
                 reader.ReadSingle());
         }
 
+        public static Rectangle ReadRectangle(this BinaryReader reader)
+        {
+            return new Rectangle(
+                reader.ReadInt32(),
+                reader.ReadInt32(),
+                reader.ReadInt32(),
+                reader.ReadInt32());
+        }
+
         public static Point2D ReadPoint2D(this BinaryReader reader)
         {
             return new Point2D(

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -134,7 +134,8 @@ namespace OpenSage
         public NetworkMessageBuffer NetworkMessageBuffer
         {
             get => _networkMessageBuffer;
-            private set
+            // TODO: Make this private again later.
+            set
             {
                 _networkMessageBuffer?.Dispose();
                 _networkMessageBuffer = value;

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using OpenSage.Audio;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.Graphics.Cameras;
@@ -114,6 +115,14 @@ namespace OpenSage.Logic.Object
             foreach (var drawModule in DrawModules)
             {
                 drawModule.UpdateConditionState(flags);
+            }
+        }
+
+        public void OnLocalSelect(AudioSystem gameAudio)
+        {
+            if (Definition.VoiceSelect != null)
+            {
+                gameAudio.PlayAudioEvent(Definition.VoiceSelect);
             }
         }
     }

--- a/src/OpenSage.Game/Logic/Object/GameObjectCollection.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObjectCollection.cs
@@ -41,5 +41,16 @@ namespace OpenSage.Logic.Object
             _items.Add(gameObject);
             return gameObject;
         }
+
+        // TODO: This is probably not how real SAGE works.
+        public int GetObjectId(GameObject gameObject)
+        {
+            return _items.IndexOf(gameObject);
+        }
+
+        public GameObject GetObjectById(int objectId)
+        {
+            return _items[objectId];
+        }
     }
 }

--- a/src/OpenSage.Game/Logic/Orders/Order.cs
+++ b/src/OpenSage.Game/Logic/Orders/Order.cs
@@ -64,6 +64,13 @@ namespace OpenSage.Logic.Orders
                 new OrderArgumentValue { ScreenPosition = value }));
         }
 
+        public void AddScreenRectangleArgument(in Rectangle value)
+        {
+            _arguments.Add(new OrderArgument(
+                OrderArgumentType.ScreenRectangle,
+                new OrderArgumentValue {ScreenRectangle  = value}));
+        }
+
         public override string ToString()
         {
             var sb = new StringBuilder();

--- a/src/OpenSage.Game/Logic/Orders/Order.cs
+++ b/src/OpenSage.Game/Logic/Orders/Order.cs
@@ -92,10 +92,34 @@ namespace OpenSage.Logic.Orders
             return sb.ToString();
         }
 
+        public static Order CreateClearSelection(uint playerId)
+        {
+            return new Order(playerId, OrderType.ClearSelection);
+        }
+
         public static Order CreateSetSelection(uint playedId, uint objectId)
         {
             var order = new Order(playedId, OrderType.SetSelection);
+
+            // TODO: Figure out what this parameter means.
+            order.AddBooleanArgument(true);
             order.AddObjectIdArgument(objectId);
+
+            return order;
+        }
+
+        public static Order CreateSetSelection(uint playerId, IEnumerable<uint> objectIds)
+        {
+            var order = new Order(playerId, OrderType.SetSelection);
+
+            // TODO: Figure out what this parameter means.
+            order.AddBooleanArgument(true);
+
+            foreach (var objectId in objectIds)
+            {
+                order.AddObjectIdArgument(objectId);
+            }
+
             return order;
         }
     }

--- a/src/OpenSage.Game/Logic/Orders/Order.cs
+++ b/src/OpenSage.Game/Logic/Orders/Order.cs
@@ -84,5 +84,12 @@ namespace OpenSage.Logic.Orders
 
             return sb.ToString();
         }
+
+        public static Order CreateSetSelection(uint playedId, uint objectId)
+        {
+            var order = new Order(playedId, OrderType.SetSelection);
+            order.AddObjectIdArgument(objectId);
+            return order;
+        }
     }
 }

--- a/src/OpenSage.Game/Logic/Orders/OrderArgumentType.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderArgumentType.cs
@@ -7,6 +7,7 @@
         Boolean = 2,
         ObjectId = 3,
         Position = 6,
-        ScreenPosition = 7
+        ScreenPosition = 7,
+        ScreenRectangle = 8
     }
 }

--- a/src/OpenSage.Game/Logic/Orders/OrderArgumentValue.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderArgumentValue.cs
@@ -24,5 +24,8 @@ namespace OpenSage.Logic.Orders
 
         [FieldOffset(0)]
         public Point2D ScreenPosition;
+
+        [FieldOffset(0)]
+        public Rectangle ScreenRectangle;
     }
 }

--- a/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 
 namespace OpenSage.Logic.Orders
@@ -37,9 +38,14 @@ namespace OpenSage.Logic.Orders
                         break;
 
                     case OrderType.SetSelection:
-                        var objectId = order.Arguments[0].Value.ObjectId;
-                        var selectedObject = _game.Scene3D.GameObjects.GetObjectById((int) objectId);
-                        _game.Selection.SetSelectedObject(player, selectedObject);
+                        // TODO: First argument is an unknown boolean.
+
+                        var objectIds = order.Arguments.Skip(1)
+                            .Select(x => (int) x.Value.ObjectId)
+                            .Select(_game.Scene3D.GameObjects.GetObjectById)
+                            .ToArray();
+
+                        _game.Selection.SetSelectedObjects(player, objectIds);
                         break;
 
                     case OrderType.ClearSelection:

--- a/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
@@ -16,6 +16,8 @@ namespace OpenSage.Logic.Orders
         {
             foreach (var order in orders)
             {
+                var player = _game.Scene3D.Players[(int) order.PlayerIndex];
+
                 switch (order.OrderType)
                 {
                     // TODO
@@ -32,6 +34,16 @@ namespace OpenSage.Logic.Orders
 
                     case OrderType.SetCameraPosition:
                         _game.Scene3D.CameraController.TerrainPosition = order.Arguments[0].Value.Position;
+                        break;
+
+                    case OrderType.SetSelection:
+                        var objectId = order.Arguments[0].Value.ObjectId;
+                        var selectedObject = _game.Scene3D.GameObjects.GetObjectById((int) objectId);
+                        _game.Selection.SetSelectedObject(player, selectedObject);
+                        break;
+
+                    case OrderType.ClearSelection:
+                        _game.Selection.ClearSelectedObjects(player);
                         break;
 
                     case OrderType.Unknown27:

--- a/src/OpenSage.Game/Logic/Orders/OrderType.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderType.cs
@@ -8,6 +8,7 @@
         SetRallyPoint = 1043,
         CreateUnit = 1047,
         BuildObject = 1049,
+        DrawBoxSelection = 1058,
         MoveTo = 1068,
         SetCameraPosition = 1092,
         Checksum = 1095,

--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -54,6 +54,11 @@ namespace OpenSage.Logic
             }
         }
 
+        public void DeselectUnits()
+        {
+            _selectedUnits.Clear();
+        }
+
         private static Player FromMapData(Data.Map.Player mapPlayer, ContentManager content)
         {
             var side = mapPlayer.Properties["playerFaction"].Value as string;

--- a/src/OpenSage.Game/Logic/SelectionSystem.cs
+++ b/src/OpenSage.Game/Logic/SelectionSystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Numerics;
 using OpenSage.Gui;
 using OpenSage.Logic.Object;
+using OpenSage.Logic.Orders;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic
@@ -90,6 +91,27 @@ namespace OpenSage.Logic
             Status = SelectionStatus.NotSelecting;
         }
 
+        public void SetSelectedObject(Player player, GameObject unitOrBuilding)
+        {
+            player.SelectUnits(new[] { unitOrBuilding });
+
+            if (player == Game.Scene3D.LocalPlayer)
+            {
+                SelectionGui.SelectedObjects.Add(unitOrBuilding.Collider);
+                unitOrBuilding.OnLocalSelect(Game.Audio);
+            }
+        }
+
+        public void ClearSelectedObjects(Player player)
+        {
+            player.DeselectUnits();
+
+            if (player == Game.Scene3D.LocalPlayer)
+            {
+                SelectionGui.SelectedObjects.Clear();
+            }
+        }
+
         private void SingleSelect()
         {
             var ray = Game.Scene3D.Camera.ScreenPointToRay(new Vector2(_startPoint.X, _startPoint.Y));
@@ -114,7 +136,10 @@ namespace OpenSage.Logic
             if (closestObject != null)
             {
                 _selectedObjects.Add(closestObject);
-                SelectionGui.SelectedObjects.Add(closestObject.Collider);
+
+                Game.NetworkMessageBuffer.AddLocalOrder(Order.CreateSetSelection(
+                    (uint) Game.Scene3D.GetPlayerIndex(Game.Scene3D.LocalPlayer),
+                    (uint) Game.Scene3D.GameObjects.GetObjectId(closestObject)));
             }
         }
 

--- a/src/OpenSage.Game/Logic/SelectionSystem.cs
+++ b/src/OpenSage.Game/Logic/SelectionSystem.cs
@@ -132,12 +132,12 @@ namespace OpenSage.Logic
             }
 
             var playerId = (uint) Game.Scene3D.GetPlayerIndex(Game.Scene3D.LocalPlayer);
-            Game.NetworkMessageBuffer.AddLocalOrder(Order.CreateClearSelection(playerId));
+            Game.NetworkMessageBuffer?.AddLocalOrder(Order.CreateClearSelection(playerId));
 
             if (closestObject != null)
             {
                 var objectId = (uint) Game.Scene3D.GameObjects.GetObjectId(closestObject);
-                Game.NetworkMessageBuffer.AddLocalOrder(Order.CreateSetSelection(playerId, objectId));
+                Game.NetworkMessageBuffer?.AddLocalOrder(Order.CreateSetSelection(playerId, objectId));
             }
         }
 
@@ -162,11 +162,11 @@ namespace OpenSage.Logic
             }
 
             var playerId = (uint) Game.Scene3D.GetPlayerIndex(Game.Scene3D.LocalPlayer);
-            Game.NetworkMessageBuffer.AddLocalOrder(Order.CreateClearSelection(playerId));
+            Game.NetworkMessageBuffer?.AddLocalOrder(Order.CreateClearSelection(playerId));
 
             if (selectedObjectIds.Count > 0)
             {
-                Game.NetworkMessageBuffer.AddLocalOrder(Order.CreateSetSelection(playerId, selectedObjectIds));
+                Game.NetworkMessageBuffer?.AddLocalOrder(Order.CreateSetSelection(playerId, selectedObjectIds));
             }
         }
 

--- a/src/OpenSage.Game/Mathematics/Rectangle.cs
+++ b/src/OpenSage.Game/Mathematics/Rectangle.cs
@@ -108,5 +108,10 @@ namespace OpenSage.Mathematics
         {
             return !(rectangle1 == rectangle2);
         }
+
+        public override string ToString()
+        {
+            return $"{nameof(X)}: {X}, {nameof(Y)}: {Y}, {nameof(Width)}: {Width}, {nameof(Height)}: {Height}";
+        }
     }
 }

--- a/src/OpenSage.Game/Network/NetworkMessageBuffer.cs
+++ b/src/OpenSage.Game/Network/NetworkMessageBuffer.cs
@@ -39,6 +39,8 @@ namespace OpenSage.Network
                 });
 
             _connection.Send(_netFrameNumber, _localOrders);
+
+            _orderProcessor.Process(_localOrders);
             _localOrders.Clear();
 
             if (_frameOrders.TryGetValue(_netFrameNumber, out var frameOrders))

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -132,6 +132,12 @@ namespace OpenSage
             // (+ objects will have invalid owners)
         }
 
+        // TODO: Move this over to a player collection?
+        public int GetPlayerIndex(Player player)
+        {
+            return _players.IndexOf(player);
+        }
+
         internal void Update(GameTime gameTime)
         {
             foreach (var gameObject in GameObjects.Items)

--- a/src/OpenSage.Mods.Generals/Gui/ReplayMenuCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/ReplayMenuCallbacks.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using OpenSage.Data;
 using OpenSage.Data.Rep;
 using OpenSage.Gui.Wnd;
 using OpenSage.Gui.Wnd.Controls;
+using OpenSage.Mathematics;
 using OpenSage.Network;
 
 namespace OpenSage.Mods.Generals.Gui
@@ -34,7 +34,8 @@ namespace OpenSage.Mods.Generals.Gui
                             $"{replayFile.Header.Timestamp.Hour.ToString("D2")}:{replayFile.Header.Timestamp.Minute.ToString("D2")}",
                             replayFile.Header.Version,
                             replayFile.Header.Metadata.MapFile.Replace("maps/", string.Empty)
-                        }));
+                        },
+                        ColorRgbaF.White));
                 }
 
                 listBox.Items = newItems.ToArray();

--- a/src/OpenSage.Viewer/UI/Views/MapView.cs
+++ b/src/OpenSage.Viewer/UI/Views/MapView.cs
@@ -6,6 +6,7 @@ using System.Text;
 using ImGuiNET;
 using OpenSage.Data.Map;
 using OpenSage.Graphics.Rendering.Shadows;
+using OpenSage.Network;
 using OpenSage.Scripting;
 using Veldrid;
 
@@ -22,6 +23,7 @@ namespace OpenSage.Viewer.UI.Views
             : base(context)
         {
             _game = context.Game;
+            _game.NetworkMessageBuffer = new NetworkMessageBuffer(_game, new EchoConnection());
             _game.Scene3D = _game.ContentManager.Load<Scene3D>(context.Entry.FilePath);
 
             _scriptStateContent = new StringBuilder();


### PR DESCRIPTION
Based on #183 

* Implement selection barks (_Are there not better tools?_)
* Modify `SelectionSystem` so that unit selection events are passed through `NetworkMessageBuffer` and `OrderProcessor`. 
* Fix Generals replay menu crash
* Parse `ScreenRectangle` order arguments and `DrawBoxSelection` orders from replays
* Process local orders locally
