### PR TITLE
Add initial support for trace output

### DIFF
--- a/src/OpenSage.Game/Diagnostics/GameTrace.cs
+++ b/src/OpenSage.Game/Diagnostics/GameTrace.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+
+namespace OpenSage.Diagnostics
+{
+    public static class GameTrace
+    {
+        private static ObjectPool<DurationEventDisposable> _durationEvents;
+        private static int _processId;
+        private static StreamWriter _output;
+        private static bool _writtenFirstEntry;
+
+        public static void Start(string outputPath)
+        {
+            _durationEvents = new ObjectPool<DurationEventDisposable>(() => new DurationEventDisposable());
+            _processId = Process.GetCurrentProcess().Id;
+            _output = new StreamWriter(outputPath, false);
+            _output.WriteLine("[");
+        }
+
+        public static void Stop()
+        {
+            _output.WriteLine("]");
+            _output.Close();
+        }
+
+        public static IDisposable TraceDurationEvent(string name)
+        {
+            WriteEvent("B", name);
+
+            return _durationEvents.Rent();
+        }
+
+        private static void WriteEvent(
+            string type,
+            string name)
+        {
+            var cat = "-"; // TODO
+            var timestamp = Stopwatch.GetTimestamp();
+            var threadId = Thread.CurrentThread.ManagedThreadId;
+
+            name = name.Replace("\\", "\\\\");
+
+            if (_writtenFirstEntry)
+            {
+                _output.Write(",");
+            }
+
+            _output.WriteLine($"{{\"name\": \"{name}\", \"cat\": \"{cat}\", \"ph\": \"{type}\", \"ts\": {timestamp}, \"pid\": {_processId}, \"tid\": {threadId}, \"s\": \"g\"}}");
+
+            _writtenFirstEntry = true;
+        }
+
+        private sealed class DurationEventDisposable : IDisposable
+        {
+            public void Dispose()
+            {
+                WriteEvent("E", string.Empty);
+            }
+        }
+
+        public static void TraceInstantEvent(string name)
+        {
+            WriteEvent("i", name);
+        }
+    }
+
+    internal sealed class ObjectPool<T>
+    {
+        private readonly ConcurrentBag<T> _objects;
+        private readonly Func<T> _objectGenerator;
+
+        public ObjectPool(Func<T> objectGenerator)
+        {
+            _objects = new ConcurrentBag<T>();
+            _objectGenerator = objectGenerator ?? throw new ArgumentNullException(nameof(objectGenerator));
+        }
+
+        public T Rent()
+        {
+            if (_objects.TryTake(out var item))
+            {
+                return item;
+            }
+            return _objectGenerator();
+        }
+
+        public void Release(T item)
+        {
+            _objects.Add(item);
+        }
+    }
+}

--- a/src/OpenSage.Game/Diagnostics/GameTrace.cs
+++ b/src/OpenSage.Game/Diagnostics/GameTrace.cs
@@ -29,6 +29,11 @@ namespace OpenSage.Diagnostics
 
         public static IDisposable TraceDurationEvent(string name)
         {
+            if (_output == null)
+            {
+                return null;
+            }
+
             WriteEvent("B", name);
 
             return _durationEvents.Rent();
@@ -38,6 +43,11 @@ namespace OpenSage.Diagnostics
             string type,
             string name)
         {
+            if (_output == null)
+            {
+                return;
+            }
+
             var cat = "-"; // TODO
             var timestamp = Stopwatch.GetTimestamp();
             var threadId = Thread.CurrentThread.ManagedThreadId;

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -213,74 +213,77 @@ namespace OpenSage
             GraphicsBackend? preferredBackend,
             bool fullscreen = false)
         {
-            // TODO: Should we receive this as an argument? Do we need configuration in this constructor?
-            Configuration = new Configuration();
+            using (GameTrace.TraceDurationEvent("Game()"))
+            {
+                // TODO: Should we receive this as an argument? Do we need configuration in this constructor?
+                Configuration = new Configuration();
 
-            // TODO: Read game version from assembly metadata or .git folder
-            // TODO: Set window icon.
-            Window = AddDisposable(new GameWindow($"OpenSAGE - {installation.Game.DisplayName} - master",
-                                                    100, 100, 1024, 768, preferredBackend, fullscreen));
-            GraphicsDevice = Window.GraphicsDevice;
+                // TODO: Read game version from assembly metadata or .git folder
+                // TODO: Set window icon.
+                Window = AddDisposable(new GameWindow($"OpenSAGE - {installation.Game.DisplayName} - master",
+                                                        100, 100, 1024, 768, preferredBackend, fullscreen));
+                GraphicsDevice = Window.GraphicsDevice;
 
-            Panel = AddDisposable(new GamePanel(GraphicsDevice));
+                Panel = AddDisposable(new GamePanel(GraphicsDevice));
 
-            InputMessageBuffer = new InputMessageBuffer();
+                InputMessageBuffer = new InputMessageBuffer();
 
-            Definition = installation.Game;
+                Definition = installation.Game;
 
-            _fileSystem = AddDisposable(installation.CreateFileSystem());
+                _fileSystem = AddDisposable(installation.CreateFileSystem());
 
-            _mapTimer = AddDisposable(new GameTimer());
-            _mapTimer.Start();
+                _mapTimer = AddDisposable(new GameTimer());
+                _mapTimer.Start();
 
-            _renderTimer = AddDisposable(new GameTimer());
-            _renderTimer.Start();
+                _renderTimer = AddDisposable(new GameTimer());
+                _renderTimer.Start();
 
-            _cachedCursors = new Dictionary<string, Cursor>();
+                _cachedCursors = new Dictionary<string, Cursor>();
 
-            _wndCallbackResolver = new WndCallbackResolver();
+                _wndCallbackResolver = new WndCallbackResolver();
 
-            ContentManager = AddDisposable(new ContentManager(
-                this,
-                _fileSystem,
-                GraphicsDevice,
-                SageGame,
-                _wndCallbackResolver));
+                ContentManager = AddDisposable(new ContentManager(
+                    this,
+                    _fileSystem,
+                    GraphicsDevice,
+                    SageGame,
+                    _wndCallbackResolver));
 
-            _textureCopier = AddDisposable(new TextureCopier(this, GraphicsDevice.SwapchainFramebuffer.OutputDescription));
+                _textureCopier = AddDisposable(new TextureCopier(this, GraphicsDevice.SwapchainFramebuffer.OutputDescription));
 
-            GameSystems = new List<GameSystem>();
+                GameSystems = new List<GameSystem>();
 
-            Audio = AddDisposable(new AudioSystem(this));
+                Audio = AddDisposable(new AudioSystem(this));
 
-            Graphics = AddDisposable(new GraphicsSystem(this));
+                Graphics = AddDisposable(new GraphicsSystem(this));
 
-            Scripting = AddDisposable(new ScriptingSystem(this));
+                Scripting = AddDisposable(new ScriptingSystem(this));
 
-            Scene2D = new Scene2D(this);
+                Scene2D = new Scene2D(this);
 
-            Selection = AddDisposable(new SelectionSystem(this));
+                Selection = AddDisposable(new SelectionSystem(this));
 
-            OrderGenerator = AddDisposable(new OrderGeneratorSystem(this));
+                OrderGenerator = AddDisposable(new OrderGeneratorSystem(this));
 
-            Panel.ClientSizeChanged += OnPanelSizeChanged;
-            OnPanelSizeChanged(this, EventArgs.Empty);
+                Panel.ClientSizeChanged += OnPanelSizeChanged;
+                OnPanelSizeChanged(this, EventArgs.Empty);
 
-            GameSystems.ForEach(gs => gs.Initialize());
+                GameSystems.ForEach(gs => gs.Initialize());
 
-            SetCursor("Arrow");
+                SetCursor("Arrow");
 
-            var playerTemplate = ContentManager.IniDataContext.PlayerTemplates.Find(t => t.Side == "Civilian");
-            CivilianPlayer = Player.FromTemplate(playerTemplate, ContentManager);
+                var playerTemplate = ContentManager.IniDataContext.PlayerTemplates.Find(t => t.Side == "Civilian");
+                CivilianPlayer = Player.FromTemplate(playerTemplate, ContentManager);
 
-            _developerModeView = AddDisposable(new DeveloperModeView(this));
+                _developerModeView = AddDisposable(new DeveloperModeView(this));
 
-            LauncherImage = LoadLauncherImage();
+                LauncherImage = LoadLauncherImage();
 
-            _mapTimer.Reset();
+                _mapTimer.Reset();
 
-            IsRunning = true;
-            IsLogicRunning = true;
+                IsRunning = true;
+                IsLogicRunning = true;
+            }
         }
 
         private void OnPanelSizeChanged(object sender, EventArgs e)

--- a/src/OpenSage.Game/Graphics/Shaders/ShaderResourceManager.cs
+++ b/src/OpenSage.Game/Graphics/Shaders/ShaderResourceManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using OpenSage.Diagnostics;
 using Veldrid;
 
 namespace OpenSage.Graphics.Shaders
@@ -20,22 +21,25 @@ namespace OpenSage.Graphics.Shaders
 
         public ShaderResourceManager(GraphicsDevice graphicsDevice, Texture solidWhiteTexture)
         {
-            Global = AddDisposable(new GlobalShaderResources(graphicsDevice, solidWhiteTexture));
-            Mesh = AddDisposable(new MeshShaderResources(graphicsDevice));
+            using (GameTrace.TraceDurationEvent("ShaderResourceManager()"))
+            {
+                Global = AddDisposable(new GlobalShaderResources(graphicsDevice, solidWhiteTexture));
+                Mesh = AddDisposable(new MeshShaderResources(graphicsDevice));
 
-            FixedFunction = AddDisposable(new FixedFunctionShaderResources(graphicsDevice, Global, Mesh));
-            MeshDepth = AddDisposable(new MeshDepthShaderResources(graphicsDevice, Global, Mesh));
-            Particle = AddDisposable(new ParticleShaderResources(graphicsDevice, Global));
-            Road = AddDisposable(new RoadShaderResources(graphicsDevice, Global));
-            Sprite = AddDisposable(new SpriteShaderResources(graphicsDevice));
-            Terrain = AddDisposable(new TerrainShaderResources(graphicsDevice, Global));
-            Water = AddDisposable(new WaterShaderResources(graphicsDevice, Global));
+                FixedFunction = AddDisposable(new FixedFunctionShaderResources(graphicsDevice, Global, Mesh));
+                MeshDepth = AddDisposable(new MeshDepthShaderResources(graphicsDevice, Global, Mesh));
+                Particle = AddDisposable(new ParticleShaderResources(graphicsDevice, Global));
+                Road = AddDisposable(new RoadShaderResources(graphicsDevice, Global));
+                Sprite = AddDisposable(new SpriteShaderResources(graphicsDevice));
+                Terrain = AddDisposable(new TerrainShaderResources(graphicsDevice, Global));
+                Water = AddDisposable(new WaterShaderResources(graphicsDevice, Global));
 
-            _shaderMaterialResources = new Dictionary<string, ShaderMaterialShaderResources>
+                _shaderMaterialResources = new Dictionary<string, ShaderMaterialShaderResources>
             {
                 { "NormalMapped", AddDisposable(new NormalMappedShaderResources(graphicsDevice, Global, Mesh)) },
                 { "Simple", AddDisposable(new SimpleShaderResources(graphicsDevice, Global, Mesh)) }
             };
+            }
         }
 
         public ShaderMaterialShaderResources GetShaderMaterialResources(string name)

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -36,8 +36,8 @@ namespace OpenSage.Launcher
             [Option("developermode", Default = false, Required = false, HelpText = "Enable developer mode.")]
             public bool DeveloperMode { get; set; }
 
-            [Option("trace", Default = null, Required = false, HelpText = "Trace output path.")]
-            public string Trace { get; set; }
+            [Option("tracefile", Default = null, Required = false, HelpText = "Generate trace output to the specified path, for example `--tracefile trace.json`. Trace files can be loaded into Chrome's tracing GUI at chrome://tracing")]
+            public string TraceFile { get; set; }
         }
 
         public static void Main(string[] args)
@@ -73,10 +73,10 @@ namespace OpenSage.Launcher
 
             Platform.Start();
 
-            var traceEnabled = !string.IsNullOrEmpty(opts.Trace);
+            var traceEnabled = !string.IsNullOrEmpty(opts.TraceFile);
             if (traceEnabled)
             {
-                GameTrace.Start(opts.Trace);
+                GameTrace.Start(opts.TraceFile);
             }
 
             // TODO: Read game version from assembly metadata or .git folder

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using CommandLine;
 using OpenSage.Data;
+using OpenSage.Diagnostics;
 using OpenSage.Logic;
 using OpenSage.Mathematics;
 using OpenSage.Mods.BuiltIn;
@@ -34,6 +35,9 @@ namespace OpenSage.Launcher
 
             [Option("developermode", Default = false, Required = false, HelpText = "Enable developer mode.")]
             public bool DeveloperMode { get; set; }
+
+            [Option("trace", Default = null, Required = false, HelpText = "Trace output path.")]
+            public string Trace { get; set; }
         }
 
         public static void Main(string[] args)
@@ -69,6 +73,12 @@ namespace OpenSage.Launcher
 
             Platform.Start();
 
+            var traceEnabled = !string.IsNullOrEmpty(opts.Trace);
+            if (traceEnabled)
+            {
+                GameTrace.Start(opts.Trace);
+            }
+
             // TODO: Read game version from assembly metadata or .git folder
             // TODO: Set window icon.
             using (var game = new Game(installation, opts.Renderer, opts.Fullscreen))
@@ -98,6 +108,11 @@ namespace OpenSage.Launcher
                 }
 
                 game.Run();
+            }
+
+            if (traceEnabled)
+            {
+                GameTrace.Stop();
             }
 
             Platform.Stop();


### PR DESCRIPTION
This adds support for optionally outputting trace data to a .json file, which can then loaded into Chrome's profiler at chrome://tracing. This PR just adds very basic support, which needs to be fleshed out with more tracing calls.