### PR TITLE
Fix wrong path seperator issue

### DIFF
--- a/src/OpenSage.Game/Data/FileSystem.cs
+++ b/src/OpenSage.Game/Data/FileSystem.cs
@@ -67,7 +67,7 @@ namespace OpenSage.Data
             }
         }
 
-        internal static string NormalizeFilePath(string filePath)
+        public static string NormalizeFilePath(string filePath)
         {
             return filePath
                 .Replace('/', Path.DirectorySeparatorChar)

--- a/src/OpenSage.Mods.Generals/Gui/MapUtils.cs
+++ b/src/OpenSage.Mods.Generals/Gui/MapUtils.cs
@@ -4,6 +4,7 @@ using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.Gui.Wnd.Controls;
 using OpenSage.Mathematics;
+using OpenSage.Data;
 
 namespace OpenSage.Mods.Generals.Gui
 {
@@ -48,8 +49,8 @@ namespace OpenSage.Mods.Generals.Gui
 
         public static void SetMapPreview(MapCache mapCache, Control mapWindow, Game game)
         {
-            var mapPath = mapCache.Name;
-            var basePath = Path.GetDirectoryName(mapPath) + "\\" + Path.GetFileNameWithoutExtension(mapPath);
+            var mapPath = FileSystem.NormalizeFilePath(mapCache.Name);
+            var basePath = Path.GetDirectoryName(mapPath) + "/" + Path.GetFileNameWithoutExtension(mapPath);
             var thumbPath = basePath + ".tga";
 
             // Set thumbnail


### PR DESCRIPTION
This fixes a crash on linux, which happened because `Path.GetDirectoryName(mapPath)` was invalid on unix systems. The path must be normalized first for this to work