### PR TITLE
Curved roads

### DIFF
--- a/src/OpenSage.Game/Terrain/Roads/CrossingRoadSegment.cs
+++ b/src/OpenSage.Game/Terrain/Roads/CrossingRoadSegment.cs
@@ -9,8 +9,6 @@ namespace OpenSage.Terrain.Roads
 {
     internal sealed class CrossingRoadSegment : IRoadSegment
     {
-        private const float OverlapLength = 0.015f;
-
         private CrossingRoadSegment(in Vector3 position, IEnumerable<RoadSegmentEndPoint> endPoints, in Vector3 start, in Vector3 end, RoadTextureType type)
         {
             Position = position;
@@ -44,20 +42,20 @@ namespace OpenSage.Terrain.Roads
             switch (type)
             {
                 case RoadTextureType.TCrossing:
-                    width = template.RoadWidthInTexture + stubLength + OverlapLength;
-                    height = template.RoadWidthInTexture + 2 * stubLength + 2 * OverlapLength;
+                    width = template.RoadWidthInTexture + stubLength + RoadConstants.OverlapLength;
+                    height = template.RoadWidthInTexture + 2 * stubLength + 2 * RoadConstants.OverlapLength;
                     break;
                 case RoadTextureType.XCrossing:
-                    width = template.RoadWidthInTexture + 2 * stubLength + 2 * OverlapLength;
+                    width = template.RoadWidthInTexture + 2 * stubLength + 2 * RoadConstants.OverlapLength;
                     height = width;
                     break;
                 case RoadTextureType.AsymmetricYCrossing:
                     width = 1.2f + template.RoadWidthInTexture / 2f;
-                    height = 1.33f + OverlapLength;
+                    height = 1.33f + RoadConstants.OverlapLength;
                     break;
                 case RoadTextureType.SymmetricYCrossing:
                     width = 1.59f;
-                    height = 1.065f + OverlapLength;
+                    height = 1.065f + RoadConstants.OverlapLength;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException("Unknown RoadTextureType: " + type);
@@ -151,7 +149,7 @@ namespace OpenSage.Terrain.Roads
                 end,
                 RoadTextureType.TCrossing);
 
-            var overlap = OverlapLength * template.RoadWidth;
+            var overlap = RoadConstants.OverlapLength * template.RoadWidth;
             Connect(crossingSegment, maxAngle.Previous.TopologyEdge, top, upDirection, overlap, edgeSegments);
             Connect(crossingSegment, maxAngle.Previous.Previous.TopologyEdge, right, rightDirection, overlap, edgeSegments);
             Connect(crossingSegment, maxAngle.TopologyEdge, bottom, -upDirection, overlap, edgeSegments);
@@ -196,7 +194,7 @@ namespace OpenSage.Terrain.Roads
                 end,
                 RoadTextureType.XCrossing);
 
-            var overlap = OverlapLength * template.RoadWidth;
+            var overlap = RoadConstants.OverlapLength * template.RoadWidth;
             Connect(crossingSegment, roadTop.TopologyEdge, top, upDirection, overlap, edgeSegments);
             Connect(crossingSegment, roadRight.TopologyEdge, right, rightDirection, overlap, edgeSegments);
             Connect(crossingSegment, roadBottom.TopologyEdge, bottom, -upDirection, overlap, edgeSegments);
@@ -305,7 +303,7 @@ namespace OpenSage.Terrain.Roads
                 end,
                 RoadTextureType.SymmetricYCrossing);
             
-            Connect(crossingSegment, topEdge.TopologyEdge, top, upDirection, OverlapLength * template.RoadWidth, edgeSegments);
+            Connect(crossingSegment, topEdge.TopologyEdge, top, upDirection, RoadConstants.OverlapLength * template.RoadWidth, edgeSegments);
             Connect(crossingSegment, leftEdge.TopologyEdge, leftSide, leftSideDirection, 0, edgeSegments);
             Connect(crossingSegment, rightEdge.TopologyEdge, rightSide, rightSideDirection, 0, edgeSegments);
 

--- a/src/OpenSage.Game/Terrain/Roads/CrossingRoadSegment.cs
+++ b/src/OpenSage.Game/Terrain/Roads/CrossingRoadSegment.cs
@@ -67,7 +67,7 @@ namespace OpenSage.Terrain.Roads
         }
 
         public static void CreateCrossing(
-            IEnumerable<IncomingRoadData> roads,
+            IReadOnlyList<IncomingRoadData> roads,
             Vector3 crossingPosition, RoadTemplate template,
             IReadOnlyDictionary<RoadTopologyEdge, StraightRoadSegment> edgeSegments)
         {
@@ -91,7 +91,7 @@ namespace OpenSage.Terrain.Roads
             }
         }
 
-        private static RoadTextureType ChooseCrossingType(IEnumerable<IncomingRoadData> incomingRoads)
+        private static RoadTextureType ChooseCrossingType(IReadOnlyList<IncomingRoadData> incomingRoads)
         {
             var angles = incomingRoads
                 .Select(r => r.AngleToPreviousEdge)
@@ -123,7 +123,7 @@ namespace OpenSage.Terrain.Roads
         }
 
         private static CrossingRoadSegment CreateTCrossing(
-            IEnumerable<IncomingRoadData> roads,
+            IReadOnlyList<IncomingRoadData> roads,
             in Vector3 crossingPosition,
             RoadTemplate template,
             IReadOnlyDictionary<RoadTopologyEdge, StraightRoadSegment> edgeSegments)
@@ -160,7 +160,7 @@ namespace OpenSage.Terrain.Roads
         }
 
         private static CrossingRoadSegment CreateXCrossing(
-            IEnumerable<IncomingRoadData> roads,
+            IReadOnlyList<IncomingRoadData> roads,
             Vector3 crossingPosition,
             RoadTemplate template,
             IReadOnlyDictionary<RoadTopologyEdge, StraightRoadSegment> edgeSegments)
@@ -206,7 +206,7 @@ namespace OpenSage.Terrain.Roads
         }
 
         private static CrossingRoadSegment CreateYAsymmCrossing(
-            IEnumerable<IncomingRoadData> roads,
+            IReadOnlyList<IncomingRoadData> roads,
             Vector3 crossingPosition,
             RoadTemplate template,
             IReadOnlyDictionary<RoadTopologyEdge, StraightRoadSegment> edgeSegments)
@@ -261,7 +261,7 @@ namespace OpenSage.Terrain.Roads
         }
 
         private static CrossingRoadSegment CreateYSymmCrossing(
-           IEnumerable<IncomingRoadData> roads,
+           IReadOnlyList<IncomingRoadData> roads,
            Vector3 crossingPosition,
            RoadTemplate template,
            IReadOnlyDictionary<RoadTopologyEdge, StraightRoadSegment> edgeSegments)
@@ -273,7 +273,7 @@ namespace OpenSage.Terrain.Roads
             var leftEdge = minAngle.Previous;
             var topEdge = leftEdge.Previous;
 
-            var upDirection = topEdge.Direction;
+            var upDirection = topEdge.OutDirection;
             var rightDirection = Vector3.Cross(upDirection, Vector3.UnitZ);
             var rightSideDirection = Vector3.Normalize(rightDirection - upDirection);
             var leftSideDirection = Vector3.Normalize(-rightDirection - upDirection);

--- a/src/OpenSage.Game/Terrain/Roads/CrossingRoadSegment.cs
+++ b/src/OpenSage.Game/Terrain/Roads/CrossingRoadSegment.cs
@@ -11,7 +11,7 @@ namespace OpenSage.Terrain.Roads
     {
         private const float OverlapLength = 0.015f;
 
-        private CrossingRoadSegment(Vector3 position, IEnumerable<RoadSegmentEndPoint> endPoints, Vector3 start, Vector3 end, RoadTextureType type)
+        private CrossingRoadSegment(in Vector3 position, IEnumerable<RoadSegmentEndPoint> endPoints, in Vector3 start, in Vector3 end, RoadTextureType type)
         {
             Position = position;
             EndPoints = endPoints;

--- a/src/OpenSage.Game/Terrain/Roads/CurvedRoadSegment.cs
+++ b/src/OpenSage.Game/Terrain/Roads/CurvedRoadSegment.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Numerics;
+using OpenSage.Data.Map;
+using OpenSage.Mathematics;
+
+namespace OpenSage.Terrain.Roads
+{
+    internal sealed class CurvedRoadSegment : IRoadSegment
+    {
+        public RoadSegmentEndPoint Start { get; }
+        public RoadSegmentEndPoint End { get; }
+        public Vector3 StartPosition => Start.Position;
+        public Vector3 EndPosition => End.Position;
+        public bool MirrorTexture => false;
+        public RoadTextureType Type => RoadTextureType.BroadCurve;
+
+        public CurvedRoadSegment(in Vector3 start, in Vector3 end, float width)
+        {
+            Start = new RoadSegmentEndPoint(start);
+            End = new RoadSegmentEndPoint(end);
+        }
+
+        public IEnumerable<RoadSegmentEndPoint> EndPoints
+        {
+            get
+            {
+                yield return Start;
+                yield return End;
+            }
+        }
+
+        public RoadSegmentMesher CreateMesher(RoadTemplate template)
+        {
+            var halfWidth = template.RoadWidth * template.RoadWidthInTexture / 2f;
+            return new StraightRoadSegmentMesher(this, halfWidth, template);
+        }
+
+        public static void CreateCurve(
+            IReadOnlyList<IncomingRoadData> incomingRoadData,
+            in Vector3 position,
+            RoadTemplate template,
+            IReadOnlyDictionary<RoadTopologyEdge, StraightRoadSegment> edgeSegments)
+        {
+            Debug.Assert(incomingRoadData.Count == 2);
+            var startEdge = incomingRoadData.OrderBy(r => r.AngleToPreviousEdge).First();
+            var endEdge = startEdge.Previous;
+
+            var type = ChooseCurveType(startEdge.TopologyEdge, endEdge.TopologyEdge, position);
+
+            switch (type)
+            {
+                case RoadTextureType.BroadCurve:
+                case RoadTextureType.TightCurve:
+                    CreateCurve(startEdge, endEdge, position, template, type, edgeSegments);
+                    break;
+            }
+        }
+
+        private static RoadTextureType ChooseCurveType(RoadTopologyEdge startEdge, RoadTopologyEdge endEdge, in Vector3 position)
+        {
+            // TODO: consider edge directions
+            var startType = startEdge.Start.Position == position ? startEdge.StartType : startEdge.EndType;
+            var endType = endEdge.Start.Position == position ? endEdge.StartType : endEdge.EndType;
+
+            var type = startType & endType;
+            if (type.HasFlag(RoadType.TightCurve))
+            {
+                return RoadTextureType.TightCurve;
+            }
+            else if (!type.HasFlag(RoadType.Angled))
+            {
+                return RoadTextureType.BroadCurve;
+            }
+            else
+            {
+                return RoadTextureType.Straight;
+            }
+        }
+
+        private static void CreateCurve(
+            IncomingRoadData startEdge,
+            IncomingRoadData endEdge,
+            Vector3 position,
+            RoadTemplate template,
+            RoadTextureType type,
+            IReadOnlyDictionary<RoadTopologyEdge, StraightRoadSegment> edgeSegments)
+        {
+            var curveAngle = MathF.PI - startEdge.AngleToPreviousEdge;
+
+            // TODO figure out exact threshold
+            if (curveAngle < 0.47f)
+            {
+                // render as angled connection
+                return;
+            }
+            
+            var halfRoadWidth = template.RoadWidth * template.RoadWidthInTexture / 2f;
+
+            var radius = 3.5f * halfRoadWidth;
+            var toCenterLength = radius / MathF.Cos(curveAngle / 2);
+            var toCenterDirection = Vector3.Normalize(startEdge.OutDirection + endEdge.OutDirection);
+            var toCenter = toCenterDirection * toCenterLength;
+            var center = position + toCenter;
+
+            var startSegmentEndDistance = Vector3.Dot(toCenter, startEdge.OutDirection);
+            var endSegmentStartDistance = Vector3.Dot(toCenter, endEdge.OutDirection);
+
+            var startEdgeVector = startEdge.TopologyEdge.End.Position - startEdge.TopologyEdge.Start.Position;
+            var endEdgeVector = endEdge.TopologyEdge.End.Position - endEdge.TopologyEdge.Start.Position;
+
+            if (startSegmentEndDistance * startSegmentEndDistance > startEdgeVector.LengthSquared() ||
+                endSegmentStartDistance * endSegmentStartDistance > endEdgeVector.LengthSquared())
+            {
+                // render as angled connection
+                return;
+            }
+
+            var startSegment = edgeSegments[startEdge.TopologyEdge];
+            var endSegment = edgeSegments[endEdge.TopologyEdge];
+
+            var startSegmentEndPoint = startSegment.StartPosition == position ? startSegment.Start : startSegment.End;
+            startSegmentEndPoint.Position = position + startEdge.OutDirection * startSegmentEndDistance;
+            startSegmentEndPoint.ConnectTo(endSegment, startEdge.OutDirection);
+
+            var endSegmentStartPoint = endSegment.StartPosition == position ? endSegment.Start : endSegment.End;
+            endSegmentStartPoint.Position = position + endEdge.OutDirection * endSegmentStartDistance;
+            endSegmentStartPoint.ConnectTo(startSegment, endEdge.OutDirection);
+
+            const float segmentAngle = MathF.PI / 6f;
+            var numberOfSegments = 1 + (int) MathF.Floor(curveAngle / segmentAngle);
+            var lastSegmentAngle = curveAngle % segmentAngle;
+
+            var endpoints = GetSegmentEndpoints();
+
+            ReadOnlySpan<Vector3> GetSegmentEndpoints()
+            {
+                var center2 = center.Vector2XY();
+                var centerLeft = new Vector3(Vector2Utility.RotateAroundPoint(center2, position.Vector2XY(), curveAngle / 2f), 0f);
+                var upDirection = Vector3.Normalize(center - centerLeft);
+
+                var cosine = MathF.Cos(segmentAngle / 2);
+                var additionalRadius = radius * (1f - cosine) / cosine;
+
+                var topLeft = centerLeft + upDirection * halfRoadWidth;
+                var bottomLeft = centerLeft - upDirection * (halfRoadWidth + additionalRadius);
+                var topRight = new Vector3(Vector2Utility.RotateAroundPoint(center2, topLeft.Vector2XY(), curveAngle), 0f);
+                var bottomRight = new Vector3(Vector2Utility.RotateAroundPoint(center2, bottomLeft.Vector2XY(), curveAngle), 0f);
+
+                var endpoints = new Vector3[]
+                {
+                    topLeft, topRight,
+                    bottomLeft, bottomRight
+                };
+
+                return endpoints.AsSpan();
+            }
+        }
+    }
+}

--- a/src/OpenSage.Game/Terrain/Roads/CurvedRoadSegment.cs
+++ b/src/OpenSage.Game/Terrain/Roads/CurvedRoadSegment.cs
@@ -18,6 +18,7 @@ namespace OpenSage.Terrain.Roads
         public Vector3  TopRight { get; }
         public Vector3  BottomLeft { get; }
         public Vector3 BottomRight { get; }
+        public float RelativeSize { get; }
 
         public bool MirrorTexture => false;
         public RoadTextureType Type => RoadTextureType.BroadCurve;
@@ -28,7 +29,8 @@ namespace OpenSage.Terrain.Roads
             in Vector3 bottomLeft,
             in Vector3 bottomRight,
             RoadSegmentEndPoint start,
-            RoadSegmentEndPoint end)
+            RoadSegmentEndPoint end,
+            float relativeSize)
         {
             TopLeft = topLeft;
             TopRight = topRight;
@@ -36,6 +38,7 @@ namespace OpenSage.Terrain.Roads
             BottomRight = bottomRight;
             Start = start;
             End = end;
+            RelativeSize = relativeSize;
         }
 
         public IEnumerable<RoadSegmentEndPoint> EndPoints
@@ -153,7 +156,7 @@ namespace OpenSage.Terrain.Roads
 
             while (remainingAngle > 0f)
             {
-                currentSegment = CreateSegment(previousEndPoint.Position, MathF.Min(segmentAngle, remainingAngle));
+                currentSegment = CreateSegment(previousEndPoint.Position);
                 currentSegment.Start.ConnectTo(previousSegment, previousDirection);
                 previousEndPoint.ConnectTo(currentSegment, -previousDirection);
 
@@ -185,7 +188,7 @@ namespace OpenSage.Terrain.Roads
                 var startPoint = new RoadSegmentEndPoint(centerLeft);
                 var endPoint = new RoadSegmentEndPoint(topRight + Vector3.Normalize(topRightToBottomRight) * halfRoadWidth); 
 
-                return new CurvedRoadSegment(topLeft, topRight, bottomLeft, bottomRight, startPoint, endPoint);
+                return new CurvedRoadSegment(topLeft, topRight, bottomLeft, bottomRight, startPoint, endPoint, angle / segmentAngle);
             }
         }
     }

--- a/src/OpenSage.Game/Terrain/Roads/CurvedRoadSegment.cs
+++ b/src/OpenSage.Game/Terrain/Roads/CurvedRoadSegment.cs
@@ -15,8 +15,8 @@ namespace OpenSage.Terrain.Roads
         public Vector3 StartPosition => 0.5f * (TopLeft + BottomLeft);
         public Vector3 EndPosition => 0.5f * (TopRight + BottomRight);
         public Vector3 TopLeft { get; }
-        public Vector3  TopRight { get; }
-        public Vector3  BottomLeft { get; }
+        public Vector3 TopRight { get; }
+        public Vector3 BottomLeft { get; }
         public Vector3 BottomRight { get; }
         public float RelativeSize { get; }
 
@@ -52,7 +52,7 @@ namespace OpenSage.Terrain.Roads
 
         public RoadSegmentMesher CreateMesher(RoadTemplate template)
         {
-            return new CurvedRoadSegmentMesher(this, Vector3.Distance(TopLeft, BottomLeft) / 2f, template);
+            return new CurvedRoadSegmentMesher(this, template);
         }
 
         public static void CreateCurve(
@@ -156,7 +156,7 @@ namespace OpenSage.Terrain.Roads
 
             while (remainingAngle > 0f)
             {
-                currentSegment = CreateSegment(previousEndPoint.Position);
+                currentSegment = CreateSegment(previousEndPoint.Position, MathF.Min(remainingAngle, segmentAngle));
                 currentSegment.Start.ConnectTo(previousSegment, previousDirection);
                 previousEndPoint.ConnectTo(currentSegment, -previousDirection);
 

--- a/src/OpenSage.Game/Terrain/Roads/ISimpleRoadSegment.cs
+++ b/src/OpenSage.Game/Terrain/Roads/ISimpleRoadSegment.cs
@@ -1,0 +1,8 @@
+﻿namespace OpenSage.Terrain.Roads
+{
+    internal interface ISimpleRoadSegment : IRoadSegment
+    {
+        RoadSegmentEndPoint Start { get; }
+        RoadSegmentEndPoint End { get; }
+    }
+}

--- a/src/OpenSage.Game/Terrain/Roads/IncomingRoadData.cs
+++ b/src/OpenSage.Game/Terrain/Roads/IncomingRoadData.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using OpenSage.Data.Map;
 
 namespace OpenSage.Terrain.Roads
 {
@@ -7,18 +8,18 @@ namespace OpenSage.Terrain.Roads
         public IncomingRoadData(
             RoadTopologyEdge topologyEdge,
             in Vector3 targetNodePosition,
-            in Vector3 direction,
+            in Vector3 outDirection,
             float angleToAxis)
         {
             TopologyEdge = topologyEdge;
             TargetNodePosition = targetNodePosition;
-            Direction = direction;
+            OutDirection = outDirection;
             AngleToAxis = angleToAxis;
         }
 
         public RoadTopologyEdge TopologyEdge { get; }
         public Vector3 TargetNodePosition { get;}
-        public Vector3 Direction { get; }
+        public Vector3 OutDirection { get; }
         public float AngleToAxis { get; }
         public IncomingRoadData Previous { get; internal set; }
         public float AngleToPreviousEdge { get; internal set; } = float.NaN;

--- a/src/OpenSage.Game/Terrain/Roads/RoadConstants.cs
+++ b/src/OpenSage.Game/Terrain/Roads/RoadConstants.cs
@@ -1,0 +1,11 @@
+﻿namespace OpenSage.Terrain.Roads
+{
+    public static class RoadConstants
+    {
+        // TODO figure out exact threshold
+        public const float MinCurveAngle = 0.47f;
+        public const float OverlapLength = 0.015f;
+        public const float BroadCurveRadius = 3.5f;
+        public const float TightCurveRadius = 1.28f;
+    }
+}

--- a/src/OpenSage.Game/Terrain/Roads/RoadNetwork.cs
+++ b/src/OpenSage.Game/Terrain/Roads/RoadNetwork.cs
@@ -53,11 +53,11 @@ namespace OpenSage.Terrain.Roads
 
                         if (connectedEdge.Start.Position == node.Position)
                         {
-                            connectedEdgeSegment.Start.ConnectTo(edgeSegment, direction);
+                            connectedEdgeSegment.Start.ConnectTo(edgeSegment, Vector3.Normalize(direction));
                         }
                         else
                         {
-                            connectedEdgeSegment.End.ConnectTo(edgeSegment, direction);
+                            connectedEdgeSegment.End.ConnectTo(edgeSegment, Vector3.Normalize(direction));
                         }
                     }
                 }
@@ -72,17 +72,20 @@ namespace OpenSage.Terrain.Roads
             {
                 foreach (var edgesPerTemplate in node.Edges.GroupBy(e => e.Template))
                 {
+                    var template = edgesPerTemplate.Key;
+                    // possible optimization: only compute angles if necessary?
+                    var incomingRoadData = ComputeRoadAngles(node, edgesPerTemplate);
+
                     switch (edgesPerTemplate.Count())
                     {
                         // TODO support end caps
                         case 1: // end point
                             break;
-                        case 2: // TODO normal road, create segments for tight/broad curves
+                        case 2:
+                            CurvedRoadSegment.CreateCurve(incomingRoadData, node.Position, template, edgeSegments);
                             break;
                         case 3:
                         case 4:
-                            var template = edgesPerTemplate.Key;
-                            var incomingRoadData = ComputeRoadAngles(node, edgesPerTemplate);
                             CrossingRoadSegment.CreateCrossing(incomingRoadData, node.Position, template, edgeSegments);
                             break;
                     }
@@ -90,11 +93,17 @@ namespace OpenSage.Terrain.Roads
             }
         }
 
-        private static IEnumerable<IncomingRoadData> ComputeRoadAngles(RoadTopologyNode node, IEnumerable<RoadTopologyEdge> edges)
+        private static IReadOnlyList<IncomingRoadData> ComputeRoadAngles(RoadTopologyNode node, IEnumerable<RoadTopologyEdge> edges)
         {
+            if (edges.Count() < 2)
+            {
+                return Array.Empty<IncomingRoadData>();
+            }
+
             IncomingRoadData GetIncomingRoadData(RoadTopologyNode node, RoadTopologyEdge incomingEdge)
             {
-                var targetNodePosition = incomingEdge.Start.Position == node.Position ? incomingEdge.End.Position : incomingEdge.Start.Position;
+                var isStart = incomingEdge.Start.Position == node.Position;
+                var targetNodePosition = isStart ? incomingEdge.End.Position : incomingEdge.Start.Position;
                 var roadVector = targetNodePosition - node.Position;
                 var direction = roadVector.LengthSquared() < 0.01f ? Vector3.UnitX : Vector3.Normalize(roadVector);
 

--- a/src/OpenSage.Game/Terrain/Roads/RoadSegmentMesher.cs
+++ b/src/OpenSage.Game/Terrain/Roads/RoadSegmentMesher.cs
@@ -340,17 +340,6 @@ namespace OpenSage.Terrain.Roads
         {
         }
 
-        private Vector2 TopUVEnd { get; set; }
-        private Vector2 BottomUVEnd { get; set; }
-
-        protected override void Prepare()
-        {
-            base.Prepare();
-            var curve = Segment as CurvedRoadSegment ?? throw new InvalidOperationException();
-            TopUVEnd = (1 - curve.RelativeSize) * TextureBounds.TopLeft + curve.RelativeSize * TextureBounds.TopRight;
-            BottomUVEnd = (1 - curve.RelativeSize) * TextureBounds.BottomLeft + curve.RelativeSize * TextureBounds.BottomRight;
-        }
-
         protected override Vector3 ToCorner(RoadSegmentEndPoint neighbor, bool atEnd)
         {
             var curve = Segment as CurvedRoadSegment;
@@ -366,8 +355,8 @@ namespace OpenSage.Terrain.Roads
 
         protected override (Vector2 top, Vector2 bottom) GetTopBottomTextureCoordinates(float relativeProgress, float distanceAlongRoad)
         {
-            var top = Vector2.Lerp(TextureBounds.TopLeft, TopUVEnd, relativeProgress);
-            var bottom = Vector2.Lerp(TextureBounds.BottomLeft, BottomUVEnd, relativeProgress);
+            var top = Vector2.Lerp(TextureBounds.TopLeft, TextureBounds.TopRight, relativeProgress);
+            var bottom = Vector2.Lerp(TextureBounds.BottomLeft, TextureBounds.BottomRight, relativeProgress);
             return (top, bottom);
         }
     }

--- a/src/OpenSage.Game/Terrain/Roads/RoadSegmentMesher.cs
+++ b/src/OpenSage.Game/Terrain/Roads/RoadSegmentMesher.cs
@@ -251,21 +251,16 @@ namespace OpenSage.Terrain.Roads
 
         protected override void Prepare()
         {
-            var straightRoad = Segment as StraightRoadSegment;
-            if (straightRoad == null)
-            {
-                throw new InvalidOperationException();
-            }
+            var simpleRoad = Segment as ISimpleRoadSegment ?? throw new InvalidOperationException();
 
-            StartToTopCorner = ToCorner(straightRoad.Start, false);
-            EndToTopCorner = ToCorner(straightRoad.End, true);
+            StartToTopCorner = ToCorner(simpleRoad.Start, false);
+            EndToTopCorner = ToCorner(simpleRoad.End, true);
         }
 
         protected override Vector3 ToTopBorder(float relativeProgress)
         {
             return Vector3.Lerp(StartToTopCorner, EndToTopCorner, relativeProgress);
         }
-
 
         /// <summary>
         /// Generate vector from the start/end position of an edge to the corner of the mesh's base geometry
@@ -332,7 +327,6 @@ namespace OpenSage.Terrain.Roads
             var uvBottom = new Vector2(u - topUOffset, v - vOffset);
             return (uvTop, uvBottom);
         }
-
     }
 
 
@@ -341,11 +335,6 @@ namespace OpenSage.Terrain.Roads
         public CurvedRoadSegmentMesher(IRoadSegment segment, float halfHeight, RoadTemplate template)
             : base(segment, halfHeight, template)
         {
-        }
-        
-        protected override void Prepare()
-        {
-            base.Prepare();
         }
 
         protected override Vector3 ToCorner(RoadSegmentEndPoint neighbor, bool atEnd)

--- a/src/OpenSage.Game/Terrain/Roads/RoadTopology.cs
+++ b/src/OpenSage.Game/Terrain/Roads/RoadTopology.cs
@@ -18,7 +18,7 @@ namespace OpenSage.Terrain.Roads
             {
                 // create a new dummy vertex, otherwise this edge gets counted twice as incoming edge of startVertex
                 // add a small offset to make sure that other map objects use the 'normal' vertex
-                endNode = GetOrCreateNode(end.Position + 0.0001f * Vector3.UnitX);
+                endNode = GetOrCreateNode(end.Position + 0.001f * Vector3.UnitX);
             }
 
             var edge = new RoadTopologyEdge(

--- a/src/OpenSage.Game/Terrain/Roads/StraightRoadSegment.cs
+++ b/src/OpenSage.Game/Terrain/Roads/StraightRoadSegment.cs
@@ -3,7 +3,7 @@ using System.Numerics;
 
 namespace OpenSage.Terrain.Roads
 {
-    internal sealed class StraightRoadSegment : IRoadSegment
+    internal sealed class StraightRoadSegment : ISimpleRoadSegment
     {
         public RoadSegmentEndPoint Start { get; }
         public RoadSegmentEndPoint End { get; }

--- a/src/OpenSage.Game/Terrain/Roads/TextureAtlas.cs
+++ b/src/OpenSage.Game/Terrain/Roads/TextureAtlas.cs
@@ -80,9 +80,16 @@ namespace OpenSage.Terrain.Roads
                 TextureCoordinates.Curve(
                     0.5f,
                     halfRoadWidth,
-                    MathUtility.ToRadians(30f)));
+                    RoadConstants.BroadCurveRadius));
 
-            // TODO: TightCurve, Join
+            _coordinates.Add(
+                RoadTextureType.TightCurve,
+                TextureCoordinates.Curve(
+                    TileCenter(2),
+                    halfRoadWidth,
+                    RoadConstants.TightCurveRadius));
+
+            // TODO: End cap/join
         }
 
         /// <summary>
@@ -136,16 +143,18 @@ namespace OpenSage.Terrain.Roads
                 new Vector2(right, bottom));
         }
 
-        public static TextureCoordinates Curve(float v, float halfRoadWidth, float angle)
+        public static TextureCoordinates Curve(float v, float halfRoadWidth, float radiusInHalfRoadWidths)
         {
-            var radius = 3.5f * halfRoadWidth;
+            var angle = MathF.PI / 6f;
+            var radius = radiusInHalfRoadWidths * halfRoadWidth;
             var cosine = MathF.Cos(angle / 2f);
             var additionalRadius = radius * (1f - cosine) / cosine;
+            var uStart = 0f;
 
-            var center = new Vector2(0f, v - radius);
+            var center = new Vector2(uStart, v - radius);
 
-            var topLeft = new Vector2(0f, v - halfRoadWidth);
-            var bottomLeft = new Vector2(0f, v + halfRoadWidth + additionalRadius);
+            var topLeft = new Vector2(uStart, v - halfRoadWidth);
+            var bottomLeft = new Vector2(uStart, v + halfRoadWidth + additionalRadius);
 
             var topRight = Vector2Utility.RotateAroundPoint(center, topLeft, -angle);
             var bottomRight = Vector2Utility.RotateAroundPoint(center, bottomLeft, -angle);

--- a/src/OpenSage.Game/Terrain/Roads/TextureAtlas.cs
+++ b/src/OpenSage.Game/Terrain/Roads/TextureAtlas.cs
@@ -139,7 +139,7 @@ namespace OpenSage.Terrain.Roads
         public static TextureCoordinates Curve(float v, float halfRoadWidth, float angle)
         {
             var radius = 3.5f * halfRoadWidth;
-            var cosine = MathF.Cos(angle);
+            var cosine = MathF.Cos(angle / 2f);
             var additionalRadius = radius * (1f - cosine) / cosine;
             var center = new Vector2(0, v - radius);
 

--- a/src/OpenSage.Game/Terrain/Roads/TextureAtlas.cs
+++ b/src/OpenSage.Game/Terrain/Roads/TextureAtlas.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Numerics;
 using OpenSage.Mathematics;
 
@@ -77,7 +78,7 @@ namespace OpenSage.Terrain.Roads
             _coordinates.Add(
                 RoadTextureType.BroadCurve,
                 TextureCoordinates.Curve(
-                    TileCenter(0),
+                    TileCenter(1),
                     halfRoadWidth,
                     MathUtility.ToRadians(30)));
 
@@ -135,15 +136,18 @@ namespace OpenSage.Terrain.Roads
                 new Vector2(right, bottom));
         }
 
-        public static TextureCoordinates Curve(float y, float halfRoadWidth, float angle)
+        public static TextureCoordinates Curve(float v, float halfRoadWidth, float angle)
         {
-            var topLeft = new Vector2(0, y - halfRoadWidth);
-            var bottomLeft = new Vector2(0, y + halfRoadWidth);
+            var radius = 3.5f * halfRoadWidth;
+            var cosine = MathF.Cos(angle);
+            var additionalRadius = radius * (1f - cosine) / cosine;
+            var center = new Vector2(0, v - radius);
 
-            var radius = 10f / 3f * halfRoadWidth;
-            var center = new Vector2(0, y - radius);
-            var topRight = Vector2Utility.RotateAroundPoint(center, topLeft, angle);
-            var bottomRight = Vector2Utility.RotateAroundPoint(center, bottomLeft, angle);
+            var topLeft = new Vector2(0, v - halfRoadWidth);
+            var bottomLeft = new Vector2(0, v + halfRoadWidth + additionalRadius);
+
+            var topRight = Vector2Utility.RotateAroundPoint(center, topLeft, -angle);
+            var bottomRight = Vector2Utility.RotateAroundPoint(center, bottomLeft, -angle);
 
             return new TextureCoordinates(
                 topLeft,

--- a/src/OpenSage.Game/Terrain/Roads/TextureAtlas.cs
+++ b/src/OpenSage.Game/Terrain/Roads/TextureAtlas.cs
@@ -78,9 +78,9 @@ namespace OpenSage.Terrain.Roads
             _coordinates.Add(
                 RoadTextureType.BroadCurve,
                 TextureCoordinates.Curve(
-                    TileCenter(1),
+                    0.5f,
                     halfRoadWidth,
-                    MathUtility.ToRadians(30)));
+                    MathUtility.ToRadians(30f)));
 
             // TODO: TightCurve, Join
         }
@@ -141,10 +141,11 @@ namespace OpenSage.Terrain.Roads
             var radius = 3.5f * halfRoadWidth;
             var cosine = MathF.Cos(angle / 2f);
             var additionalRadius = radius * (1f - cosine) / cosine;
-            var center = new Vector2(0, v - radius);
 
-            var topLeft = new Vector2(0, v - halfRoadWidth);
-            var bottomLeft = new Vector2(0, v + halfRoadWidth + additionalRadius);
+            var center = new Vector2(0f, v - radius);
+
+            var topLeft = new Vector2(0f, v - halfRoadWidth);
+            var bottomLeft = new Vector2(0f, v + halfRoadWidth + additionalRadius);
 
             var topRight = Vector2Utility.RotateAroundPoint(center, topLeft, -angle);
             var bottomRight = Vector2Utility.RotateAroundPoint(center, bottomLeft, -angle);


### PR DESCRIPTION
Adds support for tight and broad curves.

The texture mapping isn't perfect, but then again, neither is the orignal.

The decision which curve type is chosen is somewhat arbitrary (see #341), this algorithm isn't implemented yet. We only use tight and broad curves if both edges agree on the type.

![grafik](https://user-images.githubusercontent.com/10420514/71821165-aaabd300-3091-11ea-9294-87f9e6469277.png)


