### PR TITLE
Enable loading of maps from UserData folder

### DIFF
--- a/src/OpenSage.Game/Content/ContentManager.cs
+++ b/src/OpenSage.Game/Content/ContentManager.cs
@@ -19,7 +19,7 @@ namespace OpenSage.Content
         public SageGame SageGame { get; }
 
         public FileSystem FileSystem { get; }
-        public FileSystem UserDataFileSystem { get; }
+        public FileSystem UserDataFileSystem { get; internal set; }
 
         public IniDataContext IniDataContext { get; }
 
@@ -114,6 +114,20 @@ namespace OpenSage.Content
 
                 var parser = new IniParser(entry, _game.AssetStore, _game.SageGame, IniDataContext);
                 parser.ParseFile();
+            }
+        }
+
+        internal FileSystemEntry GetMapEntry(string mapPath)
+        {
+            var normalizedPath = FileSystem.NormalizeFilePath(mapPath);
+            if (UserDataFileSystem != null && normalizedPath.StartsWith(UserDataFileSystem.RootDirectory))
+            {
+                mapPath = mapPath.Substring(UserDataFileSystem.RootDirectory.Length + 1);
+                return UserDataFileSystem.GetFile(mapPath);
+            }
+            else
+            {
+                return FileSystem.GetFile(mapPath);
             }
         }
     }

--- a/src/OpenSage.Game/Content/ContentManager.cs
+++ b/src/OpenSage.Game/Content/ContentManager.cs
@@ -32,7 +32,6 @@ namespace OpenSage.Content
         public ContentManager(
             Game game,
             FileSystem fileSystem,
-            FileSystem userDataFileSystem,
             GraphicsDevice graphicsDevice,
             SageGame sageGame)
         {
@@ -41,7 +40,6 @@ namespace OpenSage.Content
                 _game = game;
 
                 FileSystem = fileSystem;
-                UserDataFileSystem = userDataFileSystem;
 
                 GraphicsDevice = graphicsDevice;
 

--- a/src/OpenSage.Game/Content/ContentManager.cs
+++ b/src/OpenSage.Game/Content/ContentManager.cs
@@ -14,13 +14,12 @@ namespace OpenSage.Content
 
         public ISubsystemLoader SubsystemLoader { get; }
 
-        private readonly FileSystem _fileSystem;
-
         public GraphicsDevice GraphicsDevice { get; }
 
         public SageGame SageGame { get; }
 
-        public FileSystem FileSystem => _fileSystem;
+        public FileSystem FileSystem { get; }
+        public FileSystem UserDataFileSystem { get; }
 
         public IniDataContext IniDataContext { get; }
 
@@ -33,13 +32,16 @@ namespace OpenSage.Content
         public ContentManager(
             Game game,
             FileSystem fileSystem,
+            FileSystem userDataFileSystem,
             GraphicsDevice graphicsDevice,
             SageGame sageGame)
         {
             using (GameTrace.TraceDurationEvent("ContentManager()"))
             {
                 _game = game;
-                _fileSystem = fileSystem;
+
+                FileSystem = fileSystem;
+                UserDataFileSystem = userDataFileSystem;
 
                 GraphicsDevice = graphicsDevice;
 
@@ -49,7 +51,7 @@ namespace OpenSage.Content
 
                 IniDataContext = new IniDataContext();
 
-                SubsystemLoader = Content.SubsystemLoader.Create(game.Definition, _fileSystem, game, this);
+                SubsystemLoader = Content.SubsystemLoader.Create(game.Definition, FileSystem, game, this);
 
                 switch (sageGame)
                 {
@@ -92,7 +94,7 @@ namespace OpenSage.Content
         // TODO: Move these methods to somewhere else (SubsystemLoader?)
         internal void LoadIniFiles(string folder)
         {
-            foreach (var iniFile in _fileSystem.GetFiles(folder))
+            foreach (var iniFile in FileSystem.GetFiles(folder))
             {
                 LoadIniFile(iniFile);
             }
@@ -100,7 +102,7 @@ namespace OpenSage.Content
 
         internal void LoadIniFile(string filePath)
         {
-            LoadIniFile(_fileSystem.GetFile(filePath));
+            LoadIniFile(FileSystem.GetFile(filePath));
         }
 
         internal void LoadIniFile(FileSystemEntry entry)

--- a/src/OpenSage.Game/Content/SubsystemLoader.cs
+++ b/src/OpenSage.Game/Content/SubsystemLoader.cs
@@ -35,6 +35,7 @@ namespace OpenSage.Content
                         @"Data\INI\AudioSettings.ini",
                         $@"Data\{_contentManager.Language}\HeaderTemplate.ini",
                         @"Maps\MapCache.ini");
+
                     break;
                 case Subsystem.Audio:
                     LoadFiles(
@@ -76,9 +77,7 @@ namespace OpenSage.Content
                     _contentManager.LoadIniFiles(@"Data\INI\MappedImages\TextureSize_512\");
                     break;
                 case Subsystem.Multiplayer:
-                    LoadFiles(
-                        @"Data\INI\Multiplayer.ini");
-                    _contentManager.LoadIniFile(_contentManager.UserDataFileSystem.GetFile(@"Maps\MapCache.ini"));
+                    LoadFiles(@"Data\INI\Multiplayer.ini");
                     break;
                 case Subsystem.LinearCampaign:
                     LoadFiles(@"Data\INI\Campaign.ini");

--- a/src/OpenSage.Game/Content/SubsystemLoader.cs
+++ b/src/OpenSage.Game/Content/SubsystemLoader.cs
@@ -76,7 +76,9 @@ namespace OpenSage.Content
                     _contentManager.LoadIniFiles(@"Data\INI\MappedImages\TextureSize_512\");
                     break;
                 case Subsystem.Multiplayer:
-                    LoadFiles(@"Data\INI\Multiplayer.ini");
+                    LoadFiles(
+                        @"Data\INI\Multiplayer.ini");
+                    _contentManager.LoadIniFile(_contentManager.UserDataFileSystem.GetFile(@"Maps\MapCache.ini"));
                     break;
                 case Subsystem.LinearCampaign:
                     LoadFiles(@"Data\INI\Campaign.ini");

--- a/src/OpenSage.Game/Diagnostics/MainView.cs
+++ b/src/OpenSage.Game/Diagnostics/MainView.cs
@@ -98,44 +98,7 @@ namespace OpenSage.Diagnostics
 
                 if (ImGui.BeginMenu("Jump"))
                 {
-                    if (ImGui.BeginMenu("Map"))
-                    {
-                        foreach (var mapCache in _context.Game.AssetStore.MapCaches)
-                        {
-                            //TODO: we should probably cache the validity of entries
-                            if (_context.Game.ContentManager.FileSystem.GetFile(mapCache.Name) == null)
-                                continue;
-
-                            var mapName = mapCache.GetNameKey().Translate();
-
-                            if (ImGui.MenuItem($"{mapName} ({mapCache.Name})"))
-                            {
-                                var playableSides = _context.Game.GetPlayableSides();
-                                var faction1 = playableSides.First();
-                                var faction2 = playableSides.Last();
-
-                                if (mapCache.IsMultiplayer)
-                                {
-                                    _context.Game.StartMultiPlayerGame(
-                                        mapCache.Name,
-                                        new EchoConnection(),
-                                        new PlayerSetting?[]
-                                        {
-                                            new PlayerSetting(null, faction1, new ColorRgb(255, 0, 0)),
-                                            new PlayerSetting(null, faction2, new ColorRgb(255, 255, 255)),
-                                        },
-                                        0
-                                    );
-                                }
-                                else
-                                {
-                                    _context.Game.StartSinglePlayerGame(mapCache.Name);
-                                }
-                            }
-                        }
-
-                        ImGui.EndMenu();
-                    }
+                    DrawMaps();
 
                     ImGui.EndMenu();
                 }
@@ -273,6 +236,48 @@ namespace OpenSage.Diagnostics
 
                 ImGui.End();
                 ImGui.PopStyleVar();
+            }
+        }
+
+        private void DrawMaps()
+        {
+            if (ImGui.BeginMenu("Map"))
+            {
+                foreach (var mapCache in _context.Game.AssetStore.MapCaches)
+                {
+                    //TODO: we should probably cache the validity of entries
+                    if (_context.Game.ContentManager.GetMapEntry(mapCache.Name) == null)
+                        continue;
+
+                    var mapName = mapCache.GetNameKey().Translate();
+
+                    if (ImGui.MenuItem($"{mapName} ({mapCache.Name})"))
+                    {
+                        var playableSides = _context.Game.GetPlayableSides();
+                        var faction1 = playableSides.First();
+                        var faction2 = playableSides.Last();
+
+                        if (mapCache.IsMultiplayer)
+                        {
+                            _context.Game.StartMultiPlayerGame(
+                                mapCache.Name,
+                                new EchoConnection(),
+                                new PlayerSetting?[]
+                                {
+                                            new PlayerSetting(null, faction1, new ColorRgb(255, 0, 0)),
+                                            new PlayerSetting(null, faction2, new ColorRgb(255, 255, 255)),
+                                },
+                                0
+                            );
+                        }
+                        else
+                        {
+                            _context.Game.StartSinglePlayerGame(mapCache.Name);
+                        }
+                    }
+                }
+
+                ImGui.EndMenu();
             }
         }
     }

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -535,7 +535,16 @@ namespace OpenSage
 
         internal Scene3D LoadMap(string mapPath)
         {
-            var entry = ContentManager.FileSystem.GetFile(mapPath) ?? _userDataFileSystem.GetFile(mapPath);
+            FileSystemEntry entry;
+            if (mapPath.StartsWith(_userDataFileSystem.RootDirectory))
+            {
+                mapPath = FileSystem.NormalizeFilePath(mapPath.Substring(_userDataFileSystem.RootDirectory.Length + 1));
+                entry = _userDataFileSystem.GetFile(mapPath);
+            }
+            else
+            {
+                entry = ContentManager.FileSystem.GetFile(mapPath);
+            }
 
             var mapFile = MapFile.FromFileSystemEntry(entry);
 
@@ -691,11 +700,6 @@ namespace OpenSage
             StartSinglePlayerGame(firstMission.Map);
         }
 
-        public void StartSinglePlayerGame(string mapFileName)
-        {
-            StartGame(mapFileName, new EchoConnection(), null, 0, false);
-        }
-
         public void StartMultiPlayerGame(
             string mapFileName,
             IConnection connection,
@@ -707,7 +711,18 @@ namespace OpenSage
                 connection,
                 playerSettings,
                 localPlayerIndex,
-                true);
+                isMultiPlayer: true);
+        }
+
+        public void StartSinglePlayerGame(
+            string mapFileName)
+        {
+            StartGame(
+                mapFileName,
+                new EchoConnection(),
+                null,
+                0,
+                isMultiPlayer: false);
         }
 
         public void EndGame()

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -399,7 +399,9 @@ namespace OpenSage
                 // the UserDataFolder before then.
                 if (Directory.Exists(UserDataFolder))
                 {
-                    _userDataFileSystem = AddDisposable(new FileSystem(UserDataFolder));
+                    _userDataFileSystem = AddDisposable(new FileSystem(FileSystem.NormalizeFilePath(UserDataFolder)));
+                    ContentManager.UserDataFileSystem = _userDataFileSystem;
+
                     var file = _userDataFileSystem.GetFile(@"Maps\MapCache.ini");
                     if (file != null)
                     {
@@ -535,17 +537,7 @@ namespace OpenSage
 
         internal Scene3D LoadMap(string mapPath)
         {
-            FileSystemEntry entry;
-            if (mapPath.StartsWith(_userDataFileSystem.RootDirectory))
-            {
-                mapPath = FileSystem.NormalizeFilePath(mapPath.Substring(_userDataFileSystem.RootDirectory.Length + 1));
-                entry = _userDataFileSystem.GetFile(mapPath);
-            }
-            else
-            {
-                entry = ContentManager.FileSystem.GetFile(mapPath);
-            }
-
+            var entry = ContentManager.GetMapEntry(mapPath);
             var mapFile = MapFile.FromFileSystemEntry(entry);
 
             return new Scene3D(this, mapFile);

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -361,7 +361,6 @@ namespace OpenSage
                 Definition = installation.Game;
 
                 _fileSystem = AddDisposable(installation.CreateFileSystem());
-                _userDataFileSystem = AddDisposable(new FileSystem(UserDataFolder));
 
                 _mapTimer = AddDisposable(new DeltaTimer());
                 _mapTimer.Start();
@@ -391,9 +390,22 @@ namespace OpenSage
                 ContentManager = AddDisposable(new ContentManager(
                     this,
                     _fileSystem,
-                    _userDataFileSystem,
                     GraphicsDevice,
                     SageGame));
+
+                // Create file system for user data folder and load user maps.
+                // This has to be done after the ContentManager is initialized and
+                // the GameData.ini file has been parsed because we don't know
+                // the UserDataFolder before then.
+                if (Directory.Exists(UserDataFolder))
+                {
+                    _userDataFileSystem = AddDisposable(new FileSystem(UserDataFolder));
+                    var file = _userDataFileSystem.GetFile(@"Maps\MapCache.ini");
+                    if (file != null)
+                    {
+                        ContentManager.LoadIniFile(file);
+                    }
+                }
 
                 _textureCopier = AddDisposable(new TextureCopier(this, GraphicsDevice.SwapchainFramebuffer.OutputDescription));
 

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -402,6 +402,7 @@ namespace OpenSage
                     _userDataFileSystem = AddDisposable(new FileSystem(FileSystem.NormalizeFilePath(UserDataFolder)));
                     ContentManager.UserDataFileSystem = _userDataFileSystem;
 
+                    // TODO: Re-generate MapCache.ini for user maps
                     var file = _userDataFileSystem.GetFile(@"Maps\MapCache.ini");
                     if (file != null)
                     {

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -642,7 +642,6 @@ namespace OpenSage
                         availablePositions.Remove((int) startPos);
                     }
 
-
                     var playerStartPosition = Scene3D.Waypoints[$"Player_{startPos}_Start"].Position;
                     playerStartPosition.Z += Scene3D.Terrain.HeightMap.GetHeight(playerStartPosition.X, playerStartPosition.Y);
 

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -121,17 +121,33 @@ namespace OpenSage.Launcher
                 }
                 else if (opts.Map != null)
                 {
-                    var pSettings = new PlayerSetting?[]
+                    var mapCache = game.AssetStore.MapCaches.GetByName(opts.Map);
+                    if (mapCache == null)
                     {
-                        new PlayerSetting(null, game.AssetStore.PlayerTemplates.GetByName("FactionAmerica"), new ColorRgb(255, 0, 0)),
-                        new PlayerSetting(null, game.AssetStore.PlayerTemplates.GetByName("FactionGLA"), new ColorRgb(255, 255, 255)),
-                    };
+                        logger.Debug("Could not find MapCache entry for map " + opts.Map);
+                        game.ShowMainMenu();
+                    }
+                    else if (mapCache.IsMultiplayer)
+                    {
+                        var pSettings = new PlayerSetting?[]
+                        {
+                            new PlayerSetting(null, game.AssetStore.PlayerTemplates.GetByName("FactionAmerica"), new ColorRgb(255, 0, 0)),
+                            new PlayerSetting(null, game.AssetStore.PlayerTemplates.GetByName("FactionGLA"), new ColorRgb(255, 255, 255)),
+                        };
 
-                    logger.Debug("Starting multiplayer game");
-                    game.StartMultiPlayerGame(opts.Map,
-                         new EchoConnection(),
-                         pSettings,
-                         0);
+                        logger.Debug("Starting multiplayer game");
+
+                        game.StartMultiPlayerGame(opts.Map,
+                            new EchoConnection(),
+                            pSettings,
+                            0);
+                    }
+                    else
+                    {
+                        logger.Debug("Starting singleplayer game");
+
+                        game.StartSinglePlayerGame(opts.Map);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
This PR contains the following changes:
* Added a `FileSystem` for the `UserData` folder
* Added code for parsing the `MapCache.ini` file from that folder
* Enabled loading of user maps via command line option and dev mode menu
* Cached and sorted the valid maps for the dev mode menu