### PR TITLE
Fix GLSL/C# mismatches

### DIFF
--- a/src/OpenSage.Game/Assets/Shaders/Mesh.h
+++ b/src/OpenSage.Game/Assets/Shaders/Mesh.h
@@ -11,7 +11,7 @@ struct MeshConstantsType
 {
     bool SkinningEnabled;
     uint NumBones;
-    vec2 Padding;
+    vec2 _Padding;
 };
 
 struct RenderItemConstantsVSType

--- a/src/OpenSage.Game/Assets/Shaders/Mesh.h
+++ b/src/OpenSage.Game/Assets/Shaders/Mesh.h
@@ -11,6 +11,7 @@ struct MeshConstantsType
 {
     bool SkinningEnabled;
     uint NumBones;
+    vec2 Padding;
 };
 
 struct RenderItemConstantsVSType

--- a/src/OpenSage.Game/Content/ModelLoader.cs
+++ b/src/OpenSage.Game/Content/ModelLoader.cs
@@ -204,11 +204,11 @@ namespace OpenSage.Content
             return new FixedFunction.ShadingConfiguration
             {
                 DiffuseLightingType = w3dShader.PrimaryGradient.ToDiffuseLightingType(),
-                SpecularEnabled = (w3dShader.SecondaryGradient == W3dShaderSecondaryGradient.Enable) ? 1u : 0u,
-                TexturingEnabled = (w3dShader.Texturing == W3dShaderTexturing.Enable) ? 1u : 0u,
+                SpecularEnabled = w3dShader.SecondaryGradient == W3dShaderSecondaryGradient.Enable,
+                TexturingEnabled = w3dShader.Texturing == W3dShaderTexturing.Enable,
                 SecondaryTextureColorBlend = w3dShader.DetailColorFunc.ToSecondaryTextureBlend(),
                 SecondaryTextureAlphaBlend = w3dShader.DetailAlphaFunc.ToSecondaryTextureBlend(),
-                AlphaTest = (w3dShader.AlphaTest == W3dShaderAlphaTest.Enable) ? 1u : 0u
+                AlphaTest = w3dShader.AlphaTest == W3dShaderAlphaTest.Enable
             };
         }
 

--- a/src/OpenSage.Game/Data/W3d/W3dShaderMaterialProperty.cs
+++ b/src/OpenSage.Game/Data/W3d/W3dShaderMaterialProperty.cs
@@ -2,6 +2,7 @@
 using System.Numerics;
 using System.Runtime.InteropServices;
 using OpenSage.Data.Utilities.Extensions;
+using OpenSage.Graphics.Shaders;
 
 namespace OpenSage.Data.W3d
 {
@@ -67,7 +68,7 @@ namespace OpenSage.Data.W3d
     public struct W3dShaderMaterialPropertyValue
     {
         [FieldOffset(0)]
-        public bool Bool;
+        public Bool32 Bool;
 
         [FieldOffset(0)]
         public float Float;

--- a/src/OpenSage.Game/Graphics/Effects/ConstantBuffer`1.cs
+++ b/src/OpenSage.Game/Graphics/Effects/ConstantBuffer`1.cs
@@ -4,7 +4,7 @@ using Veldrid;
 namespace OpenSage.Graphics.Effects
 {
     public sealed class ConstantBuffer<T> : DisposableBase
-        where T : struct
+        where T : unmanaged
     {
         private readonly GraphicsDevice _graphicsDevice;
 
@@ -12,13 +12,13 @@ namespace OpenSage.Graphics.Effects
 
         public T Value;
 
-        public ConstantBuffer(GraphicsDevice graphicsDevice, string name = null)
+        public unsafe ConstantBuffer(GraphicsDevice graphicsDevice, string name = null)
         {
             _graphicsDevice = graphicsDevice;
 
             Buffer = AddDisposable(graphicsDevice.ResourceFactory.CreateBuffer(
                 new BufferDescription(
-                    (uint) Marshal.SizeOf<T>(),
+                    (uint) sizeof(T),
                     BufferUsage.UniformBuffer | BufferUsage.Dynamic)));
 
             if (name != null)

--- a/src/OpenSage.Game/Graphics/Effects/MeshMaterial.cs
+++ b/src/OpenSage.Game/Graphics/Effects/MeshMaterial.cs
@@ -29,7 +29,7 @@ namespace OpenSage.Graphics.Effects
         [StructLayout(LayoutKind.Sequential)]
         public struct MeshConstants
         {
-            public Bool4 SkinningEnabled;
+            public Bool32 SkinningEnabled;
             public uint NumBones;
 
 #pragma warning disable CS0169

--- a/src/OpenSage.Game/Graphics/Effects/MeshMaterial.cs
+++ b/src/OpenSage.Game/Graphics/Effects/MeshMaterial.cs
@@ -1,5 +1,7 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Numerics;
+using System.Runtime.InteropServices;
 using OpenSage.Content;
+using OpenSage.Graphics.Shaders;
 using Veldrid;
 
 namespace OpenSage.Graphics.Effects
@@ -24,11 +26,15 @@ namespace OpenSage.Graphics.Effects
 
         public override LightingType LightingType => LightingType.Object;
 
-        [StructLayout(LayoutKind.Sequential, Size = 16)]
+        [StructLayout(LayoutKind.Sequential)]
         public struct MeshConstants
         {
-            public bool SkinningEnabled;
+            public Bool4 SkinningEnabled;
             public uint NumBones;
+
+#pragma warning disable CS0169
+            private readonly Vector2 _padding;
+#pragma warning restore CS0169
         }
     }
 }

--- a/src/OpenSage.Game/Graphics/Shaders/Bool32.cs
+++ b/src/OpenSage.Game/Graphics/Shaders/Bool32.cs
@@ -1,22 +1,22 @@
 ﻿namespace OpenSage.Graphics.Shaders
 {
-    public readonly struct Bool4
+    public readonly struct Bool32
     {
         private readonly int _value;
 
-        public Bool4(bool val)
+        public Bool32(bool val)
         {
             _value = val ? 1 : 0;
         }
 
-        public static implicit operator bool(Bool4 d)
+        public static implicit operator bool(Bool32 d)
         {
             return d._value == 1;
         }
 
-        public static implicit operator Bool4(bool d)
+        public static implicit operator Bool32(bool d)
         {
-            return new Bool4(d);
+            return new Bool32(d);
         }
     }
 }

--- a/src/OpenSage.Game/Graphics/Shaders/Bool4.cs
+++ b/src/OpenSage.Game/Graphics/Shaders/Bool4.cs
@@ -1,0 +1,22 @@
+﻿namespace OpenSage.Graphics.Shaders
+{
+    public readonly struct Bool4
+    {
+        private readonly int _value;
+
+        public Bool4(bool val)
+        {
+            _value = val ? 1 : 0;
+        }
+
+        public static implicit operator bool(Bool4 d)
+        {
+            return d._value == 1;
+        }
+
+        public static implicit operator Bool4(bool d)
+        {
+            return new Bool4(d);
+        }
+    }
+}

--- a/src/OpenSage.Game/Graphics/Shaders/FixedFunction.cs
+++ b/src/OpenSage.Game/Graphics/Shaders/FixedFunction.cs
@@ -83,11 +83,11 @@ namespace OpenSage.Graphics.Shaders
         public struct ShadingConfiguration
         {
             public DiffuseLightingType DiffuseLightingType;
-            public /*bool*/ uint SpecularEnabled;
-            public /*bool*/ uint TexturingEnabled;
+            public Bool32 SpecularEnabled;
+            public Bool32 TexturingEnabled;
             public SecondaryTextureBlend SecondaryTextureColorBlend;
             public SecondaryTextureBlend SecondaryTextureAlphaBlend;
-            public /*bool*/ uint AlphaTest;
+            public Bool32 AlphaTest;
 
 #pragma warning disable CS0169
             private readonly Vector2 _padding;


### PR DESCRIPTION
- Adds a Bool4 type in C# that matches the 4 byte bools in GLSL.
- Change ConstantBuffer to use the unsafe sizeof operator which returns the "real" size of the underlying type (only relevant for `bool` type)