### PR TITLE
Correct z-ordering for roads

### DIFF
--- a/src/OpenSage.Game/Graphics/Rendering/RenderItemCollection.cs
+++ b/src/OpenSage.Game/Graphics/Rendering/RenderItemCollection.cs
@@ -104,7 +104,18 @@ namespace OpenSage.Graphics.Rendering
             }
 
             // Step 3: Sort the indices by comparing render item keys.
-            _culledItemIndices.Sort((a, b) => _items[a].Key.CompareTo(_items[b].Key));
+            // If two items have the same key, compare the indices in
+            // order to provider a consistent ordering and prevent flickering.
+            _culledItemIndices.Sort((a, b) =>
+            {
+                var result = _items[a].Key.CompareTo(_items[b].Key);
+                if (result == 0)
+                {
+                    return a.CompareTo(b);
+                }
+
+                return result;
+            });
         }
 
         public void Clear()

--- a/src/OpenSage.Game/Terrain/HeightMap.cs
+++ b/src/OpenSage.Game/Terrain/HeightMap.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
 using OpenSage.Data.Map;
 using OpenSage.Mathematics;
 
@@ -27,17 +28,8 @@ namespace OpenSage.Terrain
             x = x / HorizontalScale + _heightMapData.BorderWidth;
             y = y / HorizontalScale + _heightMapData.BorderWidth;
 
-            if (x < 0)
-                x = 0;
-
-            if (x >= Width)
-                x = Width - 1;
-
-            if (y < 0)
-                y = 0;
-
-            if (y >= Height)
-                y = Height;
+            x = Math.Clamp(x, 0, Width - 1);
+            y = Math.Clamp(y, 0, Height - 1);
 
             // get integer and fractional parts of coordinates
             var nIntX0 = MathUtility.FloorToInt(x);

--- a/src/OpenSage.Game/Terrain/RoadCollection.cs
+++ b/src/OpenSage.Game/Terrain/RoadCollection.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using OpenSage.Content.Loaders;
 using OpenSage.Graphics.Rendering;
 using OpenSage.Terrain.Roads;
@@ -38,7 +39,19 @@ namespace OpenSage.Terrain
 
             var networks = RoadNetwork.BuildNetworks(topology);
 
-            foreach (var network in networks)
+            // Roads of different types are rendered in reverse template order:
+            // the first template has the lowest z-index, the last one the highest.
+            // Since we don't know the index here we start with the templates,
+            // join them with the networks and reverse the result.
+            var sortedNetworks = loadContext.AssetStore.RoadTemplates
+                .Join(
+                    networks,
+                    t => t.InstanceId,
+                    n => n.Template.InstanceId,
+                    (t, n) => n)
+                .Reverse();
+
+            foreach (var network in sortedNetworks)
             {
                 _roads.Add(AddDisposable(new Road(
                         loadContext,


### PR DESCRIPTION
This PR applies the same ordering to road textures as original SAGE. It should also stop the flickering of roads depending on the camera position.