### PR TITLE
Fix scaling being applied in geometry view

### DIFF
--- a/src/OpenSage.Game/Gui/Apt/AptRenderer.cs
+++ b/src/OpenSage.Game/Gui/Apt/AptRenderer.cs
@@ -14,8 +14,8 @@ namespace OpenSage.Gui.Apt
 
         private void CalculateTransform(ref ItemTransform transform, AptContext context)
         {
-            var movie = (Movie) context.Root.Character;
-            var movieSize = new Vector2(movie.ScreenWidth, movie.ScreenHeight);
+            if (Window == null)
+                return;
 
             var scaling = Window.GetScaling();
             transform.GeometryRotation.M11 *= scaling.X;

--- a/src/OpenSage.Game/Gui/Apt/AptRenderer.cs
+++ b/src/OpenSage.Game/Gui/Apt/AptRenderer.cs
@@ -15,7 +15,9 @@ namespace OpenSage.Gui.Apt
         private void CalculateTransform(ref ItemTransform transform, AptContext context)
         {
             if (Window == null)
+            {
                 return;
+            }
 
             var scaling = Window.GetScaling();
             transform.GeometryRotation.M11 *= scaling.X;


### PR DESCRIPTION
It makes no sense to scale the geometry in when there is no parent AptWindow