### PR TITLE
Parse arbitrary number of starting units

### DIFF
--- a/src/OpenSage.Game/Data/Big/BigArchive.cs
+++ b/src/OpenSage.Game/Data/Big/BigArchive.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -7,6 +8,7 @@ using OpenSage.Data.Utilities.Extensions;
 
 namespace OpenSage.Data.Big
 {
+    [DebuggerDisplay("Archive: {FilePath}")]
     public class BigArchive : DisposableBase
     {
         private readonly object _lockObject = new object();

--- a/src/OpenSage.Game/Data/Ini/PlayerTemplate.cs
+++ b/src/OpenSage.Game/Data/Ini/PlayerTemplate.cs
@@ -85,7 +85,7 @@ namespace OpenSage.Data.Ini
             { "MedallionHilite", (parser, x) => x.MedallionHilite = parser.ParseAssetReference() },
             { "MedallionSelect", (parser, x) => x.MedallionSelect = parser.ParseAssetReference() },
             //BFME
-            { "Evil", (parser, x) => x.PlayableSide = parser.ParseBoolean() },
+            { "Evil", (parser, x) => x.Evil = parser.ParseBoolean() },
             { "MaxLevelSP", (parser, x) => x.MaxLevelSP = parser.ParseInteger() },
             { "MaxLevelMP", (parser, x) => x.MaxLevelMP = parser.ParseInteger() },
             { "StartingUnitTacticalWOTR", (parser, x) => x.StartingUnitTacticalWOTR = parser.ParseAssetReference() },


### PR DESCRIPTION
* Support parsing an arbitrary number of `StartingUnit` entries from `PlayerTemplate`. Previously we had only supported `StartingUnit0` and `StartingUnit1`, but some BFME2 mods can use at least up to 8. According to C&C3 XML schema there can be an arbitrary number of starting units. The parsing code is quite is admittedly complex, but this is a scenario we need to take into account if and when refactoring our INI parser.
* Fix parsing `PlayerTemplate.Evil`- it was previously not assigned.