### PR TITLE
game folder detection + new start parameters + new custom game type + userdataleaf in game def. + toolmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Generals and Command & Conquer: Generals Zero Hour. Support for other SAGE-based
 games may come later. The primary development target is Windows, with support
 planned for macOS at a later date.
 
+**OpenSAGE-Plus:** a modder and user experience focused fork that wants to deliver entirely new features to the core engine - mainly new gamemodes, more script actions and conditions, extended LUA scripting capabilities, more start parameters including a toolmode to deal with all SAGE file formats. 
+
 ## Work in progress
 
 This project is in the *very* early stages. There is still a long way to go before there's anything playable. 

--- a/src/OpenSage.Game/Data/InstallationLocator.cs
+++ b/src/OpenSage.Game/Data/InstallationLocator.cs
@@ -27,10 +27,10 @@ namespace OpenSage.Data
 
     public sealed class GameInstallation
     {
-        public static IEnumerable<GameInstallation> FindAll(IEnumerable<IGameDefinition> gameDefinitions)
+        public static IEnumerable<GameInstallation> FindAll(IEnumerable<IGameDefinition> gameDefinitions, bool ForceUseEnvironmentGamePath)
         {
             return InstallationLocators
-                .GetAllForPlatform()
+                .GetAllForPlatform(ForceUseEnvironmentGamePath)
                 .SelectMany(x => gameDefinitions.SelectMany(y => x.FindInstallations(y)));
         }
 
@@ -126,9 +126,9 @@ namespace OpenSage.Data
 
     public static class InstallationLocators
     {
-        public static IEnumerable<IInstallationLocator> GetAllForPlatform()
+        public static IEnumerable<IInstallationLocator> GetAllForPlatform(bool ForceUseEnvironmentGamePath)
         {
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT && !ForceUseEnvironmentGamePath)
             {
                 yield return new RegistryInstallationLocator();
             }
@@ -136,9 +136,9 @@ namespace OpenSage.Data
             yield return new EnvironmentInstallationLocator();
         }
 
-        public static IEnumerable<GameInstallation> FindAllInstallations(IGameDefinition game)
+        public static IEnumerable<GameInstallation> FindAllInstallations(IGameDefinition game, bool ForceUseEnvironmentGamePath)
         {
-            var locators = GetAllForPlatform();
+            var locators = GetAllForPlatform(ForceUseEnvironmentGamePath);
             var result = new List<GameInstallation>();
             foreach (var locator in locators)
             {

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -211,7 +211,9 @@ namespace OpenSage
         public Game(
             GameInstallation installation,
             GraphicsBackend? preferredBackend,
-            bool fullscreen = false)
+            bool fullscreen = false,
+            int xres = 1024,
+            int yres = 768)
         {
             using (GameTrace.TraceDurationEvent("Game()"))
             {
@@ -221,7 +223,7 @@ namespace OpenSage
                 // TODO: Read game version from assembly metadata or .git folder
                 // TODO: Set window icon.
                 Window = AddDisposable(new GameWindow($"OpenSAGE - {installation.Game.DisplayName} - master",
-                                                        100, 100, 1024, 768, preferredBackend, fullscreen));
+                                                        100, 100, xres, yres, preferredBackend, fullscreen));
                 GraphicsDevice = Window.GraphicsDevice;
 
                 Panel = AddDisposable(new GamePanel(GraphicsDevice));

--- a/src/OpenSage.Game/IGameDefinition.cs
+++ b/src/OpenSage.Game/IGameDefinition.cs
@@ -15,7 +15,8 @@ namespace OpenSage
 
         IEnumerable<RegistryKeyPath> RegistryKeys { get; }
         IEnumerable<RegistryKeyPath> LanguageRegistryKeys { get; }
-        
+        IEnumerable<RegistryKeyPath> UserDataLeafName { get; }
+
         IMainMenuSource MainMenu { get; }
         IControlBarSource ControlBar { get; }
 

--- a/src/OpenSage.Game/Scripting/LuaScriptEngine.cs
+++ b/src/OpenSage.Game/Scripting/LuaScriptEngine.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenSage.Scripting
+{
+    class LuaScriptEngine
+    {
+    }
+}

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -88,7 +88,7 @@ namespace OpenSage.Launcher
             public string Decompress { get; set; }
 
             //not implemented yet
-            [Option("compress", Default = null, Required = false, HelpText = "Use RefPack compression for a file (e.g. map file)")]
+            [Option("compress", Default = null, Required = false, HelpText = "Use RefPack to compress a file (e.g. map file)")]
             public string Compress { get; set; }
 
             //not implemented yet
@@ -97,7 +97,7 @@ namespace OpenSage.Launcher
 
             //not implemented yet
             [Option("compressbig", Default = null, Required = false, HelpText = "Compress BIG files")]
-            public IEnumerable<string> CompressBigFileList { get; set; }
+            public IEnumerable<string> CompressToBigFileList { get; set; }
 
             //not implemented yet
             [Option("viewasset", Default = null, Required = false, HelpText = "View asset (e.g. w3d file)")]
@@ -106,6 +106,10 @@ namespace OpenSage.Launcher
             //not implemented yet
             [Option('u', "userdata", Default = null, Required = false, HelpText = "Use custom userdata folder")]
             public string UserDataFolder { get; set; }
+
+            //not implemented yet
+            [Option('t', "toolmode", Default = false, Required = false, HelpText = "enable toolmode to allow several file operation commands")]
+            public bool Toolmode { get; set; }
 
         }
 
@@ -118,84 +122,110 @@ namespace OpenSage.Launcher
 
         public static void Run(Options opts)
         {
+            if (opts.Toolmode)
+            {
+                if (opts.Decompress != null)
+                {
+                    var FileStream = OpenSage.Data.Map.MapFile.Decompress(File.OpenRead(opts.Decompress));
+                    var UncompressedFilePath = String.Concat(Path.GetFileNameWithoutExtension(opts.Decompress), "_uncompressed", Path.GetExtension(opts.Decompress));
+                    var NewFileStream = File.Create(UncompressedFilePath);
+                    byte[] buffer = new byte[8 * 1024];
+                    int len;
+                    while ((len = FileStream.Read(buffer, 0, buffer.Length)) > 0)
+                    {
+                        NewFileStream.Write(buffer, 0, len);
+                    }
+                    Console.WriteLine($"Uncompressed file saved to {UncompressedFilePath}");
+                }
+
+                if (opts.Compress != null)
+                {
+
+                }
+
+                if (!(opts.CompressToBigFileList == null || !opts.CompressToBigFileList.Any()))
+                {
+
+                }
+
+                if (!(opts.ExtractBigFileList == null || !opts.ExtractBigFileList.Any()))
+                {
+
+                }
+
+                if (opts.AssetFile != null) 
+                {
+
+                }
+
+                Environment.Exit(1);
+            }
+
+            var DetectedGame = opts.Game;
+            var GameFolder = opts.GamePath;
             var ForceUseEnvironmentGamePath = true;
 
-            if (opts.GamePath == null)
+            if (GameFolder == null)
             {
-                opts.GamePath = Environment.CurrentDirectory;
+                GameFolder = Environment.CurrentDirectory;
             }
-            if (File.Exists(Path.Combine(opts.GamePath, "generals.exe")) && File.Exists(Path.Combine(opts.GamePath, "INI.big")))
+            if (File.Exists(Path.Combine(GameFolder, "generals.exe")) && File.Exists(Path.Combine(GameFolder, "INI.big")))
             {
-                opts.Game = SageGame.CncGenerals;
+                DetectedGame = SageGame.CncGenerals;
             }
-            else if (File.Exists(Path.Combine(opts.GamePath, "generals.exe")) && File.Exists(Path.Combine(opts.GamePath, "INIZH.big")))
+            else if (File.Exists(Path.Combine(GameFolder, "generals.exe")) && File.Exists(Path.Combine(GameFolder, "INIZH.big")))
             {
-                opts.Game = SageGame.CncGeneralsZeroHour;
+                DetectedGame = SageGame.CncGeneralsZeroHour;
             }
-            else if (File.Exists(Path.Combine(opts.GamePath, "lotrbfme.exe")))
+            else if (File.Exists(Path.Combine(GameFolder, "lotrbfme.exe")))
             {
-                opts.Game = SageGame.Bfme;
+                DetectedGame = SageGame.Bfme;
             }
-            else if (File.Exists(Path.Combine(opts.GamePath, "lotrbfme2.exe")))
+            else if (File.Exists(Path.Combine(GameFolder, "lotrbfme2.exe")))
             {
-                opts.Game = SageGame.Bfme2;
+                DetectedGame = SageGame.Bfme2;
             }
-            else if (File.Exists(Path.Combine(opts.GamePath, "lotrbfme2ep1.exe")))
+            else if (File.Exists(Path.Combine(GameFolder, "lotrbfme2ep1.exe")))
             {
-                opts.Game = SageGame.Bfme2Rotwk;
+                DetectedGame = SageGame.Bfme2Rotwk;
             }
-            else if (File.Exists(Path.Combine(opts.GamePath, "CNC3.exe")))
+            else if (File.Exists(Path.Combine(GameFolder, "CNC3.exe")))
             {
-                opts.Game = SageGame.Cnc3;
+                DetectedGame = SageGame.Cnc3;
             }
-            else if (File.Exists(Path.Combine(opts.GamePath, "CNC3EP1.exe")))
+            else if (File.Exists(Path.Combine(GameFolder, "CNC3EP1.exe")))
             {
-                opts.Game = SageGame.Cnc3KanesWrath;
+                DetectedGame = SageGame.Cnc3KanesWrath;
             }
-            else if (File.Exists(Path.Combine(opts.GamePath, "RA3.exe")))
+            else if (File.Exists(Path.Combine(GameFolder, "RA3.exe")))
             {
-                opts.Game = SageGame.Ra3;
+                DetectedGame = SageGame.Ra3;
             }
-            else if (File.Exists(Path.Combine(opts.GamePath, "RA3EP1.exe")))
+            else if (File.Exists(Path.Combine(GameFolder, "RA3EP1.exe")))
             {
-                opts.Game = SageGame.Ra3Uprising;
+                DetectedGame = SageGame.Ra3Uprising;
             }
-            else if (File.Exists(Path.Combine(opts.GamePath, "CNC4.exe")))
+            else if (File.Exists(Path.Combine(GameFolder, "CNC4.exe")))
             {
-                opts.Game = SageGame.Cnc4;
+                DetectedGame = SageGame.Cnc4;
             }
             else
             {
                 //default game
-                opts.Game = SageGame.CncGenerals;
+                DetectedGame = SageGame.CncGenerals;
                 ForceUseEnvironmentGamePath = false;
             }
 
-            var definition = GameDefinition.FromGame(opts.Game);
+            var definition = GameDefinition.FromGame(DetectedGame);
 
             if (ForceUseEnvironmentGamePath)
             {
-                System.Environment.SetEnvironmentVariable(definition.Identifier.ToUpperInvariant() + "_PATH", opts.GamePath);
+                System.Environment.SetEnvironmentVariable(definition.Identifier.ToUpperInvariant() + "_PATH", GameFolder);
             }
 
             var installation = GameInstallation
                 .FindAll(new[] { definition }, ForceUseEnvironmentGamePath)
                 .FirstOrDefault();
-
-            if (opts.Decompress != null)
-            {
-                var FileStream = OpenSage.Data.Map.MapFile.Decompress(File.OpenRead(opts.Decompress));
-                var UncompressedFilePath = String.Concat(Path.GetFileNameWithoutExtension(opts.Decompress), "_uncompressed", Path.GetExtension(opts.Decompress));
-                var NewFileStream = File.Create(UncompressedFilePath);
-                byte[] buffer = new byte[8 * 1024];
-                int len;
-                while ((len = FileStream.Read(buffer, 0, buffer.Length)) > 0)
-                {
-                    NewFileStream.Write(buffer, 0, len);
-                }
-                Console.WriteLine($"Uncompressed file saved to {UncompressedFilePath}");
-                Environment.Exit(1);
-            }
 
             if (installation == null)
             {

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -8,6 +8,8 @@ using OpenSage.Mathematics;
 using OpenSage.Mods.BuiltIn;
 using OpenSage.Network;
 using Veldrid;
+using System.IO;
+using System.Collections.Generic;
 
 namespace OpenSage.Launcher
 {
@@ -33,11 +35,78 @@ namespace OpenSage.Launcher
             [Option('f', "fullscreen", Default = false, Required = false, HelpText = "Enable fullscreen mode.")]
             public bool Fullscreen { get; set; }
 
+            //not implemented yet
+            [Option("win", Default = true, Required = false, HelpText = "Force windowed game.")]
+            public bool Windowed { get; set; }
+
             [Option("developermode", Default = false, Required = false, HelpText = "Enable developer mode.")]
             public bool DeveloperMode { get; set; }
 
+            [Option("scriptDebugLite", Default = false, Required = false, HelpText = "Enable developer mode.")]
+            public bool ScriptDebugLite { get; set; }
+
+            [Option("scriptDebug2", Default = false, Required = false, HelpText = "Enable developer mode.")]
+            public bool ScriptDebug2 { get; set; }
+
             [Option("tracefile", Default = null, Required = false, HelpText = "Generate trace output to the specified path, for example `--tracefile trace.json`. Trace files can be loaded into Chrome's tracing GUI at chrome://tracing")]
             public string TraceFile { get; set; }
+
+            [Option('p', "gamepath", Default = null, Required = false, HelpText = "Force game to use this gamepath")]
+            public string GamePath { get; set; }
+
+            [Option('x', "xres", Default = 1024, Required = false, HelpText = "Diplayresolution width")]
+            public int Xresolution { get; set; }
+
+            [Option('y', "yres", Default = 768, Required = false, HelpText = "Diplayresolution height")]
+            public int Yresolution { get; set; }
+
+            //not implemented yet
+            [Option("fps", Default = 60, Required = false, HelpText = "Force FPS")]
+            public int FPS { get; set; }
+
+            //not implemented yet
+            [Option("noFPSLimit", Default = false, Required = false, HelpText = "Force windowed game.")]
+            public bool NoFPSLimit { get; set; }
+
+            //not implemented yet
+            [Option("LogicTickRate", Default = null, Required = false, HelpText = "Force LogicTickRate.")]
+            public int LogicTickRate { get; set; }
+
+            //not implemented yet
+            [Option("mod", Default = null, Required = false, HelpText = "Load mod file(s) and/or folder(s)")]
+            public IEnumerable<string> ModPaths { get; set; }
+
+            //not implemented yet
+            [Option("lang", Default = null, Required = false, HelpText = "Try to use a certain language if possible.")]
+            public string Language { get; set; }
+
+            //not implemented yet
+            [Option("preferLocalFiles", Default = false, Required = false, HelpText = "Local INI/XML files have priority compared to files in archives.")]
+            public bool PreferLocalFiles { get; set; }
+
+            [Option("decompress", Default = null, Required = false, HelpText = "Decompress a RefPack compression file (e.g. map file)")]
+            public string Decompress { get; set; }
+
+            //not implemented yet
+            [Option("compress", Default = null, Required = false, HelpText = "Use RefPack compression for a file (e.g. map file)")]
+            public string Compress { get; set; }
+
+            //not implemented yet
+            [Option("extractbig", Default = null, Required = false, HelpText = "Extract BIG files")]
+            public IEnumerable<string> ExtractBigFileList { get; set; }
+
+            //not implemented yet
+            [Option("compressbig", Default = null, Required = false, HelpText = "Compress BIG files")]
+            public IEnumerable<string> CompressBigFileList { get; set; }
+
+            //not implemented yet
+            [Option("viewasset", Default = null, Required = false, HelpText = "View asset (e.g. w3d file)")]
+            public string AssetFile { get; set; }
+
+            //not implemented yet
+            [Option('u', "userdata", Default = null, Required = false, HelpText = "Use custom userdata folder")]
+            public string UserDataFolder { get; set; }
+
         }
 
         public static void Main(string[] args)
@@ -46,13 +115,87 @@ namespace OpenSage.Launcher
               .WithParsed(opts => Run(opts));
         }
 
+
         public static void Run(Options opts)
         {
+            var ForceUseEnvironmentGamePath = true;
+
+            if (opts.GamePath == null)
+            {
+                opts.GamePath = Environment.CurrentDirectory;
+            }
+            if (File.Exists(Path.Combine(opts.GamePath, "generals.exe")) && File.Exists(Path.Combine(opts.GamePath, "INI.big")))
+            {
+                opts.Game = SageGame.CncGenerals;
+            }
+            else if (File.Exists(Path.Combine(opts.GamePath, "generals.exe")) && File.Exists(Path.Combine(opts.GamePath, "INIZH.big")))
+            {
+                opts.Game = SageGame.CncGeneralsZeroHour;
+            }
+            else if (File.Exists(Path.Combine(opts.GamePath, "lotrbfme.exe")))
+            {
+                opts.Game = SageGame.Bfme;
+            }
+            else if (File.Exists(Path.Combine(opts.GamePath, "lotrbfme2.exe")))
+            {
+                opts.Game = SageGame.Bfme2;
+            }
+            else if (File.Exists(Path.Combine(opts.GamePath, "lotrbfme2ep1.exe")))
+            {
+                opts.Game = SageGame.Bfme2Rotwk;
+            }
+            else if (File.Exists(Path.Combine(opts.GamePath, "CNC3.exe")))
+            {
+                opts.Game = SageGame.Cnc3;
+            }
+            else if (File.Exists(Path.Combine(opts.GamePath, "CNC3EP1.exe")))
+            {
+                opts.Game = SageGame.Cnc3KanesWrath;
+            }
+            else if (File.Exists(Path.Combine(opts.GamePath, "RA3.exe")))
+            {
+                opts.Game = SageGame.Ra3;
+            }
+            else if (File.Exists(Path.Combine(opts.GamePath, "RA3EP1.exe")))
+            {
+                opts.Game = SageGame.Ra3Uprising;
+            }
+            else if (File.Exists(Path.Combine(opts.GamePath, "CNC4.exe")))
+            {
+                opts.Game = SageGame.Cnc4;
+            }
+            else
+            {
+                //default game
+                opts.Game = SageGame.CncGenerals;
+                ForceUseEnvironmentGamePath = false;
+            }
+
             var definition = GameDefinition.FromGame(opts.Game);
 
+            if (ForceUseEnvironmentGamePath)
+            {
+                System.Environment.SetEnvironmentVariable(definition.Identifier.ToUpperInvariant() + "_PATH", opts.GamePath);
+            }
+
             var installation = GameInstallation
-                .FindAll(new[] { definition })
+                .FindAll(new[] { definition }, ForceUseEnvironmentGamePath)
                 .FirstOrDefault();
+
+            if (opts.Decompress != null)
+            {
+                var FileStream = OpenSage.Data.Map.MapFile.Decompress(File.OpenRead(opts.Decompress));
+                var UncompressedFilePath = String.Concat(Path.GetFileNameWithoutExtension(opts.Decompress), "_uncompressed", Path.GetExtension(opts.Decompress));
+                var NewFileStream = File.Create(UncompressedFilePath);
+                byte[] buffer = new byte[8 * 1024];
+                int len;
+                while ((len = FileStream.Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    NewFileStream.Write(buffer, 0, len);
+                }
+                Console.WriteLine($"Uncompressed file saved to {UncompressedFilePath}");
+                Environment.Exit(1);
+            }
 
             if (installation == null)
             {
@@ -81,14 +224,17 @@ namespace OpenSage.Launcher
 
             // TODO: Read game version from assembly metadata or .git folder
             // TODO: Set window icon.
-            using (var game = new Game(installation, opts.Renderer, opts.Fullscreen))
+            using (var game = new Game(installation, opts.Renderer, opts.Fullscreen, opts.Xresolution, opts.Yresolution))
             {
                 game.GraphicsDevice.SyncToVerticalBlank = !opts.DisableVsync;
 
                 game.Configuration.LoadShellMap = !opts.NoShellmap;
 
-                game.DeveloperModeEnabled = opts.DeveloperMode;
-
+                if (opts.DeveloperMode || opts.ScriptDebugLite || opts.ScriptDebug2)
+                {
+                    game.DeveloperModeEnabled = true;
+                }
+                
                 if (opts.Map == null)
                 {
                     game.ShowMainMenu();

--- a/src/OpenSage.Mods.Bfme/BfmeDefinition.cs
+++ b/src/OpenSage.Mods.Bfme/BfmeDefinition.cs
@@ -20,8 +20,13 @@ namespace OpenSage.Mods.BFME
         };
 
         public IEnumerable<RegistryKeyPath> LanguageRegistryKeys { get; } = new[]
-{
+        {
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\EA Games\The Battle for Middle-earth", "Language")
+        };
+
+        public IEnumerable<RegistryKeyPath> UserDataLeafName { get; } = new[]
+        {
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\EA Games\The Battle for Middle-earth", "UserDataLeafName")
         };
 
         public string Identifier { get; } = "bfme";

--- a/src/OpenSage.Mods.Bfme2/Bfme2Definition.cs
+++ b/src/OpenSage.Mods.Bfme2/Bfme2Definition.cs
@@ -24,6 +24,11 @@ namespace OpenSage.Mods.Bfme2
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\The Battle for Middle-earth II", "Language")
         };
 
+        public IEnumerable<RegistryKeyPath> UserDataLeafName { get; } = new[]
+        {
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\The Battle for Middle-earth II", "UserDataLeafName")
+        };
+
         public string Identifier { get; } = "bfme2";
 
         public IMainMenuSource MainMenu { get; } = new AptMainMenuSource("MainMenu.apt");

--- a/src/OpenSage.Mods.Bfme2/Bfme2RotwkDefinition.cs
+++ b/src/OpenSage.Mods.Bfme2/Bfme2RotwkDefinition.cs
@@ -21,7 +21,12 @@ namespace OpenSage.Mods.Bfme2
 
         public IEnumerable<RegistryKeyPath> LanguageRegistryKeys { get; } = new[]
         {
-            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\The Battle for Middle-earth II", "Language")
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\The Lord of the Rings, The Rise of the Witch-king", "Language")
+        };
+
+        public IEnumerable<RegistryKeyPath> UserDataLeafName { get; } = new[]
+        {
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\The Lord of the Rings, The Rise of the Witch-king", "UserDataLeafName")
         };
 
         public string Identifier { get; } = "bfme2_rotwk";

--- a/src/OpenSage.Mods.BuiltIn/GameDefinition.cs
+++ b/src/OpenSage.Mods.BuiltIn/GameDefinition.cs
@@ -7,6 +7,7 @@ using OpenSage.Mods.Bfme2;
 using OpenSage.Mods.Cnc4;
 using OpenSage.Mods.CnC3;
 using OpenSage.Mods.Ra3;
+//using OpenSage.Mods.CustomGame;
 
 namespace OpenSage.Mods.BuiltIn
 {
@@ -38,7 +39,8 @@ namespace OpenSage.Mods.BuiltIn
                 [SageGame.Cnc3KanesWrath] = Cnc3KanesWrathDefinition.Instance,
                 [SageGame.Ra3] = Ra3Definition.Instance,
                 [SageGame.Ra3Uprising] = Ra3UprisingDefinition.Instance,
-                [SageGame.Cnc4] = Cnc4Definition.Instance
+                [SageGame.Cnc4] = Cnc4Definition.Instance,
+                //[SageGame.CustomGame] = CustomGameDefinition.Instance
             };
         }
     }

--- a/src/OpenSage.Mods.Cnc3/Cnc3Definition.cs
+++ b/src/OpenSage.Mods.Cnc3/Cnc3Definition.cs
@@ -1,6 +1,7 @@
 ﻿﻿using System.Collections.Generic;
 using OpenSage.Data;
 using OpenSage.Gui;
+using OpenSage.Gui.Apt;
 
 namespace OpenSage.Mods.CnC3
 {
@@ -18,11 +19,19 @@ namespace OpenSage.Mods.CnC3
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Command and Conquer 3", "InstallPath")
         };
 
-        public IEnumerable<RegistryKeyPath> LanguageRegistryKeys { get; }
+        public IEnumerable<RegistryKeyPath> LanguageRegistryKeys { get; } = new[]
+        {
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Command and Conquer 3", "language")
+        };
+
+        public IEnumerable<RegistryKeyPath> UserDataLeafName { get; } = new[]
+        {
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Command and Conquer 3", "userdataleafname")
+        };
 
         public string Identifier { get; } = "cnc3";
 
-        public IMainMenuSource MainMenu { get; }
+        public IMainMenuSource MainMenu { get; } = new AptMainMenuSource("MainMenu.apt");
         public IControlBarSource ControlBar { get; }
 
         public static Cnc3Definition Instance { get; } = new Cnc3Definition();

--- a/src/OpenSage.Mods.Cnc3/Cnc3KanesWrathDefinition.cs
+++ b/src/OpenSage.Mods.Cnc3/Cnc3KanesWrathDefinition.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using OpenSage.Data;
 using OpenSage.Gui;
+using OpenSage.Gui.Apt;
 
 namespace OpenSage.Mods.CnC3
 {
@@ -15,14 +16,22 @@ namespace OpenSage.Mods.CnC3
 
         public IEnumerable<RegistryKeyPath> RegistryKeys { get; } = new[]
         {
-            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Command and Conquer 3 Kanes Wrath", "InstallPath")
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Command and Conquer 3 Kanes Wrath", "installpath")
         };
 
-        public IEnumerable<RegistryKeyPath> LanguageRegistryKeys { get; }
+        public IEnumerable<RegistryKeyPath> LanguageRegistryKeys { get; } = new[]
+        {
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Command and Conquer 3 Kanes Wrath", "language")
+        };
+
+        public IEnumerable<RegistryKeyPath> UserDataLeafName { get; } = new[]
+        {
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Command and Conquer 3 Kanes Wrath", "userdataleafname")
+        };
 
         public string Identifier { get; } = "cnc3_kw";
 
-        public IMainMenuSource MainMenu { get; }
+        public IMainMenuSource MainMenu { get; } = new AptMainMenuSource("MainMenu.apt");
         public IControlBarSource ControlBar { get; }
 
         public static Cnc3KanesWrathDefinition Instance { get; } = new Cnc3KanesWrathDefinition();

--- a/src/OpenSage.Mods.Cnc4/Cnc4Definition.cs
+++ b/src/OpenSage.Mods.Cnc4/Cnc4Definition.cs
@@ -19,7 +19,17 @@ namespace OpenSage.Mods.Cnc4
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\command and conquer 4", "install dir") // Steam
         };
 
-        public IEnumerable<RegistryKeyPath> LanguageRegistryKeys { get; }
+        public IEnumerable<RegistryKeyPath> LanguageRegistryKeys { get; } = new[]
+        {
+            new RegistryKeyPath(@"SOFTWARE\EA Games\Command Conquer 4 Tiberian Twilight", "language"), // Origin
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\command and conquer 4", "language") // Steam
+        };
+
+        public IEnumerable<RegistryKeyPath> UserDataLeafName { get; } = new[]
+        {
+            new RegistryKeyPath(@"SOFTWARE\EA Games\Command Conquer 4 Tiberian Twilight", "userdataleafname"), // Origin
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\command and conquer 4", "userdataleafname") // Steam
+        };
 
         public string Identifier { get; } = "cnc4";
 

--- a/src/OpenSage.Mods.CustomGame/CustomGameDefinition.cs
+++ b/src/OpenSage.Mods.CustomGame/CustomGameDefinition.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using OpenSage.Data;
+using OpenSage.Gui;
+using OpenSage.Gui.Apt;
+
+namespace OpenSage.Mods.CustomGame
+{
+    public class CustomGameDefinition : IGameDefinition
+    {
+        public SageGame Game => SageGame.CustomGame;
+        public string DisplayName => "Custom OpenSage Game";
+        public IGameDefinition BaseGame => null;
+
+        public bool LauncherImagePrefixLang => true;
+        public string LauncherImagePath => "Splash.jpg";
+
+        public IEnumerable<RegistryKeyPath> RegistryKeys { get; }
+
+        public IEnumerable<RegistryKeyPath> LanguageRegistryKeys { get; }
+
+        public IEnumerable<RegistryKeyPath> UserDataLeafName { get; }
+
+        public string Identifier { get; } = "CustomGame";
+
+        public IMainMenuSource MainMenu { get; }
+        public IControlBarSource ControlBar { get; }
+
+        public static CustomGameDefinition Instance { get; } = new CustomGameDefinition();
+    }
+}

--- a/src/OpenSage.Mods.CustomGame/OpenSage.Mods.CustomGame.csproj
+++ b/src/OpenSage.Mods.CustomGame/OpenSage.Mods.CustomGame.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OpenSage.Game\OpenSage.Game.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/OpenSage.Mods.Generals/GeneralsDefinition.cs
+++ b/src/OpenSage.Mods.Generals/GeneralsDefinition.cs
@@ -25,6 +25,11 @@ namespace OpenSage.Mods.Generals
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\EA Games\Generals", "Language")
         };
 
+        public IEnumerable<RegistryKeyPath> UserDataLeafName { get; } = new[]
+        {
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\EA Games\Generals", "")
+        };
+
         public string Identifier { get; } = "cnc_generals";
 
         public IMainMenuSource MainMenu { get; } = new WndMainMenuSource(@"Menus\MainMenu.wnd");

--- a/src/OpenSage.Mods.Generals/GeneralsZeroHourDefinition.cs
+++ b/src/OpenSage.Mods.Generals/GeneralsZeroHourDefinition.cs
@@ -29,6 +29,13 @@ namespace OpenSage.Mods.Generals
             new RegistryKeyPath(@"SOFTWARE\EA Games\Command and Conquer Generals Zero Hour", "Language")
         };
 
+        public IEnumerable<RegistryKeyPath> UserDataLeafName { get; } = new[]
+        {
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\EA Games\Command and Conquer The First Decade", "UserDataLeafName"),
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\EA Games\Command and Conquer Generals Zero Hour", "UserDataLeafName"),
+            new RegistryKeyPath(@"SOFTWARE\EA Games\Command and Conquer Generals Zero Hour", "UserDataLeafName")
+        };
+
         public string Identifier { get; } = "cnc_generals_zh";
 
         public IMainMenuSource MainMenu { get; } = new WndMainMenuSource(@"Menus\MainMenu.wnd");

--- a/src/OpenSage.Mods.Ra3/Ra3Definition.cs
+++ b/src/OpenSage.Mods.Ra3/Ra3Definition.cs
@@ -18,7 +18,15 @@ namespace OpenSage.Mods.Ra3
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Red Alert 3", "Install Dir"),
         };
 
-        public IEnumerable<RegistryKeyPath> LanguageRegistryKeys { get; }
+        public IEnumerable<RegistryKeyPath> LanguageRegistryKeys { get; } = new[]
+        {
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Red Alert 3", "language")
+        };
+
+        public IEnumerable<RegistryKeyPath> UserDataLeafName { get; } = new[]
+        {
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Red Alert 3", "userdataleafname")
+        };
 
         public string Identifier { get; } = "ra3";
 

--- a/src/OpenSage.Mods.Ra3/Ra3UprisingDefinition.cs
+++ b/src/OpenSage.Mods.Ra3/Ra3UprisingDefinition.cs
@@ -18,7 +18,15 @@ namespace OpenSage.Mods.Ra3
             new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Red Alert 3 Uprising", "Install Dir")
         };
 
-        public IEnumerable<RegistryKeyPath> LanguageRegistryKeys { get; }
+        public IEnumerable<RegistryKeyPath> LanguageRegistryKeys { get; } = new[]
+        {
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Red Alert 3 Uprising", "language")
+        };
+
+        public IEnumerable<RegistryKeyPath> UserDataLeafName { get; } = new[]
+        {
+            new RegistryKeyPath(@"SOFTWARE\Electronic Arts\Electronic Arts\Red Alert 3 Uprising", "userdataleafname")
+        };
 
         public string Identifier { get; } = "ra3_uprising";
 


### PR DESCRIPTION
- game folder detection
- new start parameters - some already working, some as placeholders, some were added to get parity with SAGE
- userdataleaf now in game definitions
- new custom game type to not totally depend on EA IP games and for more flexibility for future new game creators
- toolmode parameter to enable file operations (like extractbig, decompress, ...) and not interfere too much with the game start procedure if toolmode enabled options are not used - now only one bool check. Note that enabled toolmode never starts a game. I don't see any disandvantage to not inlcude all these optionalities.