### PR TITLE
Fix maps directory not being created for map cache

### DIFF
--- a/src/OpenSage.Game/Data/Map/UserMapCache.cs
+++ b/src/OpenSage.Game/Data/Map/UserMapCache.cs
@@ -78,6 +78,9 @@ namespace OpenSage.Data.Map
 
             var fullMapCacheIniPath = Path.Combine(_contentManager.UserDataFileSystem.RootDirectory, MapCacheIniPath);
 
+            // Create the full path, user directory should already exist but the maps folder may not
+            Directory.CreateDirectory(Path.GetDirectoryName(fullMapCacheIniPath));
+
             GenerateMapCacheIniFile(fullMapCacheIniPath, mapCacheEntries);
 
             mapCacheIniEntry = new FileSystemEntry(

--- a/src/OpenSage.Game/Data/Map/UserMapCache.cs
+++ b/src/OpenSage.Game/Data/Map/UserMapCache.cs
@@ -78,8 +78,12 @@ namespace OpenSage.Data.Map
 
             var fullMapCacheIniPath = Path.Combine(_contentManager.UserDataFileSystem.RootDirectory, MapCacheIniPath);
 
-            // Create the full path, user directory should already exist but the maps folder may not
-            Directory.CreateDirectory(Path.GetDirectoryName(fullMapCacheIniPath));
+            // Create the full path, user directory should already exist from the content manager but
+            // maps folder may not
+            var mapsPath = Path.GetDirectoryName(fullMapCacheIniPath);
+
+            if (!Directory.Exists(mapsPath))
+                Directory.CreateDirectory(mapsPath);
 
             GenerateMapCacheIniFile(fullMapCacheIniPath, mapCacheEntries);
 


### PR DESCRIPTION
`GenerateMapCacheIniFile` assumes the `Maps/` folder exists in the user data directory, added a call to create the directory if it does not exist preventing crash on startup when game not ran before.