### PR TITLE
Fix duplicate GameObject insertion

### DIFF
--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -188,10 +188,6 @@ namespace OpenSage
                                 position.Z += heightMap.GetHeight(position.X, position.Y);
 
                                 var gameObject = GameObject.FromMapObject(mapObject, teams, loadContext.AssetStore, gameObjects, position);
-                                if (gameObject != null)
-                                {
-                                    gameObjects.Add(gameObject);
-                                }
 
                                 break;
                         }

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -187,7 +187,7 @@ namespace OpenSage
                             default:
                                 position.Z += heightMap.GetHeight(position.X, position.Y);
 
-                                var gameObject = GameObject.FromMapObject(mapObject, teams, loadContext.AssetStore, gameObjects, position);
+                                GameObject.FromMapObject(mapObject, teams, loadContext.AssetStore, gameObjects, position);
 
                                 break;
                         }


### PR DESCRIPTION
`GameObjects` were added twice to the collection because `FromMapObject` already calls `parent.Add(mapObject.TypeName)`.