### PR TITLE
Fix wrong indices for BFME models

### DIFF
--- a/src/OpenSage.Game/Graphics/ModelMesh.W3d.cs
+++ b/src/OpenSage.Game/Graphics/ModelMesh.W3d.cs
@@ -192,7 +192,8 @@ namespace OpenSage.Graphics
 
         private static ushort[] CreateIndices(W3dMesh w3dMesh, bool usesShaderMaterial)
         {
-            if (usesShaderMaterial)
+            //TODO: fix this
+            if (false && usesShaderMaterial)
             {
                 // If using shader materials, we can use the actual shade indices from the mesh.
                 return w3dMesh.ShadeIndices.Items.Select(x => (ushort) x).ToArray();
@@ -289,7 +290,7 @@ namespace OpenSage.Graphics
             return new ModelMeshPart(
                 texCoordsVertexBuffer,
                 0,
-                (uint)w3dMesh.ShadeIndices.Items.Length,
+                (uint)w3dMesh.Triangles.Items.Length * 3,
                 blendEnabled,
                 pipeline,
                 materialResourceSet);

--- a/src/OpenSage.Game/Graphics/Shaders/ShaderMaterialShaderResources.cs
+++ b/src/OpenSage.Game/Graphics/Shaders/ShaderMaterialShaderResources.cs
@@ -46,7 +46,7 @@ namespace OpenSage.Graphics.Shaders
                     BlendStateDescription.SingleDisabled,
                     DepthStencilStateDescription.DepthOnlyLessEqual,
                     RasterizerStateDescriptionUtility.DefaultFrontIsCounterClockwise,
-                    PrimitiveTopology.TriangleStrip,
+                    PrimitiveTopology.TriangleList,
                     ShaderSet.Description,
                     resourceLayouts,
                     RenderPipeline.GameOutputDescription)));


### PR DESCRIPTION
Unfortunaly the shade indices don't work with BFME models, so we fallback to plain traingles indices