### PR TITLE
Allow null model for animation

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -148,7 +148,7 @@ namespace OpenSage.Logic.Object
                     var w3dFilePath = Path.Combine("Art", "W3D", splitName[0] + ".W3D");
                     var model = _contentManager.Load<Model>(w3dFilePath);
 
-                    if (model.Animations.Length == 0)
+                    if (model != null && model.Animations.Length == 0)
                     {
                         // TODO: What is the actual algorithm here?
                         w3dFilePath = Path.Combine("Art", "W3D", splitName[1] + ".W3D");


### PR DESCRIPTION
Final fix for #31.

Incidentally, `AllBuildingsAllSidesUnitTest_Save.map` is a great stress test, which OpenSAGE currently... fails :)

<img width="1440" alt="2018-12-03 all buildings map" src="https://user-images.githubusercontent.com/102049/49409272-c7236080-f757-11e8-8cf1-956a00fc0667.PNG">
