### PR TITLE
Added a tooltip to display full filename / item name

### DIFF
--- a/src/OpenSage.Viewer/UI/MainForm.cs
+++ b/src/OpenSage.Viewer/UI/MainForm.cs
@@ -143,6 +143,7 @@ namespace OpenSage.Viewer.UI
                     _contentView = AddDisposable(new ContentView(
                         new Views.AssetViewContext(_game, _gamePanel, _imGuiRenderer, entry)));
                 }
+                ImGuiUtility.DisplayTooltipOnHover(entry.FilePath);
             }
 
             ImGui.EndChild();

--- a/src/OpenSage.Viewer/UI/Views/ManifestView.cs
+++ b/src/OpenSage.Viewer/UI/Views/ManifestView.cs
@@ -2,6 +2,7 @@
 using ImGuiNET;
 using OpenSage.Data.StreamFS;
 using OpenSage.Mathematics;
+using OpenSage.Viewer.Util;
 
 namespace OpenSage.Viewer.UI.Views
 {
@@ -31,6 +32,7 @@ namespace OpenSage.Viewer.UI.Views
                     {
                         _selectedAsset = asset;
                     }
+                    ImGuiUtility.DisplayTooltipOnHover(asset.Name);
                 }
 
                 ImGui.EndChild();

--- a/src/OpenSage.Viewer/UI/Views/WndView.cs
+++ b/src/OpenSage.Viewer/UI/Views/WndView.cs
@@ -2,6 +2,7 @@
 using ImGuiNET;
 using OpenSage.Gui.Wnd.Controls;
 using OpenSage.Mathematics;
+using OpenSage.Viewer.Util;
 
 namespace OpenSage.Viewer.UI.Views
 {
@@ -40,6 +41,7 @@ namespace OpenSage.Viewer.UI.Views
         private void DrawControlTreeItemRecursive(Control control)
         {
             var opened = ImGui.TreeNodeEx(control.DisplayName, ImGuiTreeNodeFlags.DefaultOpen | ImGuiTreeNodeFlags.OpenOnDoubleClick);
+            ImGuiUtility.DisplayTooltipOnHover(control.DisplayName);
 
             if (ImGuiNative.igIsItemClicked(0)>0)
             {

--- a/src/OpenSage.Viewer/Util/ImGuiUtility.cs
+++ b/src/OpenSage.Viewer/Util/ImGuiUtility.cs
@@ -29,5 +29,16 @@ namespace OpenSage.Viewer.Util
 
             return nullIndex >= 0 ? input.Substring(0, nullIndex) : input;
         }
+
+        // Displays a tooltip with specified text when mouse is hovered on the last item.
+        public static void DisplayTooltipOnHover(string text)
+        {
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.SetTooltip(text);
+                ImGui.EndTooltip();
+            }
+        }
     }
 }


### PR DESCRIPTION
Now we are able to see full filename in any cases. Just hover the mouse on the item and it's full name will be displayed.
Effect:
![image](https://user-images.githubusercontent.com/2989995/49842617-87462400-fdbc-11e8-8c83-9cfdc912bc8b.png)
![image](https://user-images.githubusercontent.com/2989995/49842626-8ca36e80-fdbc-11e8-9b5b-a48db3601d1a.png)
