### PR TITLE
Fix crash loading some bridges

### DIFF
--- a/src/OpenSage.Game/Terrain/Bridge.cs
+++ b/src/OpenSage.Game/Terrain/Bridge.cs
@@ -102,9 +102,9 @@ namespace OpenSage.Terrain
         {
             const float heightBias = 1f;
 
-            var bridgeLeft = model.SubObjects.First(x => x.Name.EndsWith("BRIDGE_LEFT"));
-            var bridgeSpan = model.SubObjects.First(x => x.Name.EndsWith("BRIDGE_SPAN"));
-            var bridgeRight = model.SubObjects.First(x => x.Name.EndsWith("BRIDGE_RIGHT"));
+            var bridgeLeft = model.SubObjects.First(x => x.Name.Contains("BRIDGE_LEFT"));
+            var bridgeSpan = model.SubObjects.First(x => x.Name.Contains("BRIDGE_SPAN"));
+            var bridgeRight = model.SubObjects.First(x => x.Name.Contains("BRIDGE_RIGHT"));
 
             float GetLength(ModelSubObject subObject)
             {


### PR DESCRIPTION
To prevent trailing whitespaces and special names like `BRIDGE_RIGHT01`