### PR TITLE
Better game loop

### DIFF
--- a/src/OpenSage.Game/Diagnostics/AssetViews/ModelView.cs
+++ b/src/OpenSage.Game/Diagnostics/AssetViews/ModelView.cs
@@ -14,7 +14,7 @@ namespace OpenSage.Diagnostics.AssetViews
             : base(context)
         {
             _modelInstance = AddDisposable(model.CreateInstance(context.Game.ContentManager));
-            _modelInstance.Update(new GameTime());
+            _modelInstance.Update(GameTime.Zero);
 
             var enclosingBoundingBox = GetEnclosingBoundingBox(_modelInstance);
 

--- a/src/OpenSage.Game/Diagnostics/DeveloperModeView.cs
+++ b/src/OpenSage.Game/Diagnostics/DeveloperModeView.cs
@@ -65,7 +65,7 @@ namespace OpenSage.Diagnostics
                 : _game.Window.CurrentInputSnapshot;
 
             _imGuiRenderer.Update(
-                (float) _game.UpdateTime.ElapsedGameTime.TotalSeconds,
+                (float) _game.RenderTime.ElapsedGameTime.TotalSeconds,
                 inputSnapshot);
 
             _mainView.Draw(ref _isGameViewFocused);

--- a/src/OpenSage.Game/Diagnostics/GameLoopView.cs
+++ b/src/OpenSage.Game/Diagnostics/GameLoopView.cs
@@ -1,0 +1,22 @@
+﻿using ImGuiNET;
+
+namespace OpenSage.Diagnostics
+{
+    internal class GameLoopView : DiagnosticView
+    {
+        public GameLoopView(DiagnosticViewContext context) : base(context)
+        {
+
+        }
+
+        public override string DisplayName => "Game loop";
+
+        protected override void DrawOverride(ref bool isGameViewFocused)
+        {
+            ImGui.Text($"Logic frame: {Game.CurrentFrame}");
+            ImGui.Text($"Total time : {Game.UpdateTime.TotalGameTime}");
+            ImGui.Text($"Frame time : {Game.UpdateTime.ElapsedGameTime}");
+            ImGui.Text($"Cumulative update time error: {Game.CumulativeLogicUpdateError}");
+        }
+    }
+}

--- a/src/OpenSage.Game/Diagnostics/GameLoopView.cs
+++ b/src/OpenSage.Game/Diagnostics/GameLoopView.cs
@@ -4,8 +4,6 @@ namespace OpenSage.Diagnostics
 {
     internal class GameLoopView : DiagnosticView
     {
-        private ulong? breakOnFrame;
-
         public GameLoopView(DiagnosticViewContext context) : base(context)
         {
 
@@ -15,33 +13,11 @@ namespace OpenSage.Diagnostics
 
         protected override void DrawOverride(ref bool isGameViewFocused)
         {
-            if (breakOnFrame == Game.CurrentFrame)
-            {
-                Game.IsLogicRunning = false;
-            }
-
-            var pauseText = Game.IsLogicRunning ? "Pause" : "Play";
-
-            if (ImGui.Button(pauseText))
-            {
-                Game.IsLogicRunning = !Game.IsLogicRunning;
-            }
-
-
-            if (!Game.IsLogicRunning)
-            {
-                ImGui.SameLine();
-
-                if (ImGui.Button("Step >"))
-                {
-                    breakOnFrame = Game.CurrentFrame + 1;
-                    Game.IsLogicRunning = true;
-                }
-            }
-
             ImGui.Text($"Logic frame: {Game.CurrentFrame}");
-            ImGui.Text($"Total time : {Game.UpdateTime.TotalGameTime}");
-            ImGui.Text($"Frame time : {Game.UpdateTime.ElapsedGameTime}");
+            ImGui.Separator();
+            ImGui.Text($"Map time:    {Game.MapTime.TotalGameTime}");
+            ImGui.Text($"Render time: {Game.RenderTime.TotalGameTime}");
+            ImGui.Text($"Frame time:  {Game.RenderTime.ElapsedGameTime}");
             ImGui.Text($"Cumulative update time error: {Game.CumulativeLogicUpdateError}");
         }
     }

--- a/src/OpenSage.Game/Diagnostics/GameLoopView.cs
+++ b/src/OpenSage.Game/Diagnostics/GameLoopView.cs
@@ -4,6 +4,8 @@ namespace OpenSage.Diagnostics
 {
     internal class GameLoopView : DiagnosticView
     {
+        private ulong? breakOnFrame;
+
         public GameLoopView(DiagnosticViewContext context) : base(context)
         {
 
@@ -13,6 +15,30 @@ namespace OpenSage.Diagnostics
 
         protected override void DrawOverride(ref bool isGameViewFocused)
         {
+            if (breakOnFrame == Game.CurrentFrame)
+            {
+                Game.IsLogicRunning = false;
+            }
+
+            var pauseText = Game.IsLogicRunning ? "Pause" : "Play";
+
+            if (ImGui.Button(pauseText))
+            {
+                Game.IsLogicRunning = !Game.IsLogicRunning;
+            }
+
+
+            if (!Game.IsLogicRunning)
+            {
+                ImGui.SameLine();
+
+                if (ImGui.Button("Step >"))
+                {
+                    breakOnFrame = Game.CurrentFrame + 1;
+                    Game.IsLogicRunning = true;
+                }
+            }
+
             ImGui.Text($"Logic frame: {Game.CurrentFrame}");
             ImGui.Text($"Total time : {Game.UpdateTime.TotalGameTime}");
             ImGui.Text($"Frame time : {Game.UpdateTime.ElapsedGameTime}");

--- a/src/OpenSage.Game/Diagnostics/GameLoopView.cs
+++ b/src/OpenSage.Game/Diagnostics/GameLoopView.cs
@@ -1,8 +1,10 @@
-﻿using ImGuiNET;
+﻿using System;
+using System.Globalization;
+using ImGuiNET;
 
 namespace OpenSage.Diagnostics
 {
-    internal class GameLoopView : DiagnosticView
+    internal sealed class GameLoopView : DiagnosticView
     {
         public GameLoopView(DiagnosticViewContext context) : base(context)
         {
@@ -15,10 +17,12 @@ namespace OpenSage.Diagnostics
         {
             ImGui.Text($"Logic frame: {Game.CurrentFrame}");
             ImGui.Separator();
-            ImGui.Text($"Map time:    {Game.MapTime.TotalGameTime}");
-            ImGui.Text($"Render time: {Game.RenderTime.TotalGameTime}");
-            ImGui.Text($"Frame time:  {Game.RenderTime.ElapsedGameTime}");
-            ImGui.Text($"Cumulative update time error: {Game.CumulativeLogicUpdateError}");
+            ImGui.Text($"Map time:    {FormatTime(Game.MapTime.TotalGameTime)}");
+            ImGui.Text($"Render time: {FormatTime(Game.RenderTime.TotalGameTime)}");
+            ImGui.Text($"Frame time:  {Game.RenderTime.ElapsedGameTime.TotalMilliseconds.ToString("F2", CultureInfo.InvariantCulture)} ms");
+            ImGui.Text($"Cumulative update time error: {FormatTime(Game.CumulativeLogicUpdateError)}");
         }
+
+        private static string FormatTime(TimeSpan timeSpan) => $"{timeSpan.TotalMinutes:00}:{timeSpan.TotalSeconds:00}:{timeSpan.Milliseconds:000}";
     }
 }

--- a/src/OpenSage.Game/Diagnostics/GameView.cs
+++ b/src/OpenSage.Game/Diagnostics/GameView.cs
@@ -42,7 +42,8 @@ namespace OpenSage.Diagnostics
                 ? ImGuiUtility.TranslateInputMessages(Game.Panel.Frame, Game.Window.MessageQueue)
                 : Array.Empty<InputMessage>();
 
-            Game.Tick(inputMessages);
+            Game.Update(inputMessages);
+            Game.Render();
 
             var imagePointer = ImGuiRenderer.GetOrCreateImGuiBinding(
                 Game.GraphicsDevice.ResourceFactory,

--- a/src/OpenSage.Game/Diagnostics/MainView.cs
+++ b/src/OpenSage.Game/Diagnostics/MainView.cs
@@ -35,6 +35,7 @@ namespace OpenSage.Diagnostics
             AddView(new AptConstantsView(context));
             AddView(new AptGeometryView(context));
             AddView(new WndView(context));
+            AddView(new GameLoopView(context));
         }
 
         public void Draw(ref bool isGameViewFocused)

--- a/src/OpenSage.Game/Diagnostics/MainView.cs
+++ b/src/OpenSage.Game/Diagnostics/MainView.cs
@@ -38,6 +38,41 @@ namespace OpenSage.Diagnostics
             AddView(new GameLoopView(context));
         }
 
+        private void DrawTimingControls()
+        {
+            var (playPauseText, playPauseColor) = _context.Game.IsLogicRunning
+                ? ("Pause (F9)", new Vector4(0.980f, 0, 0.243f, 1))
+                : ("Play (F9)", new Vector4(0.066f, 0.654f, 0.066f, 1));
+
+            var buttonSize = new Vector2(80.0f, ImGui.GetWindowHeight());
+
+            ImGui.SetCursorPosX(ImGui.GetWindowContentRegionWidth() - 250);
+            ImGui.PushStyleColor(ImGuiCol.Button, playPauseColor);
+
+            if (ImGui.Button(playPauseText, buttonSize))
+            {
+                _context.Game.IsLogicRunning = !_context.Game.IsLogicRunning;
+            }
+
+            ImGui.PopStyleColor();
+
+            ImGui.SetCursorPosX(ImGui.GetWindowContentRegionWidth() - 160);
+
+            if (!_context.Game.IsLogicRunning)
+            {
+                if (ImGui.Button("Step (F10)", buttonSize))
+                {
+                    _context.Game.Step();
+                }
+            }
+            else
+            {
+                ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5f);
+                ImGui.Button("Step (F10)", buttonSize);
+                ImGui.PopStyleVar();
+            }
+        }
+
         public void Draw(ref bool isGameViewFocused)
         {
             float menuBarHeight = 0;
@@ -106,6 +141,8 @@ namespace OpenSage.Diagnostics
                     }
                     ImGui.EndMenu();
                 }
+
+                DrawTimingControls();
 
                 var fpsText = $"{ImGui.GetIO().Framerate:N2} FPS";
                 var fpsTextSize = ImGui.CalcTextSize(fpsText).X;

--- a/src/OpenSage.Game/Diagnostics/RenderedView.cs
+++ b/src/OpenSage.Game/Diagnostics/RenderedView.cs
@@ -87,7 +87,7 @@ namespace OpenSage.Diagnostics
 
             _inputMessageBuffer.PumpEvents(inputMessages);
 
-            _scene3D.Update(_context.Game.UpdateTime);
+            _scene3D.LocalLogicTick(_context.Game.UpdateTime);
 
             RenderPipeline.Execute(new RenderContext
             {

--- a/src/OpenSage.Game/Diagnostics/RenderedView.cs
+++ b/src/OpenSage.Game/Diagnostics/RenderedView.cs
@@ -87,12 +87,12 @@ namespace OpenSage.Diagnostics
 
             _inputMessageBuffer.PumpEvents(inputMessages);
 
-            _scene3D.LocalLogicTick(_context.Game.UpdateTime, 1.0f);
+            _scene3D.LocalLogicTick(_context.Game.MapTime, 1.0f);
 
             RenderPipeline.Execute(new RenderContext
             {
                 ContentManager = _context.Game.ContentManager,
-                GameTime = _context.Game.UpdateTime,
+                GameTime = _context.Game.RenderTime,
                 GraphicsDevice = _context.Game.GraphicsDevice,
                 RenderTarget = _renderTarget.Framebuffer,
                 Scene2D = null,

--- a/src/OpenSage.Game/Diagnostics/RenderedView.cs
+++ b/src/OpenSage.Game/Diagnostics/RenderedView.cs
@@ -87,7 +87,7 @@ namespace OpenSage.Diagnostics
 
             _inputMessageBuffer.PumpEvents(inputMessages);
 
-            _scene3D.LocalLogicTick(_context.Game.UpdateTime);
+            _scene3D.LocalLogicTick(_context.Game.UpdateTime, 1.0f);
 
             RenderPipeline.Execute(new RenderContext
             {

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -15,6 +15,7 @@ using OpenSage.Logic;
 using OpenSage.Mathematics;
 using OpenSage.Network;
 using OpenSage.Scripting;
+using OpenSage.Utilities;
 using Veldrid;
 using Veldrid.ImageSharp;
 using Player = OpenSage.Logic.Player;
@@ -427,15 +428,15 @@ namespace OpenSage
                 DeveloperModeEnabled = !DeveloperModeEnabled;
             }
 
-            // If the game is not paused and it's time to do a logic update, do so.
             var totalGameTime = UpdateTime.TotalGameTime;
-
+        
+            // If the game is not paused and it's time to do a logic update, do so.
             if (IsLogicRunning && totalGameTime >= _nextLogicUpdate)
             {
                 LogicTick(CurrentFrame);
                 CumulativeLogicUpdateError += (totalGameTime - _nextLogicUpdate);
                 // Logic updates happen at 5Hz.
-                _nextLogicUpdate = totalGameTime + TimeSpan.FromMilliseconds(LogicUpdateInterval);
+                _nextLogicUpdate = _nextLogicUpdate + TimeSpan.FromMilliseconds(LogicUpdateInterval);
             }
 
             // TODO: Which update should be performed first?
@@ -443,7 +444,7 @@ namespace OpenSage
             {
                 Scripting.ScriptingTick();
                 // Scripting updates happen at 30Hz.
-                _nextScriptingUpdate = totalGameTime + TimeSpan.FromMilliseconds(ScriptingUpdateInterval);
+                _nextScriptingUpdate = _nextScriptingUpdate + TimeSpan.FromMilliseconds(ScriptingUpdateInterval);
             }
         }
 
@@ -454,8 +455,12 @@ namespace OpenSage
 
             InputMessageBuffer.PumpEvents(messages);
 
+            // How close are we to the next logic frame?
+            var tickT = (float) (1.0 - TimeSpanUtility.Max(_nextLogicUpdate - UpdateTime.TotalGameTime, TimeSpan.Zero)
+                                     .TotalMilliseconds / LogicUpdateInterval);
+
             Scene2D.LocalLogicTick(UpdateTime, Scene3D?.LocalPlayer);
-            Scene3D?.LocalLogicTick(UpdateTime);
+            Scene3D?.LocalLogicTick(UpdateTime, tickT);
         }
 
         internal void LogicTick(ulong frame)

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -23,6 +23,10 @@ namespace OpenSage
 {
     public sealed class Game : DisposableBase
     {
+        // TODO: These should be configurable at runtime with GameSpeed.
+        private const double LogicUpdateInterval = 1000.0 / 5.0;
+        private const double ScriptingUpdateInterval = 1000.0 / 30.0;
+
         private readonly FileSystem _fileSystem;
         private readonly GameTimer _gameTimer;
         private readonly WndCallbackResolver _wndCallbackResolver;
@@ -67,7 +71,7 @@ namespace OpenSage
         /// </summary>
         public AudioSystem Audio { get; }
 
-        public int CurrentFrame { get; private set; }
+        public ulong CurrentFrame { get; private set; }
 
         public GameTime UpdateTime { get; private set; }
         private TimeSpan _nextLogicUpdate;
@@ -377,8 +381,9 @@ namespace OpenSage
 
         public void Run()
         {
-            _nextLogicUpdate = UpdateTime.TotalGameTime;
-            _nextScriptingUpdate = UpdateTime.TotalGameTime;
+            var totalGameTime = UpdateTime.TotalGameTime;
+            _nextLogicUpdate = totalGameTime;
+            _nextScriptingUpdate = totalGameTime;
 
             while (IsRunning)
             {
@@ -415,7 +420,7 @@ namespace OpenSage
         public void Update(IEnumerable<InputMessage> messages)
         {
             // Update timers, input and UI state
-            EveryFrameLogicTick(messages);
+            LocalLogicTick(messages);
 
             if (Window.CurrentInputSnapshot.KeyEvents.Any(x => x.Down && x.Key == Key.F11))
             {
@@ -423,41 +428,37 @@ namespace OpenSage
             }
 
             // If the game is not paused and it's time to do a logic update, do so.
-            if (IsLogicRunning && UpdateTime.TotalGameTime >= _nextLogicUpdate)
+            var totalGameTime = UpdateTime.TotalGameTime;
+
+            if (IsLogicRunning && totalGameTime >= _nextLogicUpdate)
             {
-                LogicTick();
-                CumulativeLogicUpdateError += (UpdateTime.TotalGameTime - _nextLogicUpdate);
+                LogicTick(CurrentFrame);
+                CumulativeLogicUpdateError += (totalGameTime - _nextLogicUpdate);
                 // Logic updates happen at 5Hz.
-                _nextLogicUpdate = UpdateTime.TotalGameTime.Add(TimeSpan.FromMilliseconds(1000.0 / 5.0));
+                _nextLogicUpdate = totalGameTime + TimeSpan.FromMilliseconds(LogicUpdateInterval);
             }
 
             // TODO: Which update should be performed first?
-            if (IsLogicRunning && UpdateTime.TotalGameTime >= _nextScriptingUpdate)
+            if (IsLogicRunning && totalGameTime >= _nextScriptingUpdate)
             {
                 Scripting.ScriptingTick();
                 // Scripting updates happen at 30Hz.
-                _nextScriptingUpdate = UpdateTime.TotalGameTime.Add(TimeSpan.FromMilliseconds(1000.0 / 30.0));
+                _nextScriptingUpdate = totalGameTime + TimeSpan.FromMilliseconds(ScriptingUpdateInterval);
             }
         }
 
-        internal void EveryFrameLogicTick(IEnumerable<InputMessage> messages)
+        internal void LocalLogicTick(IEnumerable<InputMessage> messages)
         {
             _gameTimer.Update();
             UpdateTime = _gameTimer.CurrentGameTime;
 
             InputMessageBuffer.PumpEvents(messages);
-            Updating?.Invoke(this, new GameUpdatingEventArgs(UpdateTime));
+
+            Scene2D.LocalLogicTick(UpdateTime, Scene3D?.LocalPlayer);
+            Scene3D?.LocalLogicTick(UpdateTime);
         }
 
-        internal void Render()
-        {
-            Scene2D.Update(UpdateTime, Scene3D?.LocalPlayer);
-            Scene3D?.Update(UpdateTime);
-
-            Graphics.Draw(UpdateTime);
-        }
-
-        internal void LogicTick()
+        internal void LogicTick(ulong frame)
         {
             NetworkMessageBuffer?.Tick();
 
@@ -466,7 +467,15 @@ namespace OpenSage
                 gameSystem.LogicTick(CurrentFrame);
             }
 
+            // TODO: What is the order?
+            Scene3D?.LogicTick(frame);
+
             CurrentFrame += 1;
+        }
+
+        internal void Render()
+        {
+            Graphics.Draw(UpdateTime);
         }
 
         protected override void Dispose(bool disposeManagedResources)

--- a/src/OpenSage.Game/GameSystem.cs
+++ b/src/OpenSage.Game/GameSystem.cs
@@ -28,6 +28,6 @@
         /// <summary>
         /// Override this method to process game logic.
         /// </summary>
-        public virtual void LogicTick(long frame) { }
+        public virtual void LogicTick(ulong frame) { }
     }
 }

--- a/src/OpenSage.Game/GameSystem.cs
+++ b/src/OpenSage.Game/GameSystem.cs
@@ -23,16 +23,11 @@
         /// <summary>
         /// Override this to perform any required setup.
         /// </summary>
-        public virtual void Initialize()
-        {
-
-        }
+        public virtual void Initialize() { }
 
         /// <summary>
         /// Override this method to process game logic.
         /// </summary>
-        public virtual void Update(GameTime gameTime)
-        {
-        }
+        public virtual void LogicTick(long frame) { }
     }
 }

--- a/src/OpenSage.Game/GameTimer.cs
+++ b/src/OpenSage.Game/GameTimer.cs
@@ -30,9 +30,7 @@ namespace OpenSage
             var deltaTime = now - _lastUpdate;
             _lastUpdate = now;
 
-            CurrentGameTime = new GameTime(
-                TimeSpan.FromTicks(now - _startTime),
-                TimeSpan.FromTicks(deltaTime));
+            CurrentGameTime = new GameTime(now - _startTime, deltaTime);
         }
 
         public void Reset()
@@ -52,10 +50,15 @@ namespace OpenSage
         public readonly TimeSpan TotalGameTime;
         public readonly TimeSpan ElapsedGameTime;
 
-        public GameTime(in TimeSpan totalGameTime, in TimeSpan elapsedGameTime)
+        public GameTime(long totalGameTimeTicks, long elapsedGameTimeTicks)
         {
-            TotalGameTime = totalGameTime;
-            ElapsedGameTime = elapsedGameTime;
+            TotalGameTime = new TimeSpan( (long)(totalGameTimeTicks * TickRatio));
+            ElapsedGameTime = new TimeSpan( (long)(elapsedGameTimeTicks * TickRatio));
         }
+
+        public static GameTime Zero { get; } = new GameTime();
+
+        // This is the ratio between stopwatch ticks and timespan ticks
+        private static readonly double TickRatio = 10000000.0 / Stopwatch.Frequency;
     }
 }

--- a/src/OpenSage.Game/GameTimer.cs
+++ b/src/OpenSage.Game/GameTimer.cs
@@ -6,8 +6,8 @@ namespace OpenSage
     public sealed class GameTimer : IDisposable
     {
         private readonly Stopwatch _stopwatch;
-        private double _startTime;
-        private double _lastUpdate;
+        private long _startTime;
+        private long _lastUpdate;
 
         public GameTime CurrentGameTime { get; private set; }
 
@@ -16,7 +16,7 @@ namespace OpenSage
             _stopwatch = new Stopwatch();
         }
 
-        private double GetTimeNow() => _stopwatch.ElapsedMilliseconds;
+        private long GetTimeNow() => _stopwatch.ElapsedTicks;
 
         public void Start()
         {
@@ -31,8 +31,8 @@ namespace OpenSage
             _lastUpdate = now;
 
             CurrentGameTime = new GameTime(
-                TimeSpan.FromMilliseconds(now - _startTime),
-                TimeSpan.FromMilliseconds(deltaTime));
+                TimeSpan.FromTicks(now - _startTime),
+                TimeSpan.FromTicks(deltaTime));
         }
 
         public void Reset()

--- a/src/OpenSage.Game/GameTimer.cs
+++ b/src/OpenSage.Game/GameTimer.cs
@@ -24,6 +24,17 @@ namespace OpenSage
             Reset();
         }
 
+        public void Continue()
+        {
+            _stopwatch.Start();
+        }
+
+        public void Pause()
+        {
+            _stopwatch.Stop();
+
+        }
+
         public void Update()
         {
             var now = GetTimeNow();

--- a/src/OpenSage.Game/Graphics/Animation/AnimationInstance.cs
+++ b/src/OpenSage.Game/Graphics/Animation/AnimationInstance.cs
@@ -61,7 +61,7 @@ namespace OpenSage.Graphics.Animation
             }
         }
 
-        internal bool Update(GameTime gameTime)
+        internal bool Update(in GameTime gameTime)
         {
             if (!_playing)
             {
@@ -72,7 +72,7 @@ namespace OpenSage.Graphics.Animation
             return true;
         }
 
-        private void UpdateBoneTransforms(GameTime gameTime)
+        private void UpdateBoneTransforms(in GameTime gameTime)
         {
             var time = _currentTimeValue + gameTime.ElapsedGameTime;
 

--- a/src/OpenSage.Game/Graphics/Cameras/ArcballCameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/ArcballCameraController.cs
@@ -108,7 +108,7 @@ namespace OpenSage.Graphics.Cameras
             throw new NotImplementedException();
         }
 
-        void ICameraController.UpdateCamera(Camera camera, in CameraInputState inputState, GameTime gameTime)
+        void ICameraController.UpdateCamera(Camera camera, in CameraInputState inputState, in GameTime gameTime)
         {
             if (inputState.LeftMouseDown)
             {

--- a/src/OpenSage.Game/Graphics/Cameras/CameraAnimation.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/CameraAnimation.cs
@@ -65,7 +65,7 @@ namespace OpenSage.Graphics.Cameras
             _lookToward = lookToward;
         }
 
-        internal void Update(RtsCameraController camera, GameTime gameTime)
+        internal void Update(RtsCameraController camera, in GameTime gameTime)
         {
             var currentTimeFraction = (float) ((gameTime.TotalGameTime - _startTime).TotalSeconds / _duration.TotalSeconds);
             currentTimeFraction = Math.Min(currentTimeFraction, 1);

--- a/src/OpenSage.Game/Graphics/Cameras/ICameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/ICameraController.cs
@@ -25,6 +25,6 @@ namespace OpenSage.Graphics.Cameras
 
         void EndAnimation();
 
-        void UpdateCamera(Camera camera, in CameraInputState inputState, GameTime gameTime);
+        void UpdateCamera(Camera camera, in CameraInputState inputState, in GameTime gameTime);
     }
 }

--- a/src/OpenSage.Game/Graphics/Cameras/RtsCameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/RtsCameraController.cs
@@ -120,7 +120,7 @@ namespace OpenSage.Graphics.Cameras
             return 0;
         }
 
-        void ICameraController.UpdateCamera(Camera camera, in CameraInputState inputState, GameTime gameTime)
+        void ICameraController.UpdateCamera(Camera camera, in CameraInputState inputState, in GameTime gameTime)
         {
             if (inputState.LeftMouseDown && inputState.PressedKeys.Contains(Key.AltLeft) || inputState.MiddleMouseDown)
             {

--- a/src/OpenSage.Game/Graphics/ModelInstance.cs
+++ b/src/OpenSage.Game/Graphics/ModelInstance.cs
@@ -127,7 +127,7 @@ namespace OpenSage.Graphics
             }
         }
 
-        public void Update(GameTime gameTime)
+        public void Update(in GameTime gameTime)
         {
             // TODO: Don't update animations if model isn't visible.
 

--- a/src/OpenSage.Game/Gui/Apt/AptWindowManager.cs
+++ b/src/OpenSage.Game/Gui/Apt/AptWindowManager.cs
@@ -42,7 +42,7 @@ namespace OpenSage.Gui.Apt
             window.Layout(_game.GraphicsDevice, newSize);
         }
 
-        internal void Update(GameTime gameTime)
+        internal void Update(in GameTime gameTime)
         {
             foreach (var window in WindowStack)
             {

--- a/src/OpenSage.Game/Gui/DebugUI/DebugOverlay.cs
+++ b/src/OpenSage.Game/Gui/DebugUI/DebugOverlay.cs
@@ -62,7 +62,7 @@ namespace OpenSage.Gui.DebugUI
             AddCoordAxes(point, 0);
         }
 
-        public void Update(GameTime gameTime)
+        public void Update(in GameTime gameTime)
         {
             foreach (var drawable in _debugDrawables)
             {

--- a/src/OpenSage.Game/Gui/Wnd/WndWindowManager.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndWindowManager.cs
@@ -118,7 +118,7 @@ namespace OpenSage.Gui.Wnd
             return window.GetSelfOrDescendantsAtPoint(mousePosition);
         }
 
-        internal void Update(GameTime gameTime)
+        internal void Update(in GameTime gameTime)
         {
             foreach (var window in WindowStack)
             {

--- a/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
@@ -24,7 +24,7 @@ namespace OpenSage.Logic.Object
 
         }
 
-        internal abstract void Update(GameTime gameTime);
+        internal abstract void Update(in GameTime time);
 
         internal abstract void SetWorldMatrix(in Matrix4x4 worldMatrix);
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -202,7 +202,7 @@ namespace OpenSage.Logic.Object
                : null;
         }
 
-        internal override void Update(GameTime gameTime)
+        internal override void Update(in GameTime gameTime)
         {
             _activeModelDrawConditionState?.Update(gameTime);
         }
@@ -249,7 +249,7 @@ namespace OpenSage.Logic.Object
             AttachedParticleSystems = attachedParticleSystems;
         }
 
-        public void Update(GameTime gameTime)
+        public void Update(in GameTime gameTime)
         {
             _modelInstance.Update(gameTime);
         }

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -74,7 +74,12 @@ namespace OpenSage.Logic.Object
             }
         }
 
-        internal void Update(GameTime gameTime)
+        internal void LogicTick(ulong frame)
+        {
+            // TODO: Update modules.
+        }
+
+        internal void LocalLogicTick(in GameTime gameTime)
         {
             foreach (var drawModule in DrawModules)
             {

--- a/src/OpenSage.Game/Scene2D.cs
+++ b/src/OpenSage.Game/Scene2D.cs
@@ -17,7 +17,7 @@ namespace OpenSage
             AptWindowManager = new AptWindowManager(game);
         }
 
-        internal void Update(GameTime gameTime, Player localPlayer)
+        internal void LocalLogicTick(in GameTime gameTime, Player localPlayer)
         {
             ControlBar?.Update(localPlayer);
 

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -168,13 +168,21 @@ namespace OpenSage
             return _players.IndexOf(player);
         }
 
-        internal void Update(GameTime gameTime)
+        internal void LogicTick(ulong frame)
+        {
+            foreach (var gameObject in GameObjects.Items)
+            {
+                gameObject.LogicTick(frame);
+            }
+        }
+
+        internal void LocalLogicTick(in GameTime gameTime)
         {
             _orderGeneratorInputHandler?.Update();
 
             foreach (var gameObject in GameObjects.Items)
             {
-                gameObject.Update(gameTime);
+                gameObject.LocalLogicTick(gameTime);
             }
 
             _cameraInputMessageHandler?.UpdateInputState(ref _cameraInputState);

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -176,13 +176,13 @@ namespace OpenSage
             }
         }
 
-        internal void LocalLogicTick(in GameTime gameTime)
+        internal void LocalLogicTick(in GameTime gameTime, float tickT)
         {
             _orderGeneratorInputHandler?.Update();
 
             foreach (var gameObject in GameObjects.Items)
             {
-                gameObject.LocalLogicTick(gameTime);
+                gameObject.LocalLogicTick(gameTime, tickT);
             }
 
             _cameraInputMessageHandler?.UpdateInputState(ref _cameraInputState);

--- a/src/OpenSage.Game/Scripting/ScriptExecutionContext.cs
+++ b/src/OpenSage.Game/Scripting/ScriptExecutionContext.cs
@@ -6,7 +6,7 @@
 
         public ScriptingSystem Scripting => _game.Scripting;
 
-        public GameTime UpdateTime => _game.UpdateTime;
+        public GameTime UpdateTime => _game.MapTime;
 
         public Scene3D Scene => _game.Scene3D;
 

--- a/src/OpenSage.Game/Scripting/ScriptingSystem.cs
+++ b/src/OpenSage.Game/Scripting/ScriptingSystem.cs
@@ -32,8 +32,6 @@ namespace OpenSage.Scripting
         private readonly List<ActionResult.ActionContinuation> _activeCoroutines;
         private readonly List<ActionResult.ActionContinuation> _finishedCoroutines;
 
-        private bool _30hzHack = true;
-
         private MapScriptCollection _mapScripts;
 
         public Dictionary<string, bool> Flags { get; }
@@ -41,8 +39,6 @@ namespace OpenSage.Scripting
         public TimerCollection Timers { get; }
 
         public bool Active { get; set; }
-
-        public ulong Frame { get; private set; }
 
         public event EventHandler<ScriptingSystem> OnUpdateFinished; 
 
@@ -65,8 +61,6 @@ namespace OpenSage.Scripting
             Flags.Clear();
             Counters.Clear();
             Timers.Clear();
-
-            Frame = 0;
         }
 
         internal override void OnSceneChanged()
@@ -106,16 +100,12 @@ namespace OpenSage.Scripting
             _activeCoroutines.Add(coroutine);
         }
 
-        public override void Update(GameTime gameTime)
+        public void ScriptingTick()
         {
             if (_mapScripts == null)
             {
                 return;
             }
-
-            // TODO: Remove this hack when we have separate update and render loops.
-            _30hzHack = !_30hzHack;
-            if (_30hzHack) return;
 
             if (!Active)
             {
@@ -141,8 +131,6 @@ namespace OpenSage.Scripting
             OnUpdateFinished?.Invoke(this, this);
 
             Timers.Update();
-
-            Frame++;
         }
     }
 }

--- a/src/OpenSage.Game/Terrain/Bridge.cs
+++ b/src/OpenSage.Game/Terrain/Bridge.cs
@@ -185,7 +185,7 @@ namespace OpenSage.Terrain
                     worldMatrix);
                 tower.Transform.Rotation = rotationAroundZ;
 
-                tower.LocalLogicTick(GameTime.Zero);
+                tower.LocalLogicTick(GameTime.Zero, 1.0f);
             }
 
             SetTowerTransform(

--- a/src/OpenSage.Game/Terrain/Bridge.cs
+++ b/src/OpenSage.Game/Terrain/Bridge.cs
@@ -32,7 +32,7 @@ namespace OpenSage.Terrain
 
             _modelInstance = AddDisposable(_model.CreateInstance(contentManager));
 
-            _modelInstance.Update(new GameTime());
+            _modelInstance.Update(GameTime.Zero);
 
             _towers = new List<GameObject>();
 
@@ -185,7 +185,7 @@ namespace OpenSage.Terrain
                     worldMatrix);
                 tower.Transform.Rotation = rotationAroundZ;
 
-                tower.Update(new GameTime());
+                tower.LocalLogicTick(GameTime.Zero);
             }
 
             SetTowerTransform(

--- a/src/OpenSage.Game/Utilities/TimeSpanUtility.cs
+++ b/src/OpenSage.Game/Utilities/TimeSpanUtility.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace OpenSage.Utilities
+{
+    public static class TimeSpanUtility
+    {
+        public static TimeSpan Max(TimeSpan a, TimeSpan b)
+        {
+            return a > b ? a : b;
+        }
+    }
+}


### PR DESCRIPTION
(Partially) resolves  #102.

* Splits updates into 2 kinds:
  * `LogicTick`
    * Run at 5Hz
    * Used for networking, order processing, unit movement etc.
  * `LocalLogicTick`
    * Runs on every frame
    * Should be used for everything else, including input handling, UI updates, animation, interpolation etc. 
* Splits timers into 2 kinds:
  * `MapTime` (name can be changed)
    * Only runs when logic ticks are running; relative to the start of the current map (hence the name)
    * Reset to 0 when the map changes 
    * Should be used for timing things that should pause when the game is paused (interpolation, animation, particles, camera animation)
  * `RenderTime`
    * Runs continuously and never resets.
    * Used for things that things that update even when the game is paused: Imgui, rendering, tracing/logging
* Map scripts are now ran at 30hz. We'll have to see how that works with synchronisation.
* `GameTimer` is now more precise, as it measures time using stopwatch ticks (instead of timespan ticks).
* `GameTime` is now passed by an `in` reference.
* Implement pause and step buttons.
![image](https://user-images.githubusercontent.com/803180/51437389-5c49cc80-1ca6-11e9-89f6-ba062b8570b6.png)
