### PR TITLE
Improve wnd image quality

### DIFF
--- a/src/OpenSage.Game/Gui/Wnd/Images/Image.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Images/Image.cs
@@ -25,19 +25,23 @@ namespace OpenSage.Gui.Wnd.Images
 
         internal void SetSize(in Size size)
         {
-            if (_size == size)
+            var actualSize = _source.NaturalSize.Width > size.Width
+                ? _source.NaturalSize
+                : size;
+
+            if (_size == actualSize)
             {
                 return;
             }
 
-            _texture = _source.GetTexture(size);
+            _texture = _source.GetTexture(actualSize);
 
             if (_texture == null)
             {
                 throw new InvalidOperationException();
             }
 
-            _size = size;
+            _size = actualSize;
         }
 
         public Image WithGrayscale(bool grayscale)


### PR DESCRIPTION
We were downsampling textures, only to upsample them again when rendering, which looked terrible.