### PR TITLE
Work on object upgrades

### DIFF
--- a/src/OpenSage.Game/Content/AssetStore.cs
+++ b/src/OpenSage.Game/Content/AssetStore.cs
@@ -164,7 +164,7 @@ namespace OpenSage.Content
         public ScopedAssetCollection<LoadSubsystem> Subsystems { get; }
         public ScopedAssetCollection<TerrainTexture> TerrainTextures { get; }
         public ScopedAssetCollection<TextureAsset> Textures { get; }
-        public ScopedAssetCollection<Upgrade> Upgrades { get; }
+        public ScopedAssetCollection<UpgradeDefinition> Upgrades { get; }
         public ScopedAssetCollection<VictorySystemData> VictorySystemDatas { get; }
         public ScopedAssetCollection<Video> Videos { get; }
         public ScopedAssetCollection<WaterSet> WaterSets { get; }
@@ -339,7 +339,7 @@ namespace OpenSage.Content
             AddAssetCollection(Subsystems = new ScopedAssetCollection<LoadSubsystem>(this));
             AddAssetCollection(TerrainTextures = new ScopedAssetCollection<TerrainTexture>(this));
             AddAssetCollection(Textures = new ScopedAssetCollection<TextureAsset>(this, loadStrategy.CreateTextureLoader()));
-            AddAssetCollection(Upgrades = new ScopedAssetCollection<Upgrade>(this));
+            AddAssetCollection(Upgrades = new ScopedAssetCollection<UpgradeDefinition>(this));
             AddAssetCollection(VictorySystemDatas = new ScopedAssetCollection<VictorySystemData>(this));
             AddAssetCollection(Videos = new ScopedAssetCollection<Video>(this));
             AddAssetCollection(WaterSets = new ScopedAssetCollection<WaterSet>(this));

--- a/src/OpenSage.Game/Content/AssetStore.cs
+++ b/src/OpenSage.Game/Content/AssetStore.cs
@@ -164,7 +164,7 @@ namespace OpenSage.Content
         public ScopedAssetCollection<LoadSubsystem> Subsystems { get; }
         public ScopedAssetCollection<TerrainTexture> TerrainTextures { get; }
         public ScopedAssetCollection<TextureAsset> Textures { get; }
-        public ScopedAssetCollection<UpgradeDefinition> Upgrades { get; }
+        public ScopedAssetCollection<UpgradeTemplate> Upgrades { get; }
         public ScopedAssetCollection<VictorySystemData> VictorySystemDatas { get; }
         public ScopedAssetCollection<Video> Videos { get; }
         public ScopedAssetCollection<WaterSet> WaterSets { get; }
@@ -339,7 +339,7 @@ namespace OpenSage.Content
             AddAssetCollection(Subsystems = new ScopedAssetCollection<LoadSubsystem>(this));
             AddAssetCollection(TerrainTextures = new ScopedAssetCollection<TerrainTexture>(this));
             AddAssetCollection(Textures = new ScopedAssetCollection<TextureAsset>(this, loadStrategy.CreateTextureLoader()));
-            AddAssetCollection(Upgrades = new ScopedAssetCollection<UpgradeDefinition>(this));
+            AddAssetCollection(Upgrades = new ScopedAssetCollection<UpgradeTemplate>(this));
             AddAssetCollection(VictorySystemDatas = new ScopedAssetCollection<VictorySystemData>(this));
             AddAssetCollection(Videos = new ScopedAssetCollection<Video>(this));
             AddAssetCollection(WaterSets = new ScopedAssetCollection<WaterSet>(this));

--- a/src/OpenSage.Game/Data/Ini/IniParser.BlockParsers.cs
+++ b/src/OpenSage.Game/Data/Ini/IniParser.BlockParsers.cs
@@ -155,7 +155,7 @@ namespace OpenSage.Data.Ini
             { "StaticGameLOD", (parser, assetStore) => assetStore.StaticGameLods.Add(StaticGameLod.Parse(parser)) },
             { "StrategicHUD", (parser, assetStore) => StrategicHud.Parse(parser, assetStore.StrategicHud.Current) },
             { "Terrain", (parser, assetStore) => assetStore.TerrainTextures.Add(TerrainTexture.Parse(parser)) },
-            { "Upgrade", (parser, assetStore) => assetStore.Upgrades.Add(Upgrade.Parse(parser)) },
+            { "Upgrade", (parser, assetStore) => assetStore.Upgrades.Add(UpgradeDefinition.Parse(parser)) },
             { "VictorySystemData", (parser, assetStore) => assetStore.VictorySystemDatas.Add(VictorySystemData.Parse(parser)) },
             { "Video", (parser, assetStore) => assetStore.Videos.Add(Video.Parse(parser)) },
             { "WaterSet", (parser, assetStore) => assetStore.WaterSets.Add(WaterSet.Parse(parser)) },

--- a/src/OpenSage.Game/Data/Ini/IniParser.BlockParsers.cs
+++ b/src/OpenSage.Game/Data/Ini/IniParser.BlockParsers.cs
@@ -155,7 +155,7 @@ namespace OpenSage.Data.Ini
             { "StaticGameLOD", (parser, assetStore) => assetStore.StaticGameLods.Add(StaticGameLod.Parse(parser)) },
             { "StrategicHUD", (parser, assetStore) => StrategicHud.Parse(parser, assetStore.StrategicHud.Current) },
             { "Terrain", (parser, assetStore) => assetStore.TerrainTextures.Add(TerrainTexture.Parse(parser)) },
-            { "Upgrade", (parser, assetStore) => assetStore.Upgrades.Add(UpgradeDefinition.Parse(parser)) },
+            { "Upgrade", (parser, assetStore) => assetStore.Upgrades.Add(UpgradeTemplate.Parse(parser)) },
             { "VictorySystemData", (parser, assetStore) => assetStore.VictorySystemDatas.Add(VictorySystemData.Parse(parser)) },
             { "Video", (parser, assetStore) => assetStore.Videos.Add(Video.Parse(parser)) },
             { "WaterSet", (parser, assetStore) => assetStore.WaterSets.Add(WaterSet.Parse(parser)) },

--- a/src/OpenSage.Game/Data/Ini/IniParser.cs
+++ b/src/OpenSage.Game/Data/Ini/IniParser.cs
@@ -409,7 +409,7 @@ namespace OpenSage.Data.Ini
             return _assetStore.CommandSets.GetLazyAssetReferenceByName(name);
         }
 
-        public LazyAssetReference<Upgrade> ParseUpgradeReference()
+        public LazyAssetReference<UpgradeDefinition> ParseUpgradeReference()
         {
             var name = ParseAssetReference();
             return _assetStore.Upgrades.GetLazyAssetReferenceByName(name);

--- a/src/OpenSage.Game/Data/Ini/IniParser.cs
+++ b/src/OpenSage.Game/Data/Ini/IniParser.cs
@@ -409,7 +409,7 @@ namespace OpenSage.Data.Ini
             return _assetStore.CommandSets.GetLazyAssetReferenceByName(name);
         }
 
-        public LazyAssetReference<UpgradeDefinition> ParseUpgradeReference()
+        public LazyAssetReference<UpgradeTemplate> ParseUpgradeReference()
         {
             var name = ParseAssetReference();
             return _assetStore.Upgrades.GetLazyAssetReferenceByName(name);

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -129,6 +129,7 @@ namespace OpenSage.Logic.Object
 
         public ProductionUpdate ProductionUpdate { get; }
         public GameObject TargetEnemy { get; }
+        public List<UpgradeDefinition> Upgrades { get; }
 
         private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
@@ -195,6 +196,8 @@ namespace OpenSage.Logic.Object
                 var rpMarkerDef = loadContext.AssetStore.ObjectDefinitions.GetByName("RallyPointMarker");
                 _rallyPointMarker = AddDisposable(new GameObject(rpMarkerDef, loadContext, owner, parent, navigation));
             }
+
+            Upgrades = new List<UpgradeDefinition>();
         }
 
         internal IEnumerable<AttachedParticleSystem> GetAllAttachedParticleSystems()
@@ -467,6 +470,18 @@ namespace OpenSage.Logic.Object
             CurrentWeapon = (weaponSet != null)
                 ? new Weapon(this, weaponSet)
                 : null;
+        }
+        
+        public void Upgrade(UpgradeDefinition upgrade)
+        {
+            if (upgrade.AcademyClassify == AcademyType.Superpower)
+            {
+                Upgrades.Add(upgrade);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -129,8 +129,7 @@ namespace OpenSage.Logic.Object
 
         public ProductionUpdate ProductionUpdate { get; }
         public GameObject TargetEnemy { get; }
-        public List<UpgradeDefinition> Upgrades { get; }
-
+        public List<UpgradeTemplate> Upgrades { get; }
         private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
         internal GameObject(ObjectDefinition objectDefinition, AssetLoadContext loadContext, Player owner,
@@ -197,7 +196,7 @@ namespace OpenSage.Logic.Object
                 _rallyPointMarker = AddDisposable(new GameObject(rpMarkerDef, loadContext, owner, parent, navigation));
             }
 
-            Upgrades = new List<UpgradeDefinition>();
+            Upgrades = new List<UpgradeTemplate>();
         }
 
         internal IEnumerable<AttachedParticleSystem> GetAllAttachedParticleSystems()
@@ -471,8 +470,7 @@ namespace OpenSage.Logic.Object
                 ? new Weapon(this, weaponSet)
                 : null;
         }
-        
-        public void Upgrade(UpgradeDefinition upgrade)
+        public void Upgrade(UpgradeTemplate upgrade)
         {
             if (upgrade.AcademyClassify == AcademyType.Superpower)
             {

--- a/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
@@ -373,11 +373,11 @@ namespace OpenSage.Logic.Object
         public int PlacementViewAngle { get; private set; }
         public LazyAssetReference<MappedImage> SelectPortrait { get; private set; }
         public string ButtonImage { get; private set; }
-        public LazyAssetReference<Upgrade> UpgradeCameo1 { get; private set; }
-        public LazyAssetReference<Upgrade> UpgradeCameo2 { get; private set; }
-        public LazyAssetReference<Upgrade> UpgradeCameo3 { get; private set; }
-        public LazyAssetReference<Upgrade> UpgradeCameo4 { get; private set; }
-        public LazyAssetReference<Upgrade> UpgradeCameo5 { get; private set; }
+        public LazyAssetReference<UpgradeDefinition> UpgradeCameo1 { get; private set; }
+        public LazyAssetReference<UpgradeDefinition> UpgradeCameo2 { get; private set; }
+        public LazyAssetReference<UpgradeDefinition> UpgradeCameo3 { get; private set; }
+        public LazyAssetReference<UpgradeDefinition> UpgradeCameo4 { get; private set; }
+        public LazyAssetReference<UpgradeDefinition> UpgradeCameo5 { get; private set; }
 
         // Design
         public ObjectBuildableType Buildable { get; private set; }

--- a/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
@@ -373,11 +373,11 @@ namespace OpenSage.Logic.Object
         public int PlacementViewAngle { get; private set; }
         public LazyAssetReference<MappedImage> SelectPortrait { get; private set; }
         public string ButtonImage { get; private set; }
-        public LazyAssetReference<UpgradeDefinition> UpgradeCameo1 { get; private set; }
-        public LazyAssetReference<UpgradeDefinition> UpgradeCameo2 { get; private set; }
-        public LazyAssetReference<UpgradeDefinition> UpgradeCameo3 { get; private set; }
-        public LazyAssetReference<UpgradeDefinition> UpgradeCameo4 { get; private set; }
-        public LazyAssetReference<UpgradeDefinition> UpgradeCameo5 { get; private set; }
+        public LazyAssetReference<UpgradeTemplate> UpgradeCameo1 { get; private set; }
+        public LazyAssetReference<UpgradeTemplate> UpgradeCameo2 { get; private set; }
+        public LazyAssetReference<UpgradeTemplate> UpgradeCameo3 { get; private set; }
+        public LazyAssetReference<UpgradeTemplate> UpgradeCameo4 { get; private set; }
+        public LazyAssetReference<UpgradeTemplate> UpgradeCameo5 { get; private set; }
 
         // Design
         public ObjectBuildableType Buildable { get; private set; }

--- a/src/OpenSage.Game/Logic/Object/Production/ProductionJob.cs
+++ b/src/OpenSage.Game/Logic/Object/Production/ProductionJob.cs
@@ -23,7 +23,7 @@ namespace OpenSage.Logic.Object.Production
         }
 
         public ObjectDefinition ObjectDefinition { get; }
-        public UpgradeDefinition UpgradeDefinition { get; }
+        public UpgradeTemplate UpgradeDefinition { get; }
 
         public ProductionJob(ObjectDefinition definition)
         {
@@ -32,7 +32,7 @@ namespace OpenSage.Logic.Object.Production
             _duration = (int) (definition.BuildTime * 1000.0f);
         }
 
-        public ProductionJob(UpgradeDefinition definition)
+        public ProductionJob(UpgradeTemplate definition)
         {
             UpgradeDefinition = definition;
             Type = ProductionJobType.Upgrade;

--- a/src/OpenSage.Game/Logic/Object/Production/ProductionJob.cs
+++ b/src/OpenSage.Game/Logic/Object/Production/ProductionJob.cs
@@ -4,17 +4,18 @@ namespace OpenSage.Logic.Object.Production
 {
     public sealed class ProductionJob
     {
-        private readonly int _cost;
-        private int _spent;
+        //Duration in milliseconds
+        private readonly int _duration;
+        private float _passed;
 
         public ProductionJobType Type { get; }
 
-        public float Progress => Math.Max(0, Math.Min(1, _spent / (float) _cost));
+        public float Progress => Math.Max(0, Math.Min(1, (float) (_passed / _duration)));
 
-        public ProductionJobResult Produce(int spent)
+        public ProductionJobResult Produce(float passed)
         {
-            _spent += spent;
-            if (_spent >= _cost)
+            _passed += passed;
+            if (_passed >= _duration)
             {
                 return ProductionJobResult.Finished;
             }
@@ -22,12 +23,20 @@ namespace OpenSage.Logic.Object.Production
         }
 
         public ObjectDefinition ObjectDefinition { get; }
+        public UpgradeDefinition UpgradeDefinition { get; }
 
         public ProductionJob(ObjectDefinition definition)
         {
             ObjectDefinition = definition;
             Type = ProductionJobType.Unit;
-            _cost = (int) definition.BuildCost;
+            _duration = (int) (definition.BuildTime * 1000.0f);
+        }
+
+        public ProductionJob(UpgradeDefinition definition)
+        {
+            UpgradeDefinition = definition;
+            Type = ProductionJobType.Upgrade;
+            _duration = (int) (definition.BuildTime * 1000.0f);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -135,7 +135,7 @@ namespace OpenSage.Logic.Object
             }
         }
 
-        private void GrantUpgrade(UpgradeDefinition upgradeDefinition)
+        private void GrantUpgrade(UpgradeTemplate upgradeDefinition)
         {
             _gameObject.Upgrade(upgradeDefinition);
         }
@@ -186,7 +186,7 @@ namespace OpenSage.Logic.Object
             _productionQueue.Add(job);
         }
 
-        internal void QueueUpgrade(UpgradeDefinition upgradeDefinition)
+        internal void QueueUpgrade(UpgradeTemplate upgradeDefinition)
         {
             var job = new ProductionJob(upgradeDefinition);
             _productionQueue.Add(job);

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -58,22 +58,35 @@ namespace OpenSage.Logic.Object
                 return;
             }
 
-            if (_productionQueue.Count > 0 && _productionQueue[0].Produce(20) == ProductionJobResult.Finished)
+            if (_productionQueue.Count > 0)
             {
-                if (_moduleData.NumDoorAnimations > 0)
+                var front = _productionQueue[0];
+                var result = front.Produce((float) time.DeltaTime.TotalMilliseconds);
+                if (result == ProductionJobResult.Finished)
                 {
-                    Logger.Info($"Door opening for {_moduleData.DoorOpeningTime}");
-                    _currentStepEnd = time.TotalTime + _moduleData.DoorOpeningTime;
-                    _currentDoorState = DoorState.Opening;
-                    _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Door1Opening, true);
+                    if (front.Type == ProductionJobType.Unit)
+                    {
+                        if (_moduleData.NumDoorAnimations > 0)
+                        {
+                            Logger.Info($"Door opening for {_moduleData.DoorOpeningTime}");
+                            _currentStepEnd = time.TotalTime + _moduleData.DoorOpeningTime;
+                            _currentDoorState = DoorState.Opening;
+                            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Door1Opening, true);
 
-                    ProduceObject(_productionQueue[0]);
-                }
-                else
-                {
-                    ProduceObject(_productionQueue[0]);
-                    MoveProducedObjectOut();
-                    _productionQueue.RemoveAt(0);
+                            ProduceObject(front);
+                        }
+                        else
+                        {
+                            ProduceObject(front);
+                            MoveProducedObjectOut();
+                            _productionQueue.RemoveAt(0);
+                        }
+                    }
+                    else if (front.Type == ProductionJobType.Upgrade)
+                    {
+                        GrantUpgrade(front);
+                        _productionQueue.RemoveAt(0);
+                    }
                 }
             }
 
@@ -110,6 +123,21 @@ namespace OpenSage.Logic.Object
                     ProduceObject(job.ObjectDefinition);
                     break;
             }
+        }
+
+        private void GrantUpgrade(ProductionJob job)
+        {
+            switch (job.Type)
+            {
+                case ProductionJobType.Upgrade:
+                    GrantUpgrade(job.UpgradeDefinition);
+                    break;
+            }
+        }
+
+        private void GrantUpgrade(UpgradeDefinition upgradeDefinition)
+        {
+            _gameObject.Upgrade(upgradeDefinition);
         }
 
         private void ProduceObject(ObjectDefinition objectDefinition)
@@ -155,6 +183,12 @@ namespace OpenSage.Logic.Object
         internal void QueueProduction(ObjectDefinition objectDefinition)
         {
             var job = new ProductionJob(objectDefinition);
+            _productionQueue.Add(job);
+        }
+
+        internal void QueueUpgrade(UpgradeDefinition upgradeDefinition)
+        {
+            var job = new ProductionJob(upgradeDefinition);
             _productionQueue.Add(job);
         }
 

--- a/src/OpenSage.Game/Logic/Object/UpgradeDefinition.cs
+++ b/src/OpenSage.Game/Logic/Object/UpgradeDefinition.cs
@@ -4,16 +4,16 @@ using OpenSage.Gui;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class Upgrade : BaseAsset
+    public sealed class UpgradeDefinition : BaseAsset
     {
-        internal static Upgrade Parse(IniParser parser)
+        internal static UpgradeDefinition Parse(IniParser parser)
         {
             return parser.ParseNamedBlock(
                 (x, name) => x.SetNameAndInstanceId("Upgrade", name),
                 FieldParseTable);
         }
 
-        private static readonly IniParseTable<Upgrade> FieldParseTable = new IniParseTable<Upgrade>
+        private static readonly IniParseTable<UpgradeDefinition> FieldParseTable = new IniParseTable<UpgradeDefinition>
         {
             { "Type", (parser, x) => x.Type = parser.ParseEnum<UpgradeType>() },
             { "DisplayName", (parser, x) => x.DisplayName = parser.ParseLocalizedStringKey() },

--- a/src/OpenSage.Game/Logic/Object/UpgradeTemplate.cs
+++ b/src/OpenSage.Game/Logic/Object/UpgradeTemplate.cs
@@ -4,16 +4,16 @@ using OpenSage.Gui;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class UpgradeDefinition : BaseAsset
+    public sealed class UpgradeTemplate : BaseAsset
     {
-        internal static UpgradeDefinition Parse(IniParser parser)
+        internal static UpgradeTemplate Parse(IniParser parser)
         {
             return parser.ParseNamedBlock(
                 (x, name) => x.SetNameAndInstanceId("Upgrade", name),
                 FieldParseTable);
         }
 
-        private static readonly IniParseTable<UpgradeDefinition> FieldParseTable = new IniParseTable<UpgradeDefinition>
+        private static readonly IniParseTable<UpgradeTemplate> FieldParseTable = new IniParseTable<UpgradeTemplate>
         {
             { "Type", (parser, x) => x.Type = parser.ParseEnum<UpgradeType>() },
             { "DisplayName", (parser, x) => x.DisplayName = parser.ParseLocalizedStringKey() },

--- a/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
@@ -42,7 +42,7 @@ namespace OpenSage.Logic.Orders
                     case OrderType.MoveTo:
                         {
                             var targetPosition = order.Arguments[0].Value.Position;
-                            foreach(var unit in player.SelectedUnits)
+                            foreach (var unit in player.SelectedUnits)
                             {
                                 unit.SetTargetPoint(targetPosition);
                             }
@@ -54,12 +54,25 @@ namespace OpenSage.Logic.Orders
                             var objectDefinition = _game.AssetStore.ObjectDefinitions.GetByInternalId(objectDefinitionId);
                             var position = order.Arguments[1].Value.Position;
                             var angle = order.Arguments[2].Value.Float;
-                            player.Money -= (uint)objectDefinition.BuildCost;
+                            player.Money -= (uint) objectDefinition.BuildCost;
 
                             var gameObject = _game.Scene3D.GameObjects.Add(objectDefinition, player);
                             gameObject.Transform.Translation = position;
                             gameObject.Transform.Rotation = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, angle);
                             gameObject.StartConstruction(_game.MapTime);
+                        }
+                        break;
+
+                    case OrderType.ObjectUprade:
+                        {
+                            var objectDefinitionId = order.Arguments[0].Value.Integer;
+                            var upgradeDefinitionId = order.Arguments[1].Value.Integer;
+
+                            var gameObject = _game.Scene3D.GameObjects.GetObjectById(objectDefinitionId);
+                            var upgradeDefinition = _game.AssetStore.Upgrades.GetByInternalId(upgradeDefinitionId);
+                            player.Money -= (uint) upgradeDefinition.BuildCost;
+
+                            gameObject.ProductionUpdate.QueueUpgrade(upgradeDefinition);
                         }
                         break;
 
@@ -78,7 +91,7 @@ namespace OpenSage.Logic.Orders
                         break;
 
                     case OrderType.Sell:
-                        foreach(var unit in player.SelectedUnits)
+                        foreach (var unit in player.SelectedUnits)
                         {
                             unit.ModelConditionFlags.Set(ModelConditionFlag.Sold, true);
                             player.Money += (uint) (unit.Definition.BuildCost * _game.AssetStore.GameData.Current.SellPercentage);
@@ -153,13 +166,13 @@ namespace OpenSage.Logic.Orders
                         break;
 
                     //case OrderType.ChooseGeneralPromotion:
-                        //gla:
-                        //tier 1:
-                        //34, 35, 36
+                    //gla:
+                    //tier 1:
+                    //34, 35, 36
 
-                        //usa:
-                        //tier1:
-                        //12, 13, 14
+                    //usa:
+                    //tier1:
+                    //12, 13, 14
                     //    break;
 
                     default:

--- a/src/OpenSage.Game/Logic/Orders/OrderType.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderType.cs
@@ -76,7 +76,7 @@
         Unknown1042 = 1042,
 
         ChooseGeneralPromotion = 1044, //something with general promotion? gla first promotion -> arg 34, gla second promotion -> arg 35, gla third promotion -> arg 36
-        Unknown1045 = 1045, //encountered while adding landmines to power plant: ObjectId:671,Integer:1604 (mines is Upgrades[13]), also when upgrading usa power plant (ObjectId:673,Integer:1593), (ObjectId:671,Integer:1593)
+        ObjectUprade = 1045, //encountered while adding landmines to power plant: ObjectId:671,Integer:1604 (mines is Upgrades[13]), also when upgrading usa power plant (ObjectId:673,Integer:1593), (ObjectId:671,Integer:1593)
         Unknown1046 = 1046,
 
         Unknown1048 = 1048,

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -479,14 +479,18 @@ namespace OpenSage
                 }
             }
 
-            foreach (var selectedUnit in LocalPlayer.SelectedUnits)
+            // The AssetViewer has no LocalPlayer
+            if (LocalPlayer != null)
             {
-                DrawHealthBox(selectedUnit);
-            }
+                foreach (var selectedUnit in LocalPlayer.SelectedUnits)
+                {
+                    DrawHealthBox(selectedUnit);
+                }
 
-            if (LocalPlayer.HoveredUnit != null)
-            {
-                DrawHealthBox(LocalPlayer.HoveredUnit);
+                if (LocalPlayer.HoveredUnit != null)
+                {
+                    DrawHealthBox(LocalPlayer.HoveredUnit);
+                }
             }
         }
     }

--- a/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
@@ -9,6 +9,7 @@ using OpenSage.Gui.Wnd.Images;
 using OpenSage.Logic;
 using OpenSage.Logic.Object;
 using OpenSage.Logic.Orders;
+using OpenSage.Logic.Object.Production;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Mods.Generals.Gui
@@ -272,6 +273,17 @@ namespace OpenSage.Mods.Generals.Gui
                                 case CommandType.SetRallyPoint:
                                     context.Game.OrderGenerator.SetRallyPoint();
                                     break;
+
+                                case CommandType.ObjectUpgrade:
+                                    order = CreateOrder(OrderType.ObjectUprade);
+                                    //TODO: figure this out correctly
+                                    var selection = context.Game.Scene3D.LocalPlayer.SelectedUnits;
+                                    var objId = context.Game.Scene3D.GameObjects.GetObjectId(selection.First());
+                                    order.AddIntegerArgument(objId);
+                                    var name = commandButton.Upgrade;
+                                    var upgrade = context.Game.AssetStore.Upgrades.GetByName(name);
+                                    order.AddIntegerArgument(upgrade.InternalId);
+                                    break;
                                 default:
                                     throw new NotImplementedException();
                             }
@@ -389,8 +401,14 @@ namespace OpenSage.Mods.Generals.Gui
                                         job.Progress);
                                 };
 
-                                img = controlBar._window.ImageLoader.CreateFromMappedImageReference(job.ObjectDefinition.SelectPortrait);
-
+                                if (job.Type == ProductionJobType.Unit)
+                                {
+                                    img = controlBar._window.ImageLoader.CreateFromMappedImageReference(job.ObjectDefinition.SelectPortrait);
+                                }
+                                else if (job.Type == ProductionJobType.Upgrade)
+                                {
+                                    img = controlBar._window.ImageLoader.CreateFromMappedImageReference(job.UpgradeDefinition.ButtonImage);
+                                }
                                 var posCopy = pos;
 
                                 queueButton.SystemCallback = (control, message, context) =>
@@ -414,7 +432,7 @@ namespace OpenSage.Mods.Generals.Gui
                 iconControl.BackgroundImage = cameoImg;
                 iconControl.Visible = !isProducing;
 
-                void ApplyUpgradeImage(string upgradeControlName, LazyAssetReference<Upgrade> upgradeReference)
+                void ApplyUpgradeImage(string upgradeControlName, LazyAssetReference<UpgradeDefinition> upgradeReference)
                 {
                     var upgrade = upgradeReference?.Value;
                     var upgradeControl = unitSelectedControl.Controls.FindControl($"ControlBar.wnd:{upgradeControlName}");

--- a/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
@@ -432,7 +432,7 @@ namespace OpenSage.Mods.Generals.Gui
                 iconControl.BackgroundImage = cameoImg;
                 iconControl.Visible = !isProducing;
 
-                void ApplyUpgradeImage(string upgradeControlName, LazyAssetReference<UpgradeDefinition> upgradeReference)
+                void ApplyUpgradeImage(string upgradeControlName, LazyAssetReference<UpgradeTemplate> upgradeReference)
                 {
                     var upgrade = upgradeReference?.Value;
                     var upgradeControl = unitSelectedControl.Controls.FindControl($"ControlBar.wnd:{upgradeControlName}");


### PR DESCRIPTION
* Adds upgrades to the production queue
* Use **BuildTime** instead of **BuildCost**. This is still different from the original games production speed. We probably need to take of GameSpeed aswell.
* Each gameobject has a list of granted upgrades