### PR TITLE
Use SortedList to simplify InstructionCollection

### DIFF
--- a/src/OpenSage.Game.Tests/Gui/Apt/ActionScript/InstructionParsingTest.cs
+++ b/src/OpenSage.Game.Tests/Gui/Apt/ActionScript/InstructionParsingTest.cs
@@ -49,8 +49,6 @@ namespace OpenSage.Tests.Gui.Apt.ActionScript
             _output = output;
         }
 
-        
-
         // variableName should be parameter2
         // instruction count should be 19 instead of 20
         private Stream Get19SimpleInstructions(string variableName, string wrongValue, string rightValue, int afterInstructionPosition)

--- a/src/OpenSage.Game.Tests/Gui/Apt/ActionScript/InstructionParsingTest.cs
+++ b/src/OpenSage.Game.Tests/Gui/Apt/ActionScript/InstructionParsingTest.cs
@@ -1,0 +1,123 @@
+﻿using System.IO;
+using static System.Text.Encoding;
+using OpenSage.Gui.Apt;
+using OpenSage.Gui.Apt.ActionScript;
+using OpenSage.Gui.Apt.ActionScript.Opcodes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OpenSage.Tests.Gui.Apt.ActionScript
+{
+    static class Utilities
+    {
+        public static void Align(this BinaryWriter writer)
+        {
+            while (writer.BaseStream.Position % 4 != 0)
+            {
+                writer.Write((byte)0);
+            }
+        }
+
+        public static void WriteSimpleInstruction(this BinaryWriter writer, InstructionType type, int? argument = null)
+        {
+            writer.Write((byte)type);
+            if (argument.HasValue)
+            {
+                if (InstructionAlignment.IsAligned(type))
+                {
+                    Align(writer);
+                }
+                writer.Write(argument.Value);
+            }
+        }
+
+        public static int WriteNullTerminatedString(this BinaryWriter writer, string value)
+        {
+            writer.Align();
+            var position = (int)writer.BaseStream.Position;
+            writer.Write(UTF8.GetBytes(value + '\0'));
+            return position;
+        }
+    }
+
+    public class InstructionParsingTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public InstructionParsingTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        
+
+        // variableName should be parameter2
+        // instruction count should be 19 instead of 20
+        private Stream Get19SimpleInstructions(string variableName, string wrongValue, string rightValue, int afterInstructionPosition)
+        {
+            var instructionStream = new MemoryStream();
+            using (var instructionWriter = new BinaryWriter(instructionStream, UTF8, true))
+            {
+                var variableNamePosition = instructionWriter.WriteNullTerminatedString(variableName);
+                var wrongValuePosition = instructionWriter.WriteNullTerminatedString(wrongValue);
+                var rightValuePosition = instructionWriter.WriteNullTerminatedString(rightValue);
+
+                instructionWriter.Align();
+                var instructionOffset = (uint)instructionStream.Position;
+                instructionWriter.WriteSimpleInstruction(InstructionType.EA_PushOne);
+                instructionWriter.WriteSimpleInstruction(InstructionType.EA_PushZero);
+                instructionWriter.WriteSimpleInstruction(InstructionType.Add2);
+                instructionWriter.WriteSimpleInstruction(InstructionType.BranchIfTrue, 18);
+                instructionWriter.WriteSimpleInstruction(InstructionType.EA_PushString, variableNamePosition);
+                instructionWriter.WriteSimpleInstruction(InstructionType.EA_PushString, wrongValuePosition);
+                instructionWriter.WriteSimpleInstruction(InstructionType.SetVariable);
+                instructionWriter.WriteSimpleInstruction(InstructionType.End);
+                instructionWriter.WriteSimpleInstruction(InstructionType.EA_PushOne);
+                instructionWriter.WriteSimpleInstruction(InstructionType.Not);
+                instructionWriter.WriteSimpleInstruction(InstructionType.BranchIfTrue, 18);
+                instructionWriter.WriteSimpleInstruction(InstructionType.EA_PushString, variableNamePosition);
+                instructionWriter.WriteSimpleInstruction(InstructionType.EA_PushString, rightValuePosition);
+                instructionWriter.WriteSimpleInstruction(InstructionType.SetVariable);
+                instructionWriter.WriteSimpleInstruction(InstructionType.End);
+                instructionWriter.WriteSimpleInstruction(InstructionType.EA_PushString, variableNamePosition);
+                instructionWriter.WriteSimpleInstruction(InstructionType.EA_PushString, wrongValuePosition);
+                instructionWriter.WriteSimpleInstruction(InstructionType.SetVariable);
+                instructionWriter.WriteSimpleInstruction(InstructionType.End);
+
+                // pathological case
+                instructionWriter.WriteSimpleInstruction(InstructionType.BranchIfTrue, -79);
+
+                var instructionOffsetPosition = (int)instructionStream.Position;
+                instructionWriter.Write(instructionOffset);
+                instructionWriter.Write(afterInstructionPosition);
+                instructionWriter.Write("DummyData");
+
+                instructionWriter.Seek(instructionOffsetPosition, SeekOrigin.Begin);
+            }
+            return instructionStream;
+        }
+
+        [Fact]
+        public void ParseAndExecuteSimpleInstructions()
+        {
+            var magic = 123456789;
+            var paramName = "name";
+            var rightValue = "test2";
+            var stream = Get19SimpleInstructions(paramName, "test1", rightValue, magic);
+            var reader = new BinaryReader(stream, UTF8, true);
+            var collection = InstructionCollection.Parse(stream, reader.ReadUInt32());
+            // Assert that the last pathological branch instruction was not read
+            Assert.True(collection.Count == 19);
+
+            var afterInstructions = reader.ReadInt32();
+            // Assert that after parsing instructions, stream will be sought back
+            Assert.True(afterInstructions == magic);
+
+            var context = new ObjectContext(new SpriteItem());
+            var vm = new VM();
+            vm.Execute(collection, context);
+            // Assert that during execution of instructions, the right value is set
+            Assert.True(context.GetMember(paramName).ToString().Equals(rightValue));
+        }
+    }
+}

--- a/src/OpenSage.Game/Data/Apt/Characters/Button.cs
+++ b/src/OpenSage.Game/Data/Apt/Characters/Button.cs
@@ -105,8 +105,8 @@ namespace OpenSage.Data.Apt.Characters
             var flags = reader.ReadByteAsEnumFlags<ButtonActionFlags>();
             var input = reader.ReadUInt16AsEnum<ButtonInput>();
             var reserved = reader.ReadByte();
-            var instructions = new InstructionCollection(reader.BaseStream);
-            instructions.Parse();
+            var instructionsPosition = reader.ReadUInt32();
+            var instructions = InstructionCollection.Parse(reader.BaseStream, instructionsPosition);
 
             return new ButtonAction(flags, input, reserved, instructions);
         }

--- a/src/OpenSage.Game/Data/Apt/FrameItems/Action.cs
+++ b/src/OpenSage.Game/Data/Apt/FrameItems/Action.cs
@@ -12,8 +12,8 @@ namespace OpenSage.Data.Apt.FrameItems
         public static Action Parse(BinaryReader reader)
         {
             var action = new Action();
-            action.Instructions = new InstructionCollection(reader.BaseStream);
-            action.Instructions.Parse();
+            var instructionsPosition = reader.ReadUInt32();
+            action.Instructions = InstructionCollection.Parse(reader.BaseStream, instructionsPosition);
             return action;
         }
     }

--- a/src/OpenSage.Game/Data/Apt/FrameItems/InitAction.cs
+++ b/src/OpenSage.Game/Data/Apt/FrameItems/InitAction.cs
@@ -15,9 +15,8 @@ namespace OpenSage.Data.Apt.FrameItems
         {
             var action = new InitAction();
             action.Sprite = reader.ReadUInt32();
-            var instructions = new InstructionCollection(reader.BaseStream);
-            instructions.Parse();
-            action.Instructions = instructions;
+            var instructionsPosition = reader.ReadUInt32();
+            action.Instructions = InstructionCollection.Parse(reader.BaseStream, instructionsPosition);
             return action;
         }
     }

--- a/src/OpenSage.Game/Data/Apt/FrameItems/PlaceObject.cs
+++ b/src/OpenSage.Game/Data/Apt/FrameItems/PlaceObject.cs
@@ -35,17 +35,18 @@ namespace OpenSage.Data.Apt.FrameItems
     public sealed class ClipEvent
     {
         public ClipEventFlags Flags { get; private set; }
+        public Byte KeyCode { get; private set;  }
         public InstructionCollection Instructions { get; private set; }
 
         public static ClipEvent Parse(BinaryReader reader)
         {
             var ev = new ClipEvent();           
             ev.Flags = reader.ReadUInt24AsEnum<ClipEventFlags>();
-            var keycode = reader.ReadByte();
+            ev.KeyCode = reader.ReadByte();
             var offsetToNext = reader.ReadUInt32();
             //var keycode = reader.ReadByte();
-            ev.Instructions = new InstructionCollection(reader.BaseStream);
-            ev.Instructions.Parse();
+            var instructionsPosition = reader.ReadUInt32();
+            ev.Instructions = InstructionCollection.Parse(reader.BaseStream, instructionsPosition);
             return ev;
         }
     }

--- a/src/OpenSage.Game/Gui/Apt/ActionScript/InstructionCollection.cs
+++ b/src/OpenSage.Game/Gui/Apt/ActionScript/InstructionCollection.cs
@@ -76,10 +76,6 @@ namespace OpenSage.Gui.Apt.ActionScript
             _instructions = instructions;
         }
 
-        /* public InstructionCollection(IList<InstructionBase> list) : base(list)
-        {
-        } */
-
         public IReadOnlyCollection<KeyValuePair<int, InstructionBase>> GetPositionedInstructions()
         {
             return _instructions;

--- a/src/OpenSage.Game/Gui/Apt/ActionScript/InstructionCollection.cs
+++ b/src/OpenSage.Game/Gui/Apt/ActionScript/InstructionCollection.cs
@@ -2,462 +2,503 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
+using static System.Text.Encoding;
 using OpenSage.Data.Utilities.Extensions;
 using OpenSage.FileFormats;
 using OpenSage.Gui.Apt.ActionScript.Opcodes;
 
 namespace OpenSage.Gui.Apt.ActionScript
 {
-    public sealed class InstructionCollection : Collection<InstructionBase>
+    // Provides some helper functions to parse instructions
+    // Implements IDisposable, will automatically seek back the stream once disposed.
+    sealed class InstructionParseHelper : IDisposable
     {
-        private BinaryReader _reader;
-        private uint _offset;
+        public readonly int StartPosition;
+        public int FurthestBranchDestination;
 
-        public InstructionCollection(Stream input)
+        // Current Position (at the time of call) relative to StartPosition
+        public int CurrentPosition => (int)(InputStream.Position);
+
+        private Stream InputStream;
+        private long previousPosition;
+        private bool disposed;
+
+        public InstructionParseHelper(Stream input, long instructionStartPosition)
         {
-            _reader = new BinaryReader(input);
-            _offset = _reader.ReadUInt32();
+            disposed = false;
+
+            InputStream = input;
+            previousPosition = InputStream.Position;
+
+            StartPosition = (int)instructionStartPosition;
+            InputStream.Seek(StartPosition, SeekOrigin.Begin);
+            FurthestBranchDestination = StartPosition;
         }
 
-        public InstructionCollection(IList<InstructionBase> list) : base(list)
+        public void Dispose()
         {
-        }
-
-        public void Parse()
-        {
-            var current = _reader.BaseStream.Position;
-            _reader.BaseStream.Seek(_offset, SeekOrigin.Begin);
-            bool parsing = true;
-            bool branched = false;
-            int branchBytes = 0;
-
-            while (parsing)
+            if(!disposed)
             {
-                //now reader the instructions
-                var type = _reader.ReadByteAsEnum<InstructionType>();
-                var aligned = InstructionAlignment.IsAligned(type);
+                disposed = true;
+                InputStream.Seek(previousPosition, SeekOrigin.Begin);
+            }
+        }
 
-                if (aligned)
+        public BinaryReader GetReader()
+        {
+            return new BinaryReader(InputStream, UTF8, true);
+        }
+
+        // Check if we can continue to parse instructions
+        public bool CanParse(SortedList<int, InstructionBase> instructions)
+        {
+            return instructions.Count == 0 ||
+                instructions.Last().Value.Type != InstructionType.End ||
+                CurrentPosition <= FurthestBranchDestination;
+        }
+
+        // Will calculate FurthestBranchDestination with offset and the current RelativePosition
+        public void ReportBranchOffset(int offset)
+        {
+            FurthestBranchDestination = Math.Max(FurthestBranchDestination, CurrentPosition + offset);
+        }
+    }
+
+    public sealed class InstructionCollection
+    {
+        private readonly SortedList<int, InstructionBase> _instructions;
+
+        public int Count => _instructions.Count;
+
+        public InstructionCollection(SortedList<int, InstructionBase> instructions)
+        {
+            _instructions = instructions;
+        }
+
+        /* public InstructionCollection(IList<InstructionBase> list) : base(list)
+        {
+        } */
+
+        public IReadOnlyCollection<KeyValuePair<int, InstructionBase>> GetPositionedInstructions()
+        {
+            return _instructions;
+        }
+
+        public ReadOnlyCollection<InstructionBase> GetInstructions()
+        {
+            return new ReadOnlyCollection<InstructionBase>(_instructions.Values);
+        }
+
+        public int GetPositionByIndex(int index)
+        {
+            return _instructions.Keys[index];
+        }
+
+        public int GetIndexByPosition(int position)
+        {
+            return _instructions.IndexOfKey(position);
+        }
+
+        public InstructionBase GetInstructionByIndex(int index)
+        {
+            return _instructions.Values[index];
+        }
+
+        public InstructionBase GetInstructionByPosition(int position)
+        {
+            return _instructions[position];
+        }
+
+        public static InstructionCollection Parse(Stream input, long instructionsPosition)
+        {
+            var instructions = new SortedList<int, InstructionBase>();
+            using (var helper = new InstructionParseHelper(input, instructionsPosition))
+            {
+                var reader = helper.GetReader();
+                while (helper.CanParse(instructions))
                 {
-                    var padding = _reader.Align(4);
-                    if (padding > 0)
-                    {
-                        Items.Add(new Padding(padding));
-                        if (branched)
-                        {
-                            branchBytes -= (int) padding;
+                    //now reader the instructions
+                    var instructionPosition = helper.CurrentPosition;
+                    var type = reader.ReadByteAsEnum<InstructionType>();
+                    var requireAlignment = InstructionAlignment.IsAligned(type);
 
-                            if (branchBytes <= 0)
-                            {
-                                branched = false;
-                                branchBytes = 0;
-                            }
-                        }
+                    if (requireAlignment)
+                    {
+                        reader.Align(4);
                     }
-                }
 
-                InstructionBase instruction = null;
-                List<Value> parameters = new List<Value>();
+                    InstructionBase instruction = null;
+                    List<Value> parameters = new List<Value>();
 
-                switch (type)
-                {
-                    case InstructionType.ToNumber:
-                        instruction = new ToNumber();
-                        break;
-                    case InstructionType.NextFrame:
-                        instruction = new NextFrame();
-                        break;
-                    case InstructionType.Play:
-                        instruction = new Play();
-                        break;
-                    case InstructionType.Stop:
-                        instruction = new Stop();
-                        break;
-                    case InstructionType.Add:
-                        instruction = new Add();
-                        break;
-                    case InstructionType.Subtract:
-                        instruction = new Subtract();
-                        break;
-                    case InstructionType.Multiply:
-                        instruction = new Multiply();
-                        break;
-                    case InstructionType.Divide:
-                        instruction = new Divide();
-                        break;
-                    case InstructionType.Not:
-                        instruction = new Not();
-                        break;
-                    case InstructionType.StringEquals:
-                        instruction = new StringEquals();
-                        break;
-                    case InstructionType.Pop:
-                        instruction = new Pop();
-                        break;
-                    case InstructionType.ToInteger:
-                        instruction = new ToInteger();
-                        break;
-                    case InstructionType.GetVariable:
-                        instruction = new GetVariable();
-                        break;
-                    case InstructionType.SetVariable:
-                        instruction = new SetVariable();
-                        break;
-                    case InstructionType.StringConcat:
-                        instruction = new StringConcat();
-                        break;
-                    case InstructionType.GetProperty:
-                        instruction = new GetProperty();
-                        break;
-                    case InstructionType.SetProperty:
-                        instruction = new SetProperty();
-                        break;
-                    case InstructionType.Trace:
-                        instruction = new Trace();
-                        break;
-                    case InstructionType.Delete:
-                        instruction = new Delete();
-                        break;
-                    case InstructionType.Delete2:
-                        instruction = new Delete2();
-                        break;
-                    case InstructionType.DefineLocal:
-                        instruction = new DefineLocal();
-                        break;
-                    case InstructionType.CallFunction:
-                        instruction = new CallFunction();
-                        break;
-                    case InstructionType.Return:
-                        instruction = new Return();
-                        break;
-                    case InstructionType.NewObject:
-                        instruction = new NewObject();
-                        break;
-                    case InstructionType.InitArray:
-                        instruction = new InitArray();
-                        break;
-                    case InstructionType.InitObject:
-                        instruction = new InitObject();
-                        break;
-                    case InstructionType.TypeOf:
-                        instruction = new TypeOf();
-                        break;
-                    case InstructionType.Add2:
-                        instruction = new Add2();
-                        break;
-                    case InstructionType.LessThan2:
-                        instruction = new LessThan2();
-                        break;
-                    case InstructionType.Equals2:
-                        instruction = new Equals2();
-                        break;
-                    case InstructionType.ToString:
-                        instruction = new ToString();
-                        break;
-                    case InstructionType.PushDuplicate:
-                        instruction = new PushDuplicate();
-                        break;
-                    case InstructionType.GetMember:
-                        instruction = new GetMember();
-                        break;
-                    case InstructionType.SetMember:
-                        instruction = new SetMember();
-                        break;
-                    case InstructionType.Increment:
-                        instruction = new Increment();
-                        break;
-                    case InstructionType.Decrement:
-                        instruction = new Decrement();
-                        break;
-                    case InstructionType.CallMethod:
-                        instruction = new CallMethod();
-                        break;
-                    case InstructionType.Enumerate2:
-                        instruction = new Enumerate2();
-                        break;
-                    case InstructionType.EA_PushThis:
-                        instruction = new PushThis();
-                        break;
-                    case InstructionType.EA_PushZero:
-                        instruction = new PushZero();
-                        break;
-                    case InstructionType.EA_PushOne:
-                        instruction = new PushOne();
-                        break;
-                    case InstructionType.EA_CallFunc:
-                        instruction = new CallFunc();
-                        break;
-                    case InstructionType.EA_CallMethodPop:
-                        instruction = new CallMethodPop();
-                        break;
-                    case InstructionType.BitwiseXOr:
-                        instruction = new BitwiseXOr();
-                        break;
-                    case InstructionType.Greater:
-                        instruction = new Greater();
-                        break;
-                    case InstructionType.EA_PushThisVar:
-                        instruction = new PushThisVar();
-                        break;
-                    case InstructionType.EA_PushGlobalVar:
-                        instruction = new PushGlobalVar();
-                        break;
-                    case InstructionType.EA_ZeroVar:
-                        instruction = new ZeroVar();
-                        break;
-                    case InstructionType.EA_PushTrue:
-                        instruction = new PushTrue();
-                        break;
-                    case InstructionType.EA_PushFalse:
-                        instruction = new PushFalse();
-                        break;
-                    case InstructionType.EA_PushNull:
-                        instruction = new PushNull();
-                        break;
-                    case InstructionType.EA_PushUndefined:
-                        instruction = new PushUndefined();
-                        break;
-                    case InstructionType.GotoFrame:
-                        instruction = new GotoFrame();
-                        parameters.Add(Value.FromInteger(_reader.ReadInt32()));
-                        break;
-                    case InstructionType.GetURL:
-                        instruction = new GetUrl();
-                        parameters.Add(Value.FromString(_reader.ReadStringAtOffset()));
-                        parameters.Add(Value.FromString(_reader.ReadStringAtOffset()));
-                        break;
-                    case InstructionType.SetRegister:
-                        instruction = new SetRegister();
-                        parameters.Add(Value.FromInteger(_reader.ReadInt32()));
-                        break;
-                    case InstructionType.ConstantPool:
-                        {
-                            instruction = new ConstantPool();
-                            var count = _reader.ReadUInt32();
-                            var constants = _reader.ReadFixedSizeArrayAtOffset<uint>(() => _reader.ReadUInt32(), count);
-
-                            foreach (var constant in constants)
-                            {
-                                parameters.Add(Value.FromConstant(constant));
-                            }
-                        }
-                        break;
-                    case InstructionType.GotoLabel:
-                        instruction = new GotoLabel();
-                        parameters.Add(Value.FromString(_reader.ReadStringAtOffset()));
-                        break;
-                    case InstructionType.DefineFunction2:
-                        {
-                            instruction = new DefineFunction2();
-                            var name = _reader.ReadStringAtOffset();
-                            var nParams = _reader.ReadUInt32();
-                            var nRegisters = _reader.ReadByte();
-                            var flags = _reader.ReadUInt24();
-
-                            //list of parameter strings
-                            var paramList = _reader.ReadFixedSizeListAtOffset<FunctionArgument>(() => new FunctionArgument()
-                            {
-                                Register = _reader.ReadInt32(),
-                                Parameter = _reader.ReadStringAtOffset(),
-                            },nParams);
-
-                            parameters.Add(Value.FromString(name));
-                            parameters.Add(Value.FromInteger((int)nParams));
-                            parameters.Add(Value.FromInteger((int)nRegisters));
-                            parameters.Add(Value.FromInteger((int)flags));
-                            foreach (var param in paramList)
-                            {
-                                parameters.Add(Value.FromInteger(param.Register));
-                                parameters.Add(Value.FromString(param.Parameter));
-                            }
-                            //body size of the function
-                            parameters.Add(Value.FromInteger(_reader.ReadInt32()));
-                            //skip 8 bytes
-                            _reader.ReadUInt64();
-                        }
-                        break;
-                    case InstructionType.PushData:
-                        {
-                            instruction = new PushData();
-
-                            var count = _reader.ReadUInt32();
-                            var constants = _reader.ReadFixedSizeArrayAtOffset<uint>(() => _reader.ReadUInt32(), count);
-
-                            foreach (var constant in constants)
-                            {
-                                parameters.Add(Value.FromConstant(constant));
-                            }
-                        }
-                        break;
-                    case InstructionType.BranchAlways:
-                        instruction = new BranchAlways();
-                        if (!branched)
-                        {
-                            branchBytes = _reader.ReadInt32();
-                            parameters.Add(Value.FromInteger(branchBytes));
-
-                            if (branchBytes > 0)
-                            {
-                                branchBytes += (int) instruction.Size + 1;
-                                branched = true;
-                            }
-                        }
-                        else
-                        {
-                            parameters.Add(Value.FromInteger(_reader.ReadInt32()));
-                        }
-                        break;
-                    case InstructionType.GetURL2:
-                        instruction = new GetUrl2();
-                        break;
-                    case InstructionType.DefineFunction:
-                        {
-                            instruction = new DefineFunction();
-                            var name = _reader.ReadStringAtOffset();
-                            //list of parameter strings
-                            var paramList = _reader.ReadListAtOffset<string>(() => _reader.ReadStringAtOffset());
-
-                            parameters.Add(Value.FromString(name));
-                            parameters.Add(Value.FromInteger(paramList.Count));
-                            foreach (var param in paramList)
-                            {
-                                parameters.Add(Value.FromString(param));
-                            }
-                            //body size of the function
-                            parameters.Add(Value.FromInteger(_reader.ReadInt32()));
-                            //skip 8 bytes
-                            _reader.ReadUInt64();
-                        }
-                        break;
-                    case InstructionType.BranchIfTrue:
-                        instruction = new BranchIfTrue();
-                        if (!branched)
-                        {
-                            branchBytes = _reader.ReadInt32();
-                            parameters.Add(Value.FromInteger(branchBytes));
-
-                            if (branchBytes > 0)
-                            {
-                                branchBytes += (int) instruction.Size + 1;
-                                branched = true;
-                            }
-                        }
-                        else
-                        {
-                            parameters.Add(Value.FromInteger(_reader.ReadInt32()));
-                        }
-                        break;
-                    case InstructionType.GotoFrame2:
-                        instruction = new GotoFrame2();
-                        parameters.Add(Value.FromInteger(_reader.ReadByte()));
-                        break;
-                    case InstructionType.EA_PushString:
-                        instruction = new PushString();
-                        //the constant id that should be pushed
-                        parameters.Add(Value.FromString(_reader.ReadStringAtOffset()));
-                        break;
-                    case InstructionType.EA_PushConstantByte:
-                        instruction = new PushConstantByte();
-                        //the constant id that should be pushed
-                        parameters.Add(Value.FromConstant(_reader.ReadByte()));
-                        break;
-                    case InstructionType.EA_GetStringVar:
-                        instruction = new GetStringVar();
-                        parameters.Add(Value.FromString(_reader.ReadStringAtOffset()));
-                        break;
-                    case InstructionType.EA_SetStringVar:
-                        instruction = new SetStringVar();
-                        parameters.Add(Value.FromString(_reader.ReadStringAtOffset()));
-                        break;
-                    case InstructionType.EA_GetStringMember:
-                        instruction = new GetStringMember();
-                        parameters.Add(Value.FromString(_reader.ReadStringAtOffset()));
-                        break;
-                    case InstructionType.EA_SetStringMember:
-                        instruction = new SetStringMember();
-                        parameters.Add(Value.FromString(_reader.ReadStringAtOffset()));
-                        break;
-                    case InstructionType.EA_PushValueOfVar:
-                        instruction = new PushValueOfVar();
-                        //the constant id that should be pushed
-                        parameters.Add(Value.FromConstant(_reader.ReadByte()));
-                        break;
-                    case InstructionType.EA_GetNamedMember:
-                        instruction = new GetNamedMember();
-                        parameters.Add(Value.FromConstant(_reader.ReadByte()));
-                        break;
-                    case InstructionType.EA_CallNamedFuncPop:
-                        instruction = new CallNamedFuncPop();
-                        parameters.Add(Value.FromConstant(_reader.ReadByte()));
-                        break;
-                    case InstructionType.EA_CallNamedFunc:
-                        instruction = new CallNamedFunc();
-                        parameters.Add(Value.FromConstant(_reader.ReadByte()));
-                        break;
-                    case InstructionType.EA_CallNamedMethodPop:
-                        instruction = new CallNamedMethodPop();
-                        parameters.Add(Value.FromConstant(_reader.ReadByte()));
-                        break;
-                    case InstructionType.EA_PushFloat:
-                        instruction = new PushFloat();
-                        parameters.Add(Value.FromFloat(_reader.ReadSingle()));
-                        break;
-                    case InstructionType.EA_PushByte:
-                        instruction = new PushByte();
-                        parameters.Add(Value.FromInteger(_reader.ReadByte()));
-                        break;
-                    case InstructionType.EA_PushShort:
-                        instruction = new PushShort();
-                        parameters.Add(Value.FromInteger(_reader.ReadUInt16()));
-                        break;
-                    case InstructionType.End:
-                        instruction = new End();
-
-                        if (!branched)
-                            parsing = false;
-                        break;
-                    case InstructionType.EA_CallNamedMethod:
-                        instruction = new CallNamedMethod();
-                        parameters.Add(Value.FromConstant(_reader.ReadByte()));
-                        break;
-                    case InstructionType.Var:
-                        instruction = new Var();
-                        break;
-                    case InstructionType.EA_PushRegister:
-                        instruction = new PushRegister();
-                        parameters.Add(Value.FromInteger(_reader.ReadByte()));
-                        break;
-                    case InstructionType.EA_PushConstantWord:
-                        instruction = new PushConstantWord();
-                        parameters.Add(Value.FromConstant(_reader.ReadUInt16()));
-                        break;
-                    case InstructionType.EA_CallFuncPop:
-                        instruction = new CallFunctionPop();
-                        break;
-                    case InstructionType.StrictEqual:
-                        instruction = new StrictEquals();
-                        break;
-                    default:
-                        throw new InvalidDataException("Unimplemented bytecode instruction:" + type.ToString());
-                }
-
-                if (instruction != null)
-                {
-                    instruction.Parameters = parameters;
-                    Items.Add(instruction);
-                }
-
-                if (branched)
-                {
-                    branchBytes -= (int) instruction.Size + 1;
-
-                    if (branchBytes <= 0)
+                    switch (type)
                     {
-                        branched = false;
+                        case InstructionType.ToNumber:
+                            instruction = new ToNumber();
+                            break;
+                        case InstructionType.NextFrame:
+                            instruction = new NextFrame();
+                            break;
+                        case InstructionType.Play:
+                            instruction = new Play();
+                            break;
+                        case InstructionType.Stop:
+                            instruction = new Stop();
+                            break;
+                        case InstructionType.Add:
+                            instruction = new Add();
+                            break;
+                        case InstructionType.Subtract:
+                            instruction = new Subtract();
+                            break;
+                        case InstructionType.Multiply:
+                            instruction = new Multiply();
+                            break;
+                        case InstructionType.Divide:
+                            instruction = new Divide();
+                            break;
+                        case InstructionType.Not:
+                            instruction = new Not();
+                            break;
+                        case InstructionType.StringEquals:
+                            instruction = new StringEquals();
+                            break;
+                        case InstructionType.Pop:
+                            instruction = new Pop();
+                            break;
+                        case InstructionType.ToInteger:
+                            instruction = new ToInteger();
+                            break;
+                        case InstructionType.GetVariable:
+                            instruction = new GetVariable();
+                            break;
+                        case InstructionType.SetVariable:
+                            instruction = new SetVariable();
+                            break;
+                        case InstructionType.StringConcat:
+                            instruction = new StringConcat();
+                            break;
+                        case InstructionType.GetProperty:
+                            instruction = new GetProperty();
+                            break;
+                        case InstructionType.SetProperty:
+                            instruction = new SetProperty();
+                            break;
+                        case InstructionType.Trace:
+                            instruction = new Trace();
+                            break;
+                        case InstructionType.Delete:
+                            instruction = new Delete();
+                            break;
+                        case InstructionType.Delete2:
+                            instruction = new Delete2();
+                            break;
+                        case InstructionType.DefineLocal:
+                            instruction = new DefineLocal();
+                            break;
+                        case InstructionType.CallFunction:
+                            instruction = new CallFunction();
+                            break;
+                        case InstructionType.Return:
+                            instruction = new Return();
+                            break;
+                        case InstructionType.NewObject:
+                            instruction = new NewObject();
+                            break;
+                        case InstructionType.InitArray:
+                            instruction = new InitArray();
+                            break;
+                        case InstructionType.InitObject:
+                            instruction = new InitObject();
+                            break;
+                        case InstructionType.TypeOf:
+                            instruction = new TypeOf();
+                            break;
+                        case InstructionType.Add2:
+                            instruction = new Add2();
+                            break;
+                        case InstructionType.LessThan2:
+                            instruction = new LessThan2();
+                            break;
+                        case InstructionType.Equals2:
+                            instruction = new Equals2();
+                            break;
+                        case InstructionType.ToString:
+                            instruction = new ToString();
+                            break;
+                        case InstructionType.PushDuplicate:
+                            instruction = new PushDuplicate();
+                            break;
+                        case InstructionType.GetMember:
+                            instruction = new GetMember();
+                            break;
+                        case InstructionType.SetMember:
+                            instruction = new SetMember();
+                            break;
+                        case InstructionType.Increment:
+                            instruction = new Increment();
+                            break;
+                        case InstructionType.Decrement:
+                            instruction = new Decrement();
+                            break;
+                        case InstructionType.CallMethod:
+                            instruction = new CallMethod();
+                            break;
+                        case InstructionType.Enumerate2:
+                            instruction = new Enumerate2();
+                            break;
+                        case InstructionType.EA_PushThis:
+                            instruction = new PushThis();
+                            break;
+                        case InstructionType.EA_PushZero:
+                            instruction = new PushZero();
+                            break;
+                        case InstructionType.EA_PushOne:
+                            instruction = new PushOne();
+                            break;
+                        case InstructionType.EA_CallFunc:
+                            instruction = new CallFunc();
+                            break;
+                        case InstructionType.EA_CallMethodPop:
+                            instruction = new CallMethodPop();
+                            break;
+                        case InstructionType.BitwiseXOr:
+                            instruction = new BitwiseXOr();
+                            break;
+                        case InstructionType.Greater:
+                            instruction = new Greater();
+                            break;
+                        case InstructionType.EA_PushThisVar:
+                            instruction = new PushThisVar();
+                            break;
+                        case InstructionType.EA_PushGlobalVar:
+                            instruction = new PushGlobalVar();
+                            break;
+                        case InstructionType.EA_ZeroVar:
+                            instruction = new ZeroVar();
+                            break;
+                        case InstructionType.EA_PushTrue:
+                            instruction = new PushTrue();
+                            break;
+                        case InstructionType.EA_PushFalse:
+                            instruction = new PushFalse();
+                            break;
+                        case InstructionType.EA_PushNull:
+                            instruction = new PushNull();
+                            break;
+                        case InstructionType.EA_PushUndefined:
+                            instruction = new PushUndefined();
+                            break;
+                        case InstructionType.GotoFrame:
+                            instruction = new GotoFrame();
+                            parameters.Add(Value.FromInteger(reader.ReadInt32()));
+                            break;
+                        case InstructionType.GetURL:
+                            instruction = new GetUrl();
+                            parameters.Add(Value.FromString(reader.ReadStringAtOffset()));
+                            parameters.Add(Value.FromString(reader.ReadStringAtOffset()));
+                            break;
+                        case InstructionType.SetRegister:
+                            instruction = new SetRegister();
+                            parameters.Add(Value.FromInteger(reader.ReadInt32()));
+                            break;
+                        case InstructionType.ConstantPool:
+                            {
+                                instruction = new ConstantPool();
+                                var count = reader.ReadUInt32();
+                                var constants = reader.ReadFixedSizeArrayAtOffset<uint>(() => reader.ReadUInt32(), count);
+
+                                foreach (var constant in constants)
+                                {
+                                    parameters.Add(Value.FromConstant(constant));
+                                }
+                            }
+                            break;
+                        case InstructionType.GotoLabel:
+                            instruction = new GotoLabel();
+                            parameters.Add(Value.FromString(reader.ReadStringAtOffset()));
+                            break;
+                        case InstructionType.DefineFunction2:
+                            {
+                                instruction = new DefineFunction2();
+                                var name = reader.ReadStringAtOffset();
+                                var nParams = reader.ReadUInt32();
+                                var nRegisters = reader.ReadByte();
+                                var flags = reader.ReadUInt24();
+
+                                //list of parameter strings
+                                var paramList = reader.ReadFixedSizeListAtOffset<FunctionArgument>(() => new FunctionArgument()
+                                {
+                                    Register = reader.ReadInt32(),
+                                    Parameter = reader.ReadStringAtOffset(),
+                                }, nParams);
+
+                                parameters.Add(Value.FromString(name));
+                                parameters.Add(Value.FromInteger((int)nParams));
+                                parameters.Add(Value.FromInteger((int)nRegisters));
+                                parameters.Add(Value.FromInteger((int)flags));
+                                foreach (var param in paramList)
+                                {
+                                    parameters.Add(Value.FromInteger(param.Register));
+                                    parameters.Add(Value.FromString(param.Parameter));
+                                }
+                                //body size of the function
+                                parameters.Add(Value.FromInteger(reader.ReadInt32()));
+                                //skip 8 bytes
+                                reader.ReadUInt64();
+                            }
+                            break;
+                        case InstructionType.PushData:
+                            {
+                                instruction = new PushData();
+
+                                var count = reader.ReadUInt32();
+                                var constants = reader.ReadFixedSizeArrayAtOffset<uint>(() => reader.ReadUInt32(), count);
+
+                                foreach (var constant in constants)
+                                {
+                                    parameters.Add(Value.FromConstant(constant));
+                                }
+                            }
+                            break;
+                        case InstructionType.BranchAlways:
+                            {
+                                instruction = new BranchAlways();
+                                var offset = reader.ReadInt32();
+                                parameters.Add(Value.FromInteger(offset));
+                                helper.ReportBranchOffset(offset);
+                            }
+                            break;
+                        case InstructionType.GetURL2:
+                            instruction = new GetUrl2();
+                            break;
+                        case InstructionType.DefineFunction:
+                            {
+                                instruction = new DefineFunction();
+                                var name = reader.ReadStringAtOffset();
+                                //list of parameter strings
+                                var paramList = reader.ReadListAtOffset<string>(() => reader.ReadStringAtOffset());
+
+                                parameters.Add(Value.FromString(name));
+                                parameters.Add(Value.FromInteger(paramList.Count));
+                                foreach (var param in paramList)
+                                {
+                                    parameters.Add(Value.FromString(param));
+                                }
+                                //body size of the function
+                                parameters.Add(Value.FromInteger(reader.ReadInt32()));
+                                //skip 8 bytes
+                                reader.ReadUInt64();
+                            }
+                            break;
+                        case InstructionType.BranchIfTrue:
+                            {
+                                instruction = new BranchIfTrue();
+                                var offset = reader.ReadInt32();
+                                parameters.Add(Value.FromInteger(offset));
+                                helper.ReportBranchOffset(offset);
+                            }
+                            break;
+                        case InstructionType.GotoFrame2:
+                            instruction = new GotoFrame2();
+                            parameters.Add(Value.FromInteger(reader.ReadByte()));
+                            break;
+                        case InstructionType.EA_PushString:
+                            instruction = new PushString();
+                            //the constant id that should be pushed
+                            parameters.Add(Value.FromString(reader.ReadStringAtOffset()));
+                            break;
+                        case InstructionType.EA_PushConstantByte:
+                            instruction = new PushConstantByte();
+                            //the constant id that should be pushed
+                            parameters.Add(Value.FromConstant(reader.ReadByte()));
+                            break;
+                        case InstructionType.EA_GetStringVar:
+                            instruction = new GetStringVar();
+                            parameters.Add(Value.FromString(reader.ReadStringAtOffset()));
+                            break;
+                        case InstructionType.EA_SetStringVar:
+                            instruction = new SetStringVar();
+                            parameters.Add(Value.FromString(reader.ReadStringAtOffset()));
+                            break;
+                        case InstructionType.EA_GetStringMember:
+                            instruction = new GetStringMember();
+                            parameters.Add(Value.FromString(reader.ReadStringAtOffset()));
+                            break;
+                        case InstructionType.EA_SetStringMember:
+                            instruction = new SetStringMember();
+                            parameters.Add(Value.FromString(reader.ReadStringAtOffset()));
+                            break;
+                        case InstructionType.EA_PushValueOfVar:
+                            instruction = new PushValueOfVar();
+                            //the constant id that should be pushed
+                            parameters.Add(Value.FromConstant(reader.ReadByte()));
+                            break;
+                        case InstructionType.EA_GetNamedMember:
+                            instruction = new GetNamedMember();
+                            parameters.Add(Value.FromConstant(reader.ReadByte()));
+                            break;
+                        case InstructionType.EA_CallNamedFuncPop:
+                            instruction = new CallNamedFuncPop();
+                            parameters.Add(Value.FromConstant(reader.ReadByte()));
+                            break;
+                        case InstructionType.EA_CallNamedFunc:
+                            instruction = new CallNamedFunc();
+                            parameters.Add(Value.FromConstant(reader.ReadByte()));
+                            break;
+                        case InstructionType.EA_CallNamedMethodPop:
+                            instruction = new CallNamedMethodPop();
+                            parameters.Add(Value.FromConstant(reader.ReadByte()));
+                            break;
+                        case InstructionType.EA_PushFloat:
+                            instruction = new PushFloat();
+                            parameters.Add(Value.FromFloat(reader.ReadSingle()));
+                            break;
+                        case InstructionType.EA_PushByte:
+                            instruction = new PushByte();
+                            parameters.Add(Value.FromInteger(reader.ReadByte()));
+                            break;
+                        case InstructionType.EA_PushShort:
+                            instruction = new PushShort();
+                            parameters.Add(Value.FromInteger(reader.ReadUInt16()));
+                            break;
+                        case InstructionType.End:
+                            instruction = new End();
+                            break;
+                        case InstructionType.EA_CallNamedMethod:
+                            instruction = new CallNamedMethod();
+                            parameters.Add(Value.FromConstant(reader.ReadByte()));
+                            break;
+                        case InstructionType.Var:
+                            instruction = new Var();
+                            break;
+                        case InstructionType.EA_PushRegister:
+                            instruction = new PushRegister();
+                            parameters.Add(Value.FromInteger(reader.ReadByte()));
+                            break;
+                        case InstructionType.EA_PushConstantWord:
+                            instruction = new PushConstantWord();
+                            parameters.Add(Value.FromConstant(reader.ReadUInt16()));
+                            break;
+                        case InstructionType.EA_CallFuncPop:
+                            instruction = new CallFunctionPop();
+                            break;
+                        case InstructionType.StrictEqual:
+                            instruction = new StrictEquals();
+                            break;
+                        default:
+                            throw new InvalidDataException("Unimplemented bytecode instruction:" + type.ToString());
+                    }
+
+                    if (instruction != null)
+                    {
+                        instruction.Parameters = parameters;
+                        instructions.Add(instructionPosition, instruction);
                     }
                 }
             }
-            _reader.BaseStream.Seek(current, SeekOrigin.Begin);
+
+            return new InstructionCollection(instructions);
         }
     }
 }

--- a/src/OpenSage.Game/Gui/Apt/ActionScript/InstructionStream.cs
+++ b/src/OpenSage.Game/Gui/Apt/ActionScript/InstructionStream.cs
@@ -16,12 +16,12 @@ namespace OpenSage.Gui.Apt.ActionScript
         /// <summary>
         /// the current instruction
         /// </summary>
-        private int _position;
+        private int _index;
 
         public InstructionStream(InstructionCollection instructions)
         {
             _instructions = instructions;
-            _position = 0;
+            _index = 0;
         }
 
         /// <summary>
@@ -30,43 +30,12 @@ namespace OpenSage.Gui.Apt.ActionScript
         /// <returns></returns>
         public InstructionBase GetInstruction()
         {
-            if (_position - 1 > _instructions.Count)
+            if (_index - 1 > _instructions.Count)
             {
                 throw new IndexOutOfRangeException();
             }
 
-
-            //skip any possible padding
-            if (_instructions[_position].Type == InstructionType.Padding)
-            {
-                ++_position;
-            }
-
-
-            return _instructions[_position++];
-        }
-
-        /// <summary>
-        /// Calculate the byteoffset for an instruction
-        /// </summary>
-        /// <param name="instr">the index of the instruction</param>
-        /// <returns></returns>
-        private uint CalculateByteOffset(int instr)
-        {
-            uint size = 0;
-
-            for (int i = 0; i < instr; ++i)
-            {
-                size += _instructions[i].Size;
-
-                if (_instructions[i].Type != InstructionType.Padding)
-                {
-                    ++size;
-                }
-
-            }
-
-            return size;
+            return _instructions.GetInstructionByIndex(_index++);
         }
 
         /// <summary>
@@ -76,31 +45,25 @@ namespace OpenSage.Gui.Apt.ActionScript
         /// <returns></returns>
         public InstructionCollection GetInstructions(int bytes)
         {
-            //get the amount of instructions contained in that byterange
-            int bytesCount = 0;
-            int instrCount = 0;
+            // get the amount of instructions contained in that byterange
+            var startPosition = _instructions.GetPositionByIndex(_index);
+            var endPosition = startPosition + bytes;
 
-            while (bytesCount < bytes)
+            
+            var subRange = _instructions.GetPositionedInstructions().Skip(_index).TakeWhile((kv) => kv.Key < endPosition);
+            if(subRange.Any() && subRange.First().Key != startPosition) // sanity check
             {
-                var instr = _instructions[_position + instrCount];
-                bytesCount += (int) instr.Size;
-                if (_instructions[_position + instrCount].Type != InstructionType.Padding)
-                    ++bytesCount;
-
-                instrCount++;
-
+                throw new InvalidOperationException("Didn't not get the right instructions!");
             }
 
-            if (bytesCount != bytes)
-                throw new InvalidOperationException("Invalid bytesize");
+            var instructions = new SortedList<int, InstructionBase>();
+            foreach(var (position, instruction) in subRange)
+            {
+                instructions.Add(position, instruction);
+            }
+            _index += instructions.Count;
 
-            var result = _instructions
-                .Skip(_position)
-                .Take(instrCount)
-                .ToList();
-            _position += instrCount;
-
-            return new InstructionCollection(result);
+            return new InstructionCollection(instructions);
         }
 
 
@@ -110,7 +73,7 @@ namespace OpenSage.Gui.Apt.ActionScript
         /// <returns></returns>
         public bool IsFinished()
         {
-            return _position == _instructions.Count;
+            return _index == _instructions.Count;
         }
 
         /// <summary>
@@ -119,36 +82,9 @@ namespace OpenSage.Gui.Apt.ActionScript
         /// <param name="offset">The offset how much to move in bytes</param>
         public void Branch(int offset)
         {
-            bool forward = offset >= 0;
-            int bytesCount = 0;
-            int instrCount = 0;
-
-            if (forward)
-            {
-                while (bytesCount < offset)
-                {
-                    var instr = _instructions[_position + instrCount];
-                    bytesCount += (int) instr.Size;
-                    if (_instructions[_position + instrCount].Type != InstructionType.Padding)
-                        ++bytesCount;
-
-                    instrCount++;
-                }
-            }
-            else
-            {
-                while (bytesCount > offset)
-                {
-                    var instr = _instructions[_position + instrCount];
-                    bytesCount -= (int) instr.Size;
-                    if (_instructions[_position + instrCount].Type != InstructionType.Padding)
-                        --bytesCount;
-
-                    instrCount--;
-                }
-            }
-
-            _position += instrCount;
+            var startPosition = _instructions.GetPositionByIndex(_index);
+            var destinationPosition = startPosition + offset;
+            _index = _instructions.GetIndexByPosition(destinationPosition);
         }
     }
 }


### PR DESCRIPTION
By using `SortedList<int, InstructionBase>`, instruction's position is stored together with instruction itself, which allows fast retrieval of a instruction by its position, and we can avoid to manually calculate branch offsets, so things become a lot simpler xD
(Actually I think we can even remove `InstructionBase.Size` since it's not needed anymore)