### PR TITLE
Prevent initialization of AudioSystem for ra3/uprising/cnc4.

### DIFF
--- a/src/OpenSage.Game/Audio/AudioSystem.cs
+++ b/src/OpenSage.Game/Audio/AudioSystem.cs
@@ -33,7 +33,8 @@ namespace OpenSage.Audio
                 case SageGame.Ra3Uprising:
                 case SageGame.Cnc4:
                     // TODO
-                    break;
+                    System.Diagnostics.Debug.WriteLine($"Skipping initialization of {game.ContentManager.SageGame}'s unimplemented AudioSystem settings.");
+                    return;
 
                 case SageGame.CncGenerals:
                 case SageGame.CncGeneralsZeroHour:


### PR DESCRIPTION
Prevent initialization of `AudioSystem` for games which we haven't implemented their audio settings yet, so OpenSage Viewer won't crash when switching to games like RA3 or Uprising.