### PR TITLE
Fix division by zero and index out of bounds

### DIFF
--- a/src/OpenSage.Game/Graphics/ParticleSystems/ParticleSystem.cs
+++ b/src/OpenSage.Game/Graphics/ParticleSystems/ParticleSystem.cs
@@ -224,17 +224,17 @@ namespace OpenSage.Graphics.ParticleSystems
         private static DeviceBuffer CreateIndexBuffer(GraphicsDevice graphicsDevice, int maxParticles, out uint numIndices)
         {
             numIndices = (uint) maxParticles * 2 * 3; // Two triangles per particle.
-            var indices = new ushort[numIndices]; 
+            var indices = new uint[numIndices]; 
             var indexCounter = 0;
-            for (ushort i = 0; i < maxParticles * 4; i += 4)
+            for (uint i = 0; i < maxParticles * 4; i += 4)
             {
-                indices[indexCounter++] = (ushort) (i + 0);
-                indices[indexCounter++] = (ushort) (i + 2);
-                indices[indexCounter++] = (ushort) (i + 1);
+                indices[indexCounter++] = (uint) (i + 0);
+                indices[indexCounter++] = (uint) (i + 2);
+                indices[indexCounter++] = (uint) (i + 1);
 
-                indices[indexCounter++] = (ushort) (i + 1);
-                indices[indexCounter++] = (ushort) (i + 2);
-                indices[indexCounter++] = (ushort) (i + 3);
+                indices[indexCounter++] = (uint) (i + 1);
+                indices[indexCounter++] = (uint) (i + 2);
+                indices[indexCounter++] = (uint) (i + 3);
             }
 
             var result = graphicsDevice.CreateStaticBuffer(

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
@@ -22,7 +22,7 @@ namespace OpenSage.Logic.Object
             _gameObject = gameObject;
             _moduleData = moduleData;
 
-            Mass = moduleData.Mass;
+            Mass = moduleData.Mass ?? moduleData.GravityMult ?? 1.0f;
         }
 
         internal override void Update(BehaviorUpdateContext context)
@@ -97,7 +97,7 @@ namespace OpenSage.Logic.Object
             { "SecondHeight", (parser, x) => x.SecondHeight = parser.ParseInteger() }
         };
 
-        public float Mass { get; private set; }
+        public float? Mass { get; private set; }
         public float AerodynamicFriction { get; private set; }
         public float ForwardFriction { get; private set; }
         public float CenterOfMassOffset { get; private set; }
@@ -106,7 +106,7 @@ namespace OpenSage.Logic.Object
         public bool AllowCollideForce { get; private set; } = true;
 
         [AddedIn(SageGame.Bfme)]
-        public float GravityMult { get; private set; }
+        public float? GravityMult { get; private set; }
 
         [AddedIn(SageGame.Bfme)]
         public int ShockStandingTime { get; private set; }


### PR DESCRIPTION
- Fixed in BFME some particlesystems that couldn't use ushort as index type 
- In BFME `PhysicsBehaviors` have no mass. Looking at the ini`s the GravityMult property seems similar