### PR TITLE
Don't crash for non existent filesystems

### DIFF
--- a/src/OpenSage.Game/Data/FileSystem.cs
+++ b/src/OpenSage.Game/Data/FileSystem.cs
@@ -25,18 +25,21 @@ namespace OpenSage.Data
             _bigArchives = new List<BigArchive>();
 
             // First create entries for all non-.big files
-            foreach (var file in Directory.GetFiles(rootDirectory, "*.*", SearchOption.AllDirectories))
+            if (Directory.Exists(rootDirectory))
             {
-                var ext = Path.GetExtension(file).ToLowerInvariant();
-                if (ext != ".big")
+                foreach (var file in Directory.GetFiles(rootDirectory, "*.*", SearchOption.AllDirectories))
                 {
-                    var relativePath = file.Substring(rootDirectory.Length);
-                    if (relativePath.StartsWith(Path.DirectorySeparatorChar.ToString()))
+                    var ext = Path.GetExtension(file).ToLowerInvariant();
+                    if (ext != ".big")
                     {
-                        relativePath = relativePath.Substring(1);
+                        var relativePath = file.Substring(rootDirectory.Length);
+                        if (relativePath.StartsWith(Path.DirectorySeparatorChar.ToString()))
+                        {
+                            relativePath = relativePath.Substring(1);
+                        }
+                        relativePath = NormalizeFilePath(relativePath);
+                        _fileTable.Add(relativePath, new FileSystemEntry(this, relativePath, (uint) new FileInfo(file).Length, () => File.OpenRead(file)));
                     }
-                    relativePath = NormalizeFilePath(relativePath);
-                    _fileTable.Add(relativePath, new FileSystemEntry(this, relativePath, (uint) new FileInfo(file).Length, () => File.OpenRead(file)));
                 }
             }
 

--- a/src/OpenSage.Game/Data/FileSystem.cs
+++ b/src/OpenSage.Game/Data/FileSystem.cs
@@ -41,10 +41,10 @@ namespace OpenSage.Data
                         _fileTable.Add(relativePath, new FileSystemEntry(this, relativePath, (uint) new FileInfo(file).Length, () => File.OpenRead(file)));
                     }
                 }
-            }
 
-            // Then load .big files
-            SkudefReader.Read(rootDirectory, path => AddBigArchive(path));
+                // Then load .big files
+                SkudefReader.Read(rootDirectory, path => AddBigArchive(path));
+            }
         }
 
         private void AddBigArchive(string path)

--- a/src/OpenSage.Game/Data/FileSystem.cs
+++ b/src/OpenSage.Game/Data/FileSystem.cs
@@ -9,7 +9,7 @@ namespace OpenSage.Data
     {
         private readonly Dictionary<string, FileSystemEntry> _fileTable;
         private readonly List<BigArchive> _bigArchives;
-
+        private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
         public string RootDirectory { get; }
 
         public IReadOnlyCollection<FileSystemEntry> Files => _fileTable.Values;
@@ -44,6 +44,10 @@ namespace OpenSage.Data
 
                 // Then load .big files
                 SkudefReader.Read(rootDirectory, path => AddBigArchive(path));
+            }
+            else
+            {
+                logger.Warn("Failed to create filesystem for non existing root directory: " + rootDirectory);
             }
         }
 


### PR DESCRIPTION
The **Load replays** button was crashing since it tried mounting the **Replays** folder which doesn't exist