### PR TITLE
Preliminary work on damage

### DIFF
--- a/src/OpenSage.Game/Content/AssetStore.cs
+++ b/src/OpenSage.Game/Content/AssetStore.cs
@@ -19,7 +19,6 @@ using OpenSage.Lod;
 using OpenSage.Logic;
 using OpenSage.Logic.AI;
 using OpenSage.Logic.Object;
-using OpenSage.Logic.Object.Damage;
 using OpenSage.Logic.Pathfinding;
 using OpenSage.Terrain;
 using OpenSage.Terrain.Roads;

--- a/src/OpenSage.Game/Content/ContentManager.cs
+++ b/src/OpenSage.Game/Content/ContentManager.cs
@@ -84,7 +84,7 @@ namespace OpenSage.Content
                         SubsystemLoader.Load(Subsystem.Wnd);
                         SubsystemLoader.Load(Subsystem.Terrain);
                         SubsystemLoader.Load(Subsystem.Credits);
-
+                        SubsystemLoader.Load(Subsystem.Damage);
                         break;
 
                     case SageGame.Cnc3:

--- a/src/OpenSage.Game/Content/SubsystemLoader.cs
+++ b/src/OpenSage.Game/Content/SubsystemLoader.cs
@@ -97,6 +97,9 @@ namespace OpenSage.Content
                 case Subsystem.Credits:
                     LoadFiles(@"Data\INI\Credits.ini");
                     break;
+                case Subsystem.Damage:
+                    LoadFiles(@"Data\INI\DamageFX.ini");
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(subsystem), subsystem, null);
             }
@@ -352,6 +355,9 @@ namespace OpenSage.Content
                     break;
                 case Subsystem.Credits:
                     yield return "Credits";
+                    yield break;
+                case Subsystem.Damage:
+                    yield return "TheDamageFXStore";
                     yield break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(subsystem), subsystem, null);

--- a/src/OpenSage.Game/Data/Ini/IniParser.BlockParsers.cs
+++ b/src/OpenSage.Game/Data/Ini/IniParser.BlockParsers.cs
@@ -18,7 +18,6 @@ using OpenSage.Lod;
 using OpenSage.Logic;
 using OpenSage.Logic.AI;
 using OpenSage.Logic.Object;
-using OpenSage.Logic.Object.Damage;
 using OpenSage.Logic.Pathfinding;
 using OpenSage.Terrain;
 using OpenSage.Terrain.Roads;

--- a/src/OpenSage.Game/Data/Ini/IniParser.cs
+++ b/src/OpenSage.Game/Data/Ini/IniParser.cs
@@ -468,6 +468,12 @@ namespace OpenSage.Data.Ini
         {
             var name = ParseAssetReference();
             return _assetStore.FXLists.GetLazyAssetReferenceByName(name);
+        public LazyAssetReference<DamageFX> ParseDamageFXReference()
+        {
+            var name = ParseAssetReference();
+            return _assetStore.DamageFXs.GetLazyAssetReferenceByName(name);
+        }
+
         }
 
         public LazyAssetReference<Graphics.Animation.W3DAnimation>[] ParseAnimationReferenceArray()

--- a/src/OpenSage.Game/Data/Ini/IniParser.cs
+++ b/src/OpenSage.Game/Data/Ini/IniParser.cs
@@ -210,6 +210,20 @@ namespace OpenSage.Data.Ini
 
         public string ScanAssetReference(in IniToken token) => token.Text;
 
+        public LazyAssetReference<FXParticleSystemTemplate> ScanFXParticleSystemTemplateReference(in IniToken token)
+        {
+            var name = token.Text;
+            return _assetStore.FXParticleSystemTemplates.GetLazyAssetReferenceByName(name);
+        }
+
+        public LazyAssetReference<FXList> ScanFXListReference(in IniToken token)
+        {
+            var name = token.Text;
+            return _assetStore.FXLists.GetLazyAssetReferenceByName(name);
+        }
+
+        public string ScanParticleSystemReference(in IniToken token) => token.Text;
+
         public string ParseAssetReference()
         {
             var token = GetNextTokenOptional();
@@ -467,13 +481,23 @@ namespace OpenSage.Data.Ini
         public LazyAssetReference<FXList> ParseFXListReference()
         {
             var name = ParseAssetReference();
-            return _assetStore.FXLists.GetLazyAssetReferenceByName(name);
+            return (!string.Equals(name, "NONE", StringComparison.OrdinalIgnoreCase))
+                ? _assetStore.FXLists.GetLazyAssetReferenceByName(name)
+                : null;
+        }
+
         public LazyAssetReference<DamageFX> ParseDamageFXReference()
         {
             var name = ParseAssetReference();
             return _assetStore.DamageFXs.GetLazyAssetReferenceByName(name);
         }
 
+        public LazyAssetReference<ObjectCreationList> ParseObjectCreationListReference()
+        {
+            var name = ParseAssetReference();
+            return (!string.Equals(name, "NONE", StringComparison.OrdinalIgnoreCase))
+                ? _assetStore.ObjectCreationLists.GetLazyAssetReferenceByName(name)
+                : null;
         }
 
         public LazyAssetReference<Graphics.Animation.W3DAnimation>[] ParseAnimationReferenceArray()

--- a/src/OpenSage.Game/GameContext.cs
+++ b/src/OpenSage.Game/GameContext.cs
@@ -1,4 +1,5 @@
-﻿using OpenSage.Audio;
+﻿using System;
+using OpenSage.Audio;
 using OpenSage.Content.Loaders;
 using OpenSage.Graphics.ParticleSystems;
 using OpenSage.Logic.Object;
@@ -10,8 +11,11 @@ namespace OpenSage
         public readonly AssetLoadContext AssetLoadContext;
         public readonly AudioSystem AudioSystem;
         public readonly ParticleSystemManager ParticleSystems;
+        public readonly ObjectCreationListManager ObjectCreationLists;
         public readonly Terrain.Terrain Terrain;
         public readonly Navigation.Navigation Navigation;
+
+        public readonly Random Random = new Random();
 
         // TODO: Make this readonly.
         public GameObjectCollection GameObjects;
@@ -20,12 +24,14 @@ namespace OpenSage
             AssetLoadContext assetLoadContext,
             AudioSystem audioSystem,
             ParticleSystemManager particleSystems,
+            ObjectCreationListManager objectCreationLists,
             Terrain.Terrain terrain,
             Navigation.Navigation navigation)
         {
             AssetLoadContext = assetLoadContext;
             AudioSystem = audioSystem;
             ParticleSystems = particleSystems;
+            ObjectCreationLists = objectCreationLists;
             Terrain = terrain;
             Navigation = navigation;
         }

--- a/src/OpenSage.Game/Logic/Object/ArmorTemplateSet.cs
+++ b/src/OpenSage.Game/Logic/Object/ArmorTemplateSet.cs
@@ -15,11 +15,11 @@ namespace OpenSage.Logic.Object
         {
             { "Conditions", (parser, x) => x.Conditions = parser.ParseEnumBitArray<ArmorSetCondition>() },
             { "Armor", (parser, x) => x.Armor = parser.ParseArmorTemplateReference() },
-            { "DamageFX", (parser, x) => x.DamageFX = parser.ParseAssetReference() },
+            { "DamageFX", (parser, x) => x.DamageFX = parser.ParseDamageFXReference() },
         };
 
         public BitArray<ArmorSetCondition> Conditions { get; private set; }
         public LazyAssetReference<ArmorTemplate> Armor { get; private set; }
-        public string DamageFX { get; private set; }
+        public LazyAssetReference<DamageFX> DamageFX { get; private set; }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
+++ b/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
@@ -9,6 +9,8 @@ namespace OpenSage.Logic.Object
         internal virtual void Update(BehaviorUpdateContext context) { }
 
         internal virtual void OnDie(BehaviorUpdateContext context, DeathType deathType) { }
+
+        internal virtual void OnDamageStateChanged(BehaviorUpdateContext context, BodyDamageType fromDamage, BodyDamageType toDamage) { }
     }
 
     internal sealed class BehaviorUpdateContext

--- a/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDamagedBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDamagedBehavior.cs
@@ -1,5 +1,4 @@
 ﻿using OpenSage.Data.Ini;
-using OpenSage.Logic.Object.Damage;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
@@ -7,16 +7,19 @@ namespace OpenSage.Logic.Object
         private readonly GameObject _gameObject;
         private readonly PhysicsBehaviorModuleData _moduleData;
 
+        public float Mass { get; set; }
+
         internal PhysicsBehavior(GameObject gameObject, PhysicsBehaviorModuleData moduleData)
         {
             _gameObject = gameObject;
             _moduleData = moduleData;
+
+            Mass = moduleData.Mass;
         }
 
         internal override void Update(BehaviorUpdateContext context)
         {
             var gravity = context.GameContext.AssetLoadContext.AssetStore.GameData.Current.Gravity;
-            var mass = _moduleData.Mass;
 
             // TODO
         }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
@@ -5,6 +5,22 @@ using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
+    public sealed class SlowDeathBehavior : UpdateModule
+    {
+        private readonly SlowDeathBehaviorModuleData _moduleData;
+
+        internal SlowDeathBehavior(SlowDeathBehaviorModuleData moduleData)
+        {
+            _moduleData = moduleData;
+        }
+
+        internal override void OnDie(BehaviorUpdateContext context, DeathType deathType)
+        {
+            // TODO
+            context.GameObject.Destroy();
+        }
+    }
+
     public class SlowDeathBehaviorModuleData : UpdateModuleData
     {
         internal static SlowDeathBehaviorModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -76,6 +92,11 @@ namespace OpenSage.Logic.Object
 
         [AddedIn(SageGame.Bfme2Rotwk)]
         public bool DoNotRandomizeMidpoint { get; private set; }
+
+        internal override BehaviorModule CreateModule(GameObject gameObject)
+        {
+            return new SlowDeathBehavior(this);
+        }
     }
 
     public enum SlowDeathPhase

--- a/src/OpenSage.Game/Logic/Object/Body/HiveStructureBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/HiveStructureBody.cs
@@ -1,5 +1,4 @@
 ﻿using OpenSage.Data.Ini;
-using OpenSage.Logic.Object.Damage;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object

--- a/src/OpenSage.Game/Logic/Object/Body/InactiveBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/InactiveBody.cs
@@ -5,7 +5,21 @@ namespace OpenSage.Logic.Object
 {
     public sealed class InactiveBody : BodyModule
     {
+        private readonly GameObject _gameObject;
+
+        internal InactiveBody(GameObject gameObject)
+        {
+            _gameObject = gameObject;
+        }
+
         public override Fix64 MaxHealth => Fix64.Zero;
+
+        public override void DoDamage(DamageType damageType, Fix64 amount, DeathType deathType)
+        {
+            // TODO
+
+            _gameObject.Die(deathType);
+        }
     }
 
     /// <summary>
@@ -19,7 +33,7 @@ namespace OpenSage.Logic.Object
 
         internal override BodyModule CreateBodyModule(GameObject gameObject)
         {
-            return new InactiveBody();
+            return new InactiveBody(gameObject);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Collide/AODCrushCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/AODCrushCollide.cs
@@ -1,5 +1,4 @@
 ﻿using OpenSage.Data.Ini;
-using OpenSage.Logic.Object.Damage;
 
 namespace OpenSage.Logic.Object
 {

--- a/src/OpenSage.Game/Logic/Object/Damage/DamageModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/DamageModule.cs
@@ -1,5 +1,10 @@
 ﻿namespace OpenSage.Logic.Object
 {
+    public abstract class DamageModule : BehaviorModule
+    {
+
+    }
+
     public abstract class DamageModuleData : ContainModuleData
     {
     }

--- a/src/OpenSage.Game/Logic/Object/Damage/ReflectDamage.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/ReflectDamage.cs
@@ -1,5 +1,4 @@
 ﻿using OpenSage.Data.Ini;
-using OpenSage.Logic.Object.Damage;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object

--- a/src/OpenSage.Game/Logic/Object/Damage/TransitionDamageFX.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/TransitionDamageFX.cs
@@ -1,11 +1,57 @@
 ﻿using System.Collections.Generic;
 using System.Numerics;
+using OpenSage.Content;
 using OpenSage.Data.Ini;
-using OpenSage.Logic.Object.Damage;
+using OpenSage.FX;
+using OpenSage.Graphics.ParticleSystems;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
+    public sealed class TransitionDamageFX : DamageModule
+    {
+        private readonly TransitionDamageFXModuleData _moduleData;
+
+        public TransitionDamageFX(TransitionDamageFXModuleData moduleData)
+        {
+            _moduleData = moduleData;
+        }
+
+        internal override void OnDamageStateChanged(BehaviorUpdateContext context, BodyDamageType fromDamage, BodyDamageType toDamage)
+        {
+            List<TransitionDamageParticleSystem> particleSystems = null;
+
+            switch ((fromDamage, toDamage))
+            {
+                case (BodyDamageType.Pristine, BodyDamageType.Damaged):
+                    particleSystems = _moduleData.DamagedParticleSystems;
+                    break;
+
+                case (BodyDamageType.Damaged, BodyDamageType.ReallyDamaged):
+                    particleSystems = _moduleData.ReallyDamagedParticleSystems;
+                    break;
+
+                case (BodyDamageType.ReallyDamaged, BodyDamageType.Rubble):
+                    particleSystems = _moduleData.RubbleParticleSystems;
+                    break;
+            }
+
+            if (particleSystems != null)
+            {
+                var worldMatrix = context.GameObject.Transform.Matrix;
+
+                foreach (var particleSystemTemplate in particleSystems)
+                {
+                    context.GameContext.ParticleSystems
+                        .Create(particleSystemTemplate.ParticleSystem.Value, worldMatrix)
+                        .Activate();
+                }
+            }
+
+            // TODO: FXLists
+        }
+    }
+
     public sealed class TransitionDamageFXModuleData : DamageModuleData
     {
         internal static TransitionDamageFXModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -22,29 +68,29 @@ namespace OpenSage.Logic.Object
 
             { "DamageParticleTypes", (parser, x) => x.DamageParticleTypes = parser.ParseEnumBitArray<DamageType>() },
 
-            { "DamagedParticleSystem1", (parser, x) => x.DamagedParticleSystem1 = TransitionDamageParticleSystem.Parse(parser) },
-            { "DamagedParticleSystem2", (parser, x) => x.DamagedParticleSystem2 = TransitionDamageParticleSystem.Parse(parser) },
-            { "DamagedParticleSystem3", (parser, x) => x.DamagedParticleSystem3 = TransitionDamageParticleSystem.Parse(parser) },
-            { "DamagedParticleSystem4", (parser, x) => x.DamagedParticleSystem4 = TransitionDamageParticleSystem.Parse(parser) },
-            { "DamagedParticleSystem5", (parser, x) => x.DamagedParticleSystem5 = TransitionDamageParticleSystem.Parse(parser) },
-            { "DamagedParticleSystem6", (parser, x) => x.DamagedParticleSystem6 = TransitionDamageParticleSystem.Parse(parser) },
+            { "DamagedParticleSystem1", (parser, x) => x.DamagedParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "DamagedParticleSystem2", (parser, x) => x.DamagedParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "DamagedParticleSystem3", (parser, x) => x.DamagedParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "DamagedParticleSystem4", (parser, x) => x.DamagedParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "DamagedParticleSystem5", (parser, x) => x.DamagedParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "DamagedParticleSystem6", (parser, x) => x.DamagedParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
 
-            { "ReallyDamagedParticleSystem1", (parser, x) => x.ReallyDamagedParticleSystem1 = TransitionDamageParticleSystem.Parse(parser) },
-            { "ReallyDamagedParticleSystem2", (parser, x) => x.ReallyDamagedParticleSystem2 = TransitionDamageParticleSystem.Parse(parser) },
-            { "ReallyDamagedParticleSystem3", (parser, x) => x.ReallyDamagedParticleSystem3 = TransitionDamageParticleSystem.Parse(parser) },
-            { "ReallyDamagedParticleSystem4", (parser, x) => x.ReallyDamagedParticleSystem4 = TransitionDamageParticleSystem.Parse(parser) },
-            { "ReallyDamagedParticleSystem5", (parser, x) => x.ReallyDamagedParticleSystem5 = TransitionDamageParticleSystem.Parse(parser) },
-            { "ReallyDamagedParticleSystem6", (parser, x) => x.ReallyDamagedParticleSystem6 = TransitionDamageParticleSystem.Parse(parser) },
-            { "ReallyDamagedParticleSystem7", (parser, x) => x.ReallyDamagedParticleSystem7 = TransitionDamageParticleSystem.Parse(parser) },
-            { "ReallyDamagedParticleSystem8", (parser, x) => x.ReallyDamagedParticleSystem8 = TransitionDamageParticleSystem.Parse(parser) },
+            { "ReallyDamagedParticleSystem1", (parser, x) => x.ReallyDamagedParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "ReallyDamagedParticleSystem2", (parser, x) => x.ReallyDamagedParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "ReallyDamagedParticleSystem3", (parser, x) => x.ReallyDamagedParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "ReallyDamagedParticleSystem4", (parser, x) => x.ReallyDamagedParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "ReallyDamagedParticleSystem5", (parser, x) => x.ReallyDamagedParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "ReallyDamagedParticleSystem6", (parser, x) => x.ReallyDamagedParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "ReallyDamagedParticleSystem7", (parser, x) => x.ReallyDamagedParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "ReallyDamagedParticleSystem8", (parser, x) => x.ReallyDamagedParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
 
-            { "RubbleParticleSystem1", (parser, x) => x.RubbleParticleSystem1 = TransitionDamageParticleSystem.Parse(parser) },
-            { "RubbleParticleSystem2", (parser, x) => x.RubbleParticleSystem2 = TransitionDamageParticleSystem.Parse(parser) },
-            { "RubbleParticleSystem3", (parser, x) => x.RubbleParticleSystem3 = TransitionDamageParticleSystem.Parse(parser) },
-            { "RubbleParticleSystem4", (parser, x) => x.RubbleParticleSystem4 = TransitionDamageParticleSystem.Parse(parser) },
-            { "RubbleParticleSystem5", (parser, x) => x.RubbleParticleSystem5 = TransitionDamageParticleSystem.Parse(parser) },
-            { "RubbleParticleSystem6", (parser, x) => x.RubbleParticleSystem6 = TransitionDamageParticleSystem.Parse(parser) },
-            { "RubbleParticleSystem7", (parser, x) => x.RubbleParticleSystem7 = TransitionDamageParticleSystem.Parse(parser) },
+            { "RubbleParticleSystem1", (parser, x) => x.RubbleParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "RubbleParticleSystem2", (parser, x) => x.RubbleParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "RubbleParticleSystem3", (parser, x) => x.RubbleParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "RubbleParticleSystem4", (parser, x) => x.RubbleParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "RubbleParticleSystem5", (parser, x) => x.RubbleParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "RubbleParticleSystem6", (parser, x) => x.RubbleParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
+            { "RubbleParticleSystem7", (parser, x) => x.RubbleParticleSystems.Add(TransitionDamageParticleSystem.Parse(parser)) },
 
             { "RubbleNeighbor", (parser, x) => x.RubbleNeighbors.Add(RubbleNeighbor.Parse(parser)) },
             { "PristineShowSubObject", (parser, x) => x.PristineShowSubObject = parser.ParseAssetReferenceArray() },
@@ -65,29 +111,11 @@ namespace OpenSage.Logic.Object
 
         public BitArray<DamageType> DamageParticleTypes { get; private set; }
 
-        public TransitionDamageParticleSystem DamagedParticleSystem1 { get; private set; }
-        public TransitionDamageParticleSystem DamagedParticleSystem2 { get; private set; }
-        public TransitionDamageParticleSystem DamagedParticleSystem3 { get; private set; }
-        public TransitionDamageParticleSystem DamagedParticleSystem4 { get; private set; }
-        public TransitionDamageParticleSystem DamagedParticleSystem5 { get; private set; }
-        public TransitionDamageParticleSystem DamagedParticleSystem6 { get; private set; }
+        public List<TransitionDamageParticleSystem> DamagedParticleSystems { get; } = new List<TransitionDamageParticleSystem>();
 
-        public TransitionDamageParticleSystem ReallyDamagedParticleSystem1 { get; private set; }
-        public TransitionDamageParticleSystem ReallyDamagedParticleSystem2 { get; private set; }
-        public TransitionDamageParticleSystem ReallyDamagedParticleSystem3 { get; private set; }
-        public TransitionDamageParticleSystem ReallyDamagedParticleSystem4 { get; private set; }
-        public TransitionDamageParticleSystem ReallyDamagedParticleSystem5 { get; private set; }
-        public TransitionDamageParticleSystem ReallyDamagedParticleSystem6 { get; private set; }
-        public TransitionDamageParticleSystem ReallyDamagedParticleSystem7 { get; private set; }
-        public TransitionDamageParticleSystem ReallyDamagedParticleSystem8 { get; private set; }
+        public List<TransitionDamageParticleSystem> ReallyDamagedParticleSystems { get; } = new List<TransitionDamageParticleSystem>();
 
-        public TransitionDamageParticleSystem RubbleParticleSystem1 { get; private set; }
-        public TransitionDamageParticleSystem RubbleParticleSystem2 { get; private set; }
-        public TransitionDamageParticleSystem RubbleParticleSystem3 { get; private set; }
-        public TransitionDamageParticleSystem RubbleParticleSystem4 { get; private set; }
-        public TransitionDamageParticleSystem RubbleParticleSystem5 { get; private set; }
-        public TransitionDamageParticleSystem RubbleParticleSystem6 { get; private set; }
-        public TransitionDamageParticleSystem RubbleParticleSystem7 { get; private set; }
+        public List<TransitionDamageParticleSystem> RubbleParticleSystems { get; } = new List<TransitionDamageParticleSystem>();
 
         [AddedIn(SageGame.Bfme)]
         public List<RubbleNeighbor> RubbleNeighbors { get; private set; } = new List<RubbleNeighbor>();
@@ -109,6 +137,11 @@ namespace OpenSage.Logic.Object
 
         [AddedIn(SageGame.Bfme)]
         public string[] ReallyDamagedHideSubObject { get; private set; }
+
+        internal override BehaviorModule CreateModule(GameObject gameObject)
+        {
+            return new TransitionDamageFX(this);
+        }
     }
 
     public sealed class TransitionDamageFXList
@@ -118,12 +151,12 @@ namespace OpenSage.Logic.Object
             return new TransitionDamageFXList
             {
                 Location = parser.ParseAttribute("Loc", () => parser.ParseVector3()),
-                FXList = parser.ParseAttribute("FXList", parser.ScanAssetReference)
+                FXList = parser.ParseAttribute("FXList", parser.ScanFXListReference)
             };
         }
 
         public Vector3 Location { get; private set; }
-        public string FXList { get; private set; }
+        public LazyAssetReference<FXList> FXList { get; private set; }
     }
 
     public sealed class TransitionDamageParticleSystem
@@ -134,13 +167,13 @@ namespace OpenSage.Logic.Object
             {
                 Bone = parser.ParseAttribute("Bone", parser.ScanBoneName),
                 RandomBone = parser.ParseAttributeBoolean("RandomBone"),
-                ParticleSystem = parser.ParseAttribute("PSys", parser.ScanAssetReference)
+                ParticleSystem = parser.ParseAttribute("PSys", parser.ScanFXParticleSystemTemplateReference)
             };
         }
 
         public string Bone { get; private set; }
         public bool RandomBone { get; private set; }
-        public string ParticleSystem { get; private set; }
+        public LazyAssetReference<FXParticleSystemTemplate> ParticleSystem { get; private set; }
     }
 
     [AddedIn(SageGame.Bfme)]

--- a/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
@@ -1,7 +1,23 @@
-﻿using OpenSage.Data.Ini;
+﻿using OpenSage.Content;
+using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
+    public sealed class CreateObjectDie : DieModule
+    {
+        private readonly CreateObjectDieModuleData _moduleData;
+
+        internal CreateObjectDie(CreateObjectDieModuleData moduleData)
+        {
+            _moduleData = moduleData;
+        }
+
+        internal override void OnDie(BehaviorUpdateContext context, DeathType deathType)
+        {
+            context.GameContext.ObjectCreationLists.Create(_moduleData.CreationList.Value, context);
+        }
+    }
+
     public sealed class CreateObjectDieModuleData : DieModuleData
     {
         internal static CreateObjectDieModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -9,13 +25,13 @@ namespace OpenSage.Logic.Object
         private static new readonly IniParseTable<CreateObjectDieModuleData> FieldParseTable = DieModuleData.FieldParseTable
             .Concat(new IniParseTable<CreateObjectDieModuleData>
             {
-                { "CreationList", (parser, x) => x.CreationList = parser.ParseAssetReference() },
+                { "CreationList", (parser, x) => x.CreationList = parser.ParseObjectCreationListReference() },
                 { "TransferPreviousHealth", (parser, x) => x.TransferPreviousHealth = parser.ParseBoolean() },
                 { "DebrisPortionOfSelf", (parser, x) => x.DebrisPortionOfSelf = parser.ParseAssetReference() },
                 { "UpgradeRequired", (parser, x) => x.UpgradeRequired = parser.ParseAssetReferenceArray() }
             });
 
-        public string CreationList { get; private set; }
+        public LazyAssetReference<ObjectCreationList> CreationList { get; private set; }
 
         [AddedIn(SageGame.CncGeneralsZeroHour)]
         public bool TransferPreviousHealth { get; private set; }
@@ -25,5 +41,10 @@ namespace OpenSage.Logic.Object
 
         [AddedIn(SageGame.Bfme2)]
         public string[] UpgradeRequired { get; private set; }
+
+        internal override BehaviorModule CreateModule(GameObject gameObject)
+        {
+            return new CreateObjectDie(this);
+        }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/DamageFilteredCreateObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DamageFilteredCreateObjectDie.cs
@@ -1,5 +1,4 @@
 ﻿using OpenSage.Data.Ini;
-using OpenSage.Logic.Object.Damage;
 
 namespace OpenSage.Logic.Object
 {

--- a/src/OpenSage.Game/Logic/Object/Die/FXListDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/FXListDie.cs
@@ -1,7 +1,27 @@
-﻿using OpenSage.Data.Ini;
+﻿using OpenSage.Content;
+using OpenSage.Data.Ini;
+using OpenSage.FX;
 
 namespace OpenSage.Logic.Object
 {
+    public sealed class FXListDie : DieModule
+    {
+        private readonly FXListDieModuleData _moduleData;
+
+        internal FXListDie(FXListDieModuleData moduleData)
+        {
+            _moduleData = moduleData;
+        }
+
+        internal override void OnDie(BehaviorUpdateContext context, DeathType deathType)
+        {
+            _moduleData.DeathFX.Value.Execute(new FXListExecutionContext(
+                context.GameObject.Transform.Rotation,
+                context.GameObject.Transform.Translation,
+                context.GameContext));
+        }
+    }
+
     public sealed class FXListDieModuleData : DieModuleData
     {
         internal static FXListDieModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -9,14 +29,14 @@ namespace OpenSage.Logic.Object
         private static new readonly IniParseTable<FXListDieModuleData> FieldParseTable = DieModuleData.FieldParseTable
             .Concat(new IniParseTable<FXListDieModuleData>
             {
-                { "DeathFX", (parser, x) => x.DeathFX = parser.ParseAssetReference() },
+                { "DeathFX", (parser, x) => x.DeathFX = parser.ParseFXListReference() },
                 { "OrientToObject", (parser, x) => x.OrientToObject = parser.ParseBoolean() },
                 { "StartsActive", (parser, x) => x.StartsActive = parser.ParseBoolean() },
                 { "ConflictsWith", (parser, x) => x.ConflictsWith = parser.ParseAssetReferenceArray() },
                 { "TriggeredBy", (parser, x) => x.TriggeredBy = parser.ParseAssetReferenceArray() }
             });
 
-        public string DeathFX { get; private set; }
+        public LazyAssetReference<FXList> DeathFX { get; private set; }
         public bool OrientToObject { get; private set; }
 
         [AddedIn(SageGame.CncGeneralsZeroHour)]
@@ -27,5 +47,10 @@ namespace OpenSage.Logic.Object
 
         [AddedIn(SageGame.CncGeneralsZeroHour)]
         public string[] TriggeredBy { get; private set; }
+
+        internal override BehaviorModule CreateModule(GameObject gameObject)
+        {
+            return new FXListDie(this);
+        }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dDebrisDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dDebrisDraw.cs
@@ -1,7 +1,73 @@
-﻿using OpenSage.Data.Ini;
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using OpenSage.Data.Ini;
+using OpenSage.Graphics;
+using OpenSage.Graphics.Cameras;
+using OpenSage.Graphics.Rendering;
+using OpenSage.Graphics.Shaders;
+using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
+    public sealed class W3dDebrisDraw : DrawModule
+    {
+        private readonly GameContext _gameContext;
+        private ModelInstance _modelInstance;
+
+        internal W3dDebrisDraw(GameContext context)
+        {
+            _gameContext = context;
+        }
+
+        public void SetModelName(string modelName)
+        {
+            var model = _gameContext.AssetLoadContext.AssetStore.Models.GetByName(modelName);
+            _modelInstance = AddDisposable(model.CreateInstance(_gameContext.AssetLoadContext));
+            _modelInstance.Update(TimeInterval.Zero);
+        }
+
+        public override IEnumerable<BitArray<ModelConditionFlag>> ModelConditionStates { get; } = Array.Empty<BitArray<ModelConditionFlag>>();
+
+        internal override void BuildRenderList(
+            RenderList renderList,
+            Camera camera,
+            bool castsShadow,
+            MeshShaderResources.RenderItemConstantsPS renderItemConstantsPS)
+        {
+            _modelInstance.BuildRenderList(
+                renderList,
+                camera,
+                castsShadow,
+                renderItemConstantsPS);
+        }
+
+        internal override (ModelInstance, ModelBone) FindBone(string boneName)
+        {
+            throw new NotSupportedException();
+        }
+
+        internal override string GetWeaponFireFXBone(WeaponSlot slot)
+        {
+            throw new NotSupportedException();
+        }
+
+        internal override string GetWeaponLaunchBone(WeaponSlot slot)
+        {
+            throw new NotSupportedException();
+        }
+
+        internal override void SetWorldMatrix(in Matrix4x4 worldMatrix)
+        {
+            _modelInstance.SetWorldMatrix(worldMatrix);
+        }
+
+        internal override void Update(in TimeInterval time, GameObject gameObject)
+        {
+            _modelInstance.Update(time);
+        }
+    }
+
     /// <summary>
     /// Special-case draw module used by ObjectCreationList.INI when using the CreateDebris code 
     /// which defaults to calling the GenericDebris object definition as a template for each debris 
@@ -12,5 +78,10 @@ namespace OpenSage.Logic.Object
         internal static W3dDebrisDrawModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
 
         internal static readonly IniParseTable<W3dDebrisDrawModuleData> FieldParseTable = new IniParseTable<W3dDebrisDrawModuleData>();
+
+        internal override DrawModule CreateDrawModule(GameContext context)
+        {
+            return new W3dDebrisDraw(context);
+        }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -173,7 +173,7 @@ namespace OpenSage.Logic.Object
                 var numIntersectionBits = conditionState.ConditionFlags.CountIntersectionBits(flags);
 
                 // If there's no intersection never select this.
-                if (numIntersectionBits != numStateBits)
+                if (numIntersectionBits == 0)
                 {
                     continue;
                 }

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -221,7 +221,8 @@ namespace OpenSage.Logic.Object
 
             ModelConditionFlags = new BitArray<ModelConditionFlag>();
 
-            Body = AddDisposable(objectDefinition.Body?.CreateBodyModule(this));
+            // TODO: Don't create InactiveBody here, it should be done by inheriting from Default/Object.ini
+            Body = AddDisposable(objectDefinition.Body?.CreateBodyModule(this) ?? new InactiveBody(this));
 
             AIUpdate = AddDisposable(objectDefinition.AIUpdate?.CreateAIUpdate(this));
 

--- a/src/OpenSage.Game/Logic/Object/ObjectCreationList.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectCreationList.cs
@@ -131,6 +131,15 @@ namespace OpenSage.Logic.Object
             var physicsBehavior = debrisObject.FindBehavior<PhysicsBehavior>();
             physicsBehavior.Mass = Mass;
 
+            if (Disposition.Get(ObjectDisposition.SendItFlying))
+            {
+                physicsBehavior.AddForce(
+                    new Vector3(
+                        ((float)context.GameContext.Random.NextDouble() - 0.5f) * DispositionIntensity * 200,
+                        ((float) context.GameContext.Random.NextDouble() - 0.5f) * DispositionIntensity * 200,
+                        DispositionIntensity * 200));
+            }
+
             // TODO: Count, Disposition, DispositionIntensity
         }
     }

--- a/src/OpenSage.Game/Logic/Object/ObjectCreationList.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectCreationList.cs
@@ -2,7 +2,6 @@
 using System.Numerics;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
-using OpenSage.Graphics;
 using OpenSage.Gui.InGame;
 using OpenSage.Mathematics;
 
@@ -12,7 +11,7 @@ namespace OpenSage.Logic.Object
     {
         public void Create(ObjectCreationList list, BehaviorUpdateContext context)
         {
-            foreach (var item in list.Items)
+            foreach (var item in list.Nuggets)
             {
                 item.Execute(context);
             }
@@ -30,30 +29,30 @@ namespace OpenSage.Logic.Object
 
         private static readonly IniParseTable<ObjectCreationList> FieldParseTable = new IniParseTable<ObjectCreationList>
         {
-            { "ApplyRandomForce", (parser, x) => x.Items.Add(ApplyRandomForceObjectCreationListItem.Parse(parser)) },
-            { "Attack", (parser, x) => x.Items.Add(AttackObjectCreationListItem.Parse(parser)) },
-            { "CreateDebris", (parser, x) => x.Items.Add(CreateDebrisObjectCreationListItem.Parse(parser)) },
-            { "CreateObject", (parser, x) => x.Items.Add(CreateObjectObjectCreationListItem.Parse(parser)) },
-            { "DeliverPayload", (parser, x) => x.Items.Add(DeliverPayloadObjectCreationListItem.Parse(parser)) },
-            { "FireWeapon", (parser, x) => x.Items.Add(FireWeaponObjectCreationListItem.Parse(parser)) }
+            { "ApplyRandomForce", (parser, x) => x.Nuggets.Add(ApplyRandomForceOCNugget.Parse(parser)) },
+            { "Attack", (parser, x) => x.Nuggets.Add(AttackOCNugget.Parse(parser)) },
+            { "CreateDebris", (parser, x) => x.Nuggets.Add(CreateDebrisOCNugget.Parse(parser)) },
+            { "CreateObject", (parser, x) => x.Nuggets.Add(CreateObjectOCNugget.Parse(parser)) },
+            { "DeliverPayload", (parser, x) => x.Nuggets.Add(DeliverPayloadOCNugget.Parse(parser)) },
+            { "FireWeapon", (parser, x) => x.Nuggets.Add(FireWeaponOCNugget.Parse(parser)) }
         };
 
-        public List<ObjectCreationListItem> Items { get; } = new List<ObjectCreationListItem>();
+        public List<OCNugget> Nuggets { get; } = new List<OCNugget>();
     }
 
-    public abstract class ObjectCreationListItem
+    public abstract class OCNugget
     {
         internal abstract void Execute(BehaviorUpdateContext context);
     }
 
-    public sealed class CreateDebrisObjectCreationListItem : ObjectCreationListItem
+    public sealed class CreateDebrisOCNugget : OCNugget
     {
-        internal static CreateDebrisObjectCreationListItem Parse(IniParser parser)
+        internal static CreateDebrisOCNugget Parse(IniParser parser)
         {
             return parser.ParseBlock(FieldParseTable);
         }
 
-        private static readonly IniParseTable<CreateDebrisObjectCreationListItem> FieldParseTable = new IniParseTable<CreateDebrisObjectCreationListItem>
+        private static readonly IniParseTable<CreateDebrisOCNugget> FieldParseTable = new IniParseTable<CreateDebrisOCNugget>
         {
             { "ModelNames", (parser, x) => x.ModelNames = parser.ParseAssetReferenceArray() },
             { "AnimationSet", (parser, x) => x.AnimationSets.Add(parser.ParseAssetReferenceArray()) },
@@ -136,11 +135,11 @@ namespace OpenSage.Logic.Object
         }
     }
 
-    public sealed class CreateObjectObjectCreationListItem : ObjectCreationListItem
+    public sealed class CreateObjectOCNugget : OCNugget
     {
-        internal static CreateObjectObjectCreationListItem Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
+        internal static CreateObjectOCNugget Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
 
-        private static readonly IniParseTable<CreateObjectObjectCreationListItem> FieldParseTable = new IniParseTable<CreateObjectObjectCreationListItem>
+        private static readonly IniParseTable<CreateObjectOCNugget> FieldParseTable = new IniParseTable<CreateObjectOCNugget>
         {
             { "ObjectNames", (parser, x) => x.ObjectNames = parser.ParseObjectReferenceArray() },
             { "Offset", (parser, x) => x.Offset = parser.ParseVector3() },
@@ -319,14 +318,14 @@ namespace OpenSage.Logic.Object
         }
     }
 
-    public sealed class ApplyRandomForceObjectCreationListItem : ObjectCreationListItem
+    public sealed class ApplyRandomForceOCNugget : OCNugget
     {
-        internal static ApplyRandomForceObjectCreationListItem Parse(IniParser parser)
+        internal static ApplyRandomForceOCNugget Parse(IniParser parser)
         {
             return parser.ParseBlock(FieldParseTable);
         }
 
-        private static readonly IniParseTable<ApplyRandomForceObjectCreationListItem> FieldParseTable = new IniParseTable<ApplyRandomForceObjectCreationListItem>
+        private static readonly IniParseTable<ApplyRandomForceOCNugget> FieldParseTable = new IniParseTable<ApplyRandomForceOCNugget>
         {
             { "MinForceMagnitude", (parser, x) => x.MinForceMagnitude = parser.ParseInteger() },
             { "MaxForceMagnitude", (parser, x) => x.MaxForceMagnitude = parser.ParseInteger() },
@@ -347,14 +346,14 @@ namespace OpenSage.Logic.Object
         }
     }
 
-    public sealed class FireWeaponObjectCreationListItem : ObjectCreationListItem
+    public sealed class FireWeaponOCNugget : OCNugget
     {
-        internal static FireWeaponObjectCreationListItem Parse(IniParser parser)
+        internal static FireWeaponOCNugget Parse(IniParser parser)
         {
             return parser.ParseBlock(FieldParseTable);
         }
 
-        private static readonly IniParseTable<FireWeaponObjectCreationListItem> FieldParseTable = new IniParseTable<FireWeaponObjectCreationListItem>
+        private static readonly IniParseTable<FireWeaponOCNugget> FieldParseTable = new IniParseTable<FireWeaponOCNugget>
         {
             { "Weapon", (parser, x) => x.Weapon = parser.ParseAssetReference() }
         };
@@ -367,14 +366,14 @@ namespace OpenSage.Logic.Object
         }
     }
 
-    public sealed class AttackObjectCreationListItem : ObjectCreationListItem
+    public sealed class AttackOCNugget : OCNugget
     {
-        internal static AttackObjectCreationListItem Parse(IniParser parser)
+        internal static AttackOCNugget Parse(IniParser parser)
         {
             return parser.ParseBlock(FieldParseTable);
         }
 
-        private static readonly IniParseTable<AttackObjectCreationListItem> FieldParseTable = new IniParseTable<AttackObjectCreationListItem>
+        private static readonly IniParseTable<AttackOCNugget> FieldParseTable = new IniParseTable<AttackOCNugget>
         {
             { "WeaponSlot", (parser, x) => x.WeaponSlot = parser.ParseEnum<WeaponSlot>() },
             { "NumberOfShots", (parser, x) => x.NumberOfShots = parser.ParseInteger() },
@@ -393,14 +392,14 @@ namespace OpenSage.Logic.Object
         }
     }
 
-    public sealed class DeliverPayloadObjectCreationListItem : ObjectCreationListItem
+    public sealed class DeliverPayloadOCNugget : OCNugget
     {
-        internal static DeliverPayloadObjectCreationListItem Parse(IniParser parser)
+        internal static DeliverPayloadOCNugget Parse(IniParser parser)
         {
             return parser.ParseBlock(FieldParseTable);
         }
 
-        private static readonly IniParseTable<DeliverPayloadObjectCreationListItem> FieldParseTable = new IniParseTable<DeliverPayloadObjectCreationListItem>
+        private static readonly IniParseTable<DeliverPayloadOCNugget> FieldParseTable = new IniParseTable<DeliverPayloadOCNugget>
         {
             { "Transport", (parser, x) => x.Transport = parser.ParseAssetReference() },
             { "FormationSize", (parser, x) => x.FormationSize = parser.ParseInteger() },

--- a/src/OpenSage.Game/Logic/Object/ObjectCreationList.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectCreationList.cs
@@ -1,11 +1,24 @@
 ﻿using System.Collections.Generic;
 using System.Numerics;
+using OpenSage.Content;
 using OpenSage.Data.Ini;
+using OpenSage.Graphics;
 using OpenSage.Gui.InGame;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
+    internal sealed class ObjectCreationListManager
+    {
+        public void Create(ObjectCreationList list, BehaviorUpdateContext context)
+        {
+            foreach (var item in list.Items)
+            {
+                item.Execute(context);
+            }
+        }
+    }
+
     public sealed class ObjectCreationList : BaseAsset
     {
         internal static ObjectCreationList Parse(IniParser parser)
@@ -30,7 +43,7 @@ namespace OpenSage.Logic.Object
 
     public abstract class ObjectCreationListItem
     {
-
+        internal abstract void Execute(BehaviorUpdateContext context);
     }
 
     public sealed class CreateDebrisObjectCreationListItem : ObjectCreationListItem
@@ -100,6 +113,27 @@ namespace OpenSage.Logic.Object
 
         [AddedIn(SageGame.CncGeneralsZeroHour)]
         public int RollRate { get; private set; }
+
+        internal override void Execute(BehaviorUpdateContext context)
+        {
+            var debrisObject = context.GameContext.GameObjects.Add("GenericDebris", context.GameObject.Owner);
+
+            debrisObject.Transform.Translation = context.GameObject.Transform.Translation + Offset;
+            debrisObject.Transform.Rotation = context.GameObject.Transform.Rotation;
+
+            // Model
+            var w3dDebrisDraw = (W3dDebrisDraw) debrisObject.DrawModules[0];
+            // TODO
+            //var modelName = ModelNames[context.GameContext.Random.Next(ModelNames.Length)];
+            var modelName = ModelNames[0];
+            w3dDebrisDraw.SetModelName(modelName);
+
+            // Physics
+            var physicsBehavior = debrisObject.FindBehavior<PhysicsBehavior>();
+            physicsBehavior.Mass = Mass;
+
+            // TODO: Count, Disposition, DispositionIntensity
+        }
     }
 
     public sealed class CreateObjectObjectCreationListItem : ObjectCreationListItem
@@ -108,7 +142,7 @@ namespace OpenSage.Logic.Object
 
         private static readonly IniParseTable<CreateObjectObjectCreationListItem> FieldParseTable = new IniParseTable<CreateObjectObjectCreationListItem>
         {
-            { "ObjectNames", (parser, x) => x.ObjectNames = parser.ParseAssetReference() },
+            { "ObjectNames", (parser, x) => x.ObjectNames = parser.ParseObjectReferenceArray() },
             { "Offset", (parser, x) => x.Offset = parser.ParseVector3() },
             { "Count", (parser, x) => x.Count = parser.ParseInteger() },
             { "SpreadFormation", (parser, x) => x.SpreadFormation = parser.ParseBoolean() },
@@ -165,7 +199,7 @@ namespace OpenSage.Logic.Object
             { "WaypointSpawnPoints", (parser, x) => x.WaypointSpawnPoints = parser.ParseAssetReference() },
         };
 
-        public string ObjectNames { get; private set; }
+        public LazyAssetReference<ObjectDefinition>[] ObjectNames { get; private set; }
         public Vector3 Offset { get; private set; }
         public int Count { get; private set; }
         public bool SpreadFormation { get; private set; }
@@ -266,6 +300,23 @@ namespace OpenSage.Logic.Object
 
         [AddedIn(SageGame.Bfme2)]
         public string WaypointSpawnPoints { get; private set; }
+
+        internal override void Execute(BehaviorUpdateContext context)
+        {
+            // TODO
+
+            foreach (var objectName in ObjectNames)
+            {
+                var newGameObject = context.GameContext.GameObjects.Add(objectName.Value, context.GameObject.Owner);
+                newGameObject.Transform.Translation = context.GameObject.Transform.Translation;
+                newGameObject.Transform.Rotation = context.GameObject.Transform.Rotation;
+
+                // TODO: Count
+                // TODO: Disposition
+                // TODO: DispositionIntensity
+                // TODO: Offset
+            }
+        }
     }
 
     public sealed class ApplyRandomForceObjectCreationListItem : ObjectCreationListItem
@@ -289,6 +340,11 @@ namespace OpenSage.Logic.Object
         public float MinForcePitch { get; private set; }
         public float MaxForcePitch { get; private set; }
         public float SpinRate { get; private set; }
+
+        internal override void Execute(BehaviorUpdateContext context)
+        {
+            // TODO
+        }
     }
 
     public sealed class FireWeaponObjectCreationListItem : ObjectCreationListItem
@@ -304,6 +360,11 @@ namespace OpenSage.Logic.Object
         };
 
         public string Weapon { get; private set; }
+
+        internal override void Execute(BehaviorUpdateContext context)
+        {
+            // TODO
+        }
     }
 
     public sealed class AttackObjectCreationListItem : ObjectCreationListItem
@@ -325,6 +386,11 @@ namespace OpenSage.Logic.Object
         public int NumberOfShots { get; private set; }
         public int DeliveryDecalRadius { get; private set; }
         public RadiusDecalTemplate DeliveryDecal { get; private set; }
+
+        internal override void Execute(BehaviorUpdateContext context)
+        {
+            // TODO
+        }
     }
 
     public sealed class DeliverPayloadObjectCreationListItem : ObjectCreationListItem
@@ -406,6 +472,11 @@ namespace OpenSage.Logic.Object
         public float WeaponConvergenceFactor { get; private set; }
         public int DeliveryDecalRadius { get; private set; }
         public RadiusDecalTemplate DeliveryDecal { get; private set; }
+
+        internal override void Execute(BehaviorUpdateContext context)
+        {
+            // TODO
+        }
     }
 
     public enum ObjectDisposition

--- a/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
@@ -177,9 +177,9 @@ namespace OpenSage.Logic.Object
             { "SoundMoveStartDamaged", (parser, x) => x.SoundMoveStart = parser.ParseAssetReference() },
             { "SoundMoveLoop", (parser, x) => x.SoundMoveLoop = parser.ParseAssetReference() },
             { "SoundMoveLoopDamaged", (parser, x) => x.SoundMoveLoopDamaged = parser.ParseAssetReference() },
-            { "SoundOnDamaged", (parser, x) => x.SoundOnDamaged = parser.ParseAssetReference() },
-            { "SoundOnReallyDamaged", (parser, x) => x.SoundOnReallyDamaged = parser.ParseAssetReference() },
-            { "SoundDie", (parser, x) => x.SoundDie = parser.ParseAssetReference() },
+            { "SoundOnDamaged", (parser, x) => x.SoundOnDamaged = parser.ParseAudioEventReference() },
+            { "SoundOnReallyDamaged", (parser, x) => x.SoundOnReallyDamaged = parser.ParseAudioEventReference() },
+            { "SoundDie", (parser, x) => x.SoundDie = parser.ParseAudioEventReference() },
             { "SoundDieFire", (parser, x) => x.SoundDieFire = parser.ParseAssetReference() },
             { "SoundDieToxin", (parser, x) => x.SoundDieToxin = parser.ParseAssetReference() },
             { "SoundStealthOn", (parser, x) => x.SoundStealthOn = parser.ParseAssetReference() },
@@ -718,9 +718,9 @@ namespace OpenSage.Logic.Object
         [AddedIn(SageGame.Bfme)]
         public string SoundMoveLoopDamaged { get; private set; }
 
-        public string SoundOnDamaged { get; private set; }
-        public string SoundOnReallyDamaged { get; private set; }
-        public string SoundDie { get; private set; }
+        public LazyAssetReference<BaseAudioEventInfo> SoundOnDamaged { get; private set; }
+        public LazyAssetReference<BaseAudioEventInfo> SoundOnReallyDamaged { get; private set; }
+        public LazyAssetReference<BaseAudioEventInfo> SoundDie { get; private set; }
         public string SoundDieFire { get; private set; }
         public string SoundDieToxin { get; private set; }
         public string SoundStealthOn { get; private set; }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/MissileAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/MissileAIUpdate.cs
@@ -48,7 +48,11 @@ namespace OpenSage.Logic.Object
                             AddTargetPoint(pointToReachBeforeTurning);
                         }
 
-                        AddTargetPoint(context.GameObject.CurrentWeapon.CurrentTarget.TargetPosition);
+                        // TODO: What to do if target doesn't exist anymore?
+                        if (context.GameObject.CurrentWeapon.CurrentTarget != null)
+                        {
+                            AddTargetPoint(context.GameObject.CurrentWeapon.CurrentTarget.TargetPosition);
+                        }
 
                         context.GameObject.Speed = _moduleData.InitialVelocity;
 

--- a/src/OpenSage.Game/Logic/Object/Update/BoneFXUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BoneFXUpdate.cs
@@ -1,5 +1,4 @@
 ﻿using OpenSage.Data.Ini;
-using OpenSage.Logic.Object.Damage;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object

--- a/src/OpenSage.Game/Logic/Object/Update/FlammableUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FlammableUpdate.cs
@@ -1,5 +1,4 @@
 ﻿using OpenSage.Data.Ini;
-using OpenSage.Logic.Object.Damage;
 
 namespace OpenSage.Logic.Object
 {

--- a/src/OpenSage.Game/Logic/Object/Update/ParticleUplinkCannonUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ParticleUplinkCannonUpdate.cs
@@ -1,5 +1,4 @@
 ﻿using OpenSage.Data.Ini;
-using OpenSage.Logic.Object.Damage;
 
 namespace OpenSage.Logic.Object
 {

--- a/src/OpenSage.Game/Logic/Object/Update/StructureToppleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StructureToppleUpdate.cs
@@ -1,5 +1,4 @@
 ﻿using OpenSage.Data.Ini;
-using OpenSage.Logic.Object.Damage;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object

--- a/src/OpenSage.Game/Logic/Object/Weapon/Weapon.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/Weapon.cs
@@ -97,6 +97,11 @@ namespace OpenSage.Logic.Object
         public void LogicTick(TimeSpan currentTime)
         {
             _stateMachine.Update(currentTime);
+
+            if (CurrentTarget != null && CurrentTarget.IsDestroyed)
+            {
+                CurrentTarget = null;
+            }
         }
 
         public void Fire(TimeSpan currentTime)

--- a/src/OpenSage.Game/Logic/Object/Weapon/WeaponTarget.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/WeaponTarget.cs
@@ -9,6 +9,8 @@ namespace OpenSage.Logic.Object
         public readonly Vector3? TargetGroundPosition;
         public readonly GameObject TargetObject;
 
+        public bool IsDestroyed => TargetType == WeaponTargetType.Object && TargetObject.Destroyed;
+
         public Vector3 TargetPosition => TargetType == WeaponTargetType.Position
             ? TargetGroundPosition.Value
             : TargetObject.Transform.Translation;

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -310,6 +310,7 @@ namespace OpenSage
                 game.AssetStore.LoadContext,
                 game.Audio,
                 _particleSystemManager,
+                new ObjectCreationListManager(),
                 Terrain,
                 Navigation);
 

--- a/src/OpenSage.Game/Subsystem.cs
+++ b/src/OpenSage.Game/Subsystem.cs
@@ -70,5 +70,10 @@
         /// Things that need to be loaded in order to display the credits.
         /// </summary>
         Credits,
+
+        /// <summary>
+        /// Things that need to be loaded in order to do damage to objects.
+        /// </summary>
+        Damage,
     }
 }


### PR DESCRIPTION
This PR provides stub implementations of some basic modules required to make things take damage:

* `PhysicsBehavior`
* `ObjectCreationList`
* `TransitionDamageFX`
* `CreateObjectDie`
* `FXListDie`
* `Damaged` and `ReallyDamaged` model flags