### PR TITLE
only allow drag-selection for own units

### DIFF
--- a/src/OpenSage.Game/Logic/SelectionSystem.cs
+++ b/src/OpenSage.Game/Logic/SelectionSystem.cs
@@ -162,6 +162,12 @@ namespace OpenSage.Logic
                     continue;
                 }
 
+                //only allow own objects to be drag selected
+                if (gameObject.Owner != Game.Scene3D.LocalPlayer)
+                {
+                    continue;
+                }
+
                 if (gameObject.Collider.Intersects(boxFrustum))
                 {
                     var objectId = (uint) Game.Scene3D.GameObjects.GetObjectId(gameObject);


### PR DESCRIPTION
fixes the drag selection of all objects, and limits it to local player objects instead