### PR TITLE
Implement .skudef reader

### DIFF
--- a/src/OpenSage.Game/Data/FileSystem.cs
+++ b/src/OpenSage.Game/Data/FileSystem.cs
@@ -7,52 +7,55 @@ namespace OpenSage.Data
 {
     public sealed class FileSystem : IDisposable
     {
-        private readonly FileSystem _nextFileSystem;
-
         private readonly Dictionary<string, FileSystemEntry> _fileTable;
         private readonly List<BigArchive> _bigArchives;
 
         public string RootDirectory { get; }
 
         public IReadOnlyCollection<FileSystemEntry> Files => _fileTable.Values;
-        public FileSystem NextFileSystem => _nextFileSystem;
+        public FileSystem NextFileSystem { get; }
 
         public FileSystem(string rootDirectory, FileSystem nextFileSystem = null)
         {
             RootDirectory = rootDirectory;
 
-            _nextFileSystem = nextFileSystem;
+            NextFileSystem = nextFileSystem;
 
-            _fileTable = new Dictionary<string, FileSystemEntry>(StringComparer.OrdinalIgnoreCase);
+            _fileTable = new Dictionary<string, FileSystemEntry>();
             _bigArchives = new List<BigArchive>();
 
-            // TODO: Figure out if there's a specific order that .big files should be loaded in,
-            // since some files are contained in more than one .big file so the later one
-            // takes precedence over the earlier one.
-
+            // First create entries for all non-.big files
             foreach (var file in Directory.GetFiles(rootDirectory, "*.*", SearchOption.AllDirectories))
             {
                 var ext = Path.GetExtension(file).ToLowerInvariant();
-                if (ext == ".big")
-                {
-                    var archive = new BigArchive(file);
-
-                    _bigArchives.Add(archive);
-
-                    foreach (var entry in archive.Entries)
-                    {
-                        var filePath = NormalizeFilePath(entry.FullName);
-                        _fileTable[filePath] = new FileSystemEntry(this, NormalizeFilePath(filePath), entry.Length, entry.Open);
-                    }
-                }
-                else
+                if (ext != ".big")
                 {
                     var relativePath = file.Substring(rootDirectory.Length);
                     if (relativePath.StartsWith(Path.DirectorySeparatorChar.ToString()))
                     {
                         relativePath = relativePath.Substring(1);
                     }
-                    _fileTable[relativePath] = new FileSystemEntry(this, NormalizeFilePath(relativePath), (uint) new FileInfo(file).Length, () => File.OpenRead(file));
+                    relativePath = NormalizeFilePath(relativePath);
+                    _fileTable.Add(relativePath, new FileSystemEntry(this, relativePath, (uint) new FileInfo(file).Length, () => File.OpenRead(file)));
+                }
+            }
+
+            // Then load .big files
+            SkudefReader.Read(rootDirectory, path => AddBigArchive(path));
+        }
+
+        private void AddBigArchive(string path)
+        {
+            var archive = new BigArchive(path);
+
+            _bigArchives.Add(archive);
+
+            foreach (var entry in archive.Entries)
+            {
+                var filePath = NormalizeFilePath(entry.FullName);
+                if (!_fileTable.ContainsKey(filePath))
+                {
+                    _fileTable.Add(filePath, new FileSystemEntry(this, filePath, entry.Length, entry.Open));
                 }
             }
         }
@@ -61,7 +64,8 @@ namespace OpenSage.Data
         {
             return filePath
                 .Replace('/', Path.DirectorySeparatorChar)
-                .Replace('\\', Path.DirectorySeparatorChar);
+                .Replace('\\', Path.DirectorySeparatorChar)
+                .ToLowerInvariant();
         }
 
         public FileSystemEntry GetFile(string filePath)
@@ -73,7 +77,7 @@ namespace OpenSage.Data
                 return file;
             }
 
-            return _nextFileSystem?.GetFile(filePath);
+            return NextFileSystem?.GetFile(filePath);
         }
 
         public FileSystemEntry SearchFile(string fileName, params string[] searchFolders)
@@ -82,13 +86,14 @@ namespace OpenSage.Data
 
             foreach (var searchFolder in searchFolders)
             {
+                var normalizedSearchFolder = NormalizeFilePath(searchFolder);
                 if (_fileTable.TryGetValue(Path.Combine(searchFolder, fileName), out var file))
                 {
                     return file;
                 }
             }
 
-            return _nextFileSystem?.SearchFile(fileName, searchFolders);
+            return NextFileSystem?.SearchFile(fileName, searchFolders);
         }
 
         public IEnumerable<FileSystemEntry> GetFiles(string folderPath)
@@ -103,9 +108,9 @@ namespace OpenSage.Data
                 }
             }
 
-            if (_nextFileSystem != null)
+            if (NextFileSystem != null)
             {
-                foreach (var entry in _nextFileSystem.GetFiles(folderPath))
+                foreach (var entry in NextFileSystem.GetFiles(folderPath))
                 {
                     yield return entry;
                 }

--- a/src/OpenSage.Game/Data/SkudefReader.cs
+++ b/src/OpenSage.Game/Data/SkudefReader.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+
+namespace OpenSage.Data
+{
+    internal static class SkudefReader
+    {
+        public static void Read(string rootDirectory, Action<string> addBigArchive)
+        {
+            var skudefFiles = Directory.GetFiles(rootDirectory, "*.skudef");
+            var skudefFile = skudefFiles.LastOrDefault(); // TODO: This is not the right logic.
+
+            // If no skudef (i.e. for pre-C&C3 games), use default one.
+            using (var skudefFileContents = (skudefFile != null)
+                ? (TextReader) new StreamReader(skudefFile)
+                : new StringReader("add-bigs-recurse ."))
+            {
+                Read(rootDirectory, skudefFileContents, addBigArchive);
+            }
+        }
+
+        private static void Read(string skudefDirectory, TextReader skudefReader, Action<string> addBigArchive)
+        {
+            string line;
+            while ((line = skudefReader.ReadLine()) != null)
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                var spaceIndex = line.IndexOf(' ');
+                var command = line.Substring(0, spaceIndex);
+                var parameter = line.Substring(spaceIndex + 1);
+                var fullPath = Path.Combine(skudefDirectory, parameter);
+
+                switch (command)
+                {
+                    case "add-big":
+                        addBigArchive(fullPath);
+                        break;
+
+                    case "add-bigs-recurse":
+                        foreach (var bigPath in Directory.GetFiles(fullPath, "*.big", SearchOption.AllDirectories))
+                        {
+                            addBigArchive(bigPath);
+                        }
+                        break;
+
+                    case "add-config":
+                        using (var reader = new StreamReader(fullPath))
+                        {
+                            Read(Path.GetDirectoryName(fullPath), reader, addBigArchive);
+                        }
+                        break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
C&C3 and above used `.skudef` files to define which `.big` files to load, and in which order. Our `FileSystem` implementation now uses these files when loading `.big` archives.

I've made it work for pre-C&C3 games by creating a dummy `.skudef` for those games which justs loads all `.big` files in an alphabetical order. If it turns out that order is important for any pre-C&C3 game, we can improve this by allowing each game to define its own default `.skudef`.

I also improved performance of file lookup by making all paths lowercase.