### PR TITLE
Avoid reducing mapped images quality

### DIFF
--- a/src/OpenSage.Game/Gui/Wnd/Images/Image.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Images/Image.cs
@@ -34,7 +34,7 @@ namespace OpenSage.Gui.Wnd.Images
                 return;
             }
 
-            _texture = _source.GetTexture(size);
+            _texture = _source.GetTexture(actualSize);
             if(size.Width == 0 || size.Height == 0)
             {
                 return;

--- a/src/OpenSage.Game/Gui/Wnd/Images/MappedImageSource.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Images/MappedImageSource.cs
@@ -21,17 +21,7 @@ namespace OpenSage.Gui.Wnd.Images
 
         protected override Texture CreateTexture(Size size, GraphicsLoadContext loadContext)
         {
-            return MappedImageUtility.CreateTexture(loadContext, size, spriteBatch =>
-            {
-                var requiresFlip = !loadContext.GraphicsDevice.IsUvOriginTopLeft;
-
-                spriteBatch.DrawImage(
-                    _mappedImage.Texture.Value,
-                    _mappedImage.Coords,
-                    new Rectangle(Point2D.Zero, size).ToRectangleF(),
-                    ColorRgbaF.White,
-                    requiresFlip);
-            });
+            return MappedImageUtility.CreateTexture(loadContext, _mappedImage); 
         }
     }
 }

--- a/src/OpenSage.Game/Gui/Wnd/Images/MappedImageUtility.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Images/MappedImageUtility.cs
@@ -18,8 +18,9 @@ namespace OpenSage.Gui.Wnd.Images
         {
             var graphicsDevice = loadContext.GraphicsDevice;
 
-            var width = (uint) mappedImage.Coords.Width;
-            var height = (uint) mappedImage.Coords.Height;
+            var src = mappedImage.Coords;
+            var width = (uint) src.Width;
+            var height = (uint) src.Height;
 
             var imageTexture = graphicsDevice.ResourceFactory.CreateTexture(
                 TextureDescription.Texture2D(
@@ -28,7 +29,7 @@ namespace OpenSage.Gui.Wnd.Images
                     1,
                     1,
                     PixelFormat.R8_G8_B8_A8_UNorm,
-                    TextureUsage.Sampled | TextureUsage.RenderTarget));
+                    TextureUsage.Sampled));
 
             imageTexture.Name = "WndImage";
 
@@ -36,7 +37,6 @@ namespace OpenSage.Gui.Wnd.Images
 
             commandList.Begin();
 
-            var src = mappedImage.Coords;
             commandList.CopyTexture(
                 mappedImage.Texture.Value, (uint) src.Left, (uint) src.Top, 0, 0, 0,    // Source
                 imageTexture, 0, 0, 0, 0, 0, width, height, 1, 1);                      // Destination

--- a/src/OpenSage.Game/Gui/Wnd/Images/MappedImageUtility.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Images/MappedImageUtility.cs
@@ -9,6 +9,49 @@ namespace OpenSage.Gui.Wnd.Images
     internal static class MappedImageUtility
     {
         /// <summary>
+        /// Creates a texture from a mapped image.
+        /// This version does a simple copy of the original image part
+        /// </summary>
+        public static Texture CreateTexture(
+            GraphicsLoadContext loadContext,
+            MappedImage mappedImage)
+        {
+            var graphicsDevice = loadContext.GraphicsDevice;
+
+            var width = (uint) mappedImage.Coords.Width;
+            var height = (uint) mappedImage.Coords.Height;
+
+            var imageTexture = graphicsDevice.ResourceFactory.CreateTexture(
+                TextureDescription.Texture2D(
+                    width,
+                    height,
+                    1,
+                    1,
+                    PixelFormat.R8_G8_B8_A8_UNorm,
+                    TextureUsage.Sampled | TextureUsage.RenderTarget));
+
+            imageTexture.Name = "WndImage";
+
+            var commandList = graphicsDevice.ResourceFactory.CreateCommandList();
+
+            commandList.Begin();
+
+            var src = mappedImage.Coords;
+            commandList.CopyTexture(
+                mappedImage.Texture.Value, (uint) src.Left, (uint) src.Top, 0, 0, 0,    // Source
+                imageTexture, 0, 0, 0, 0, 0, width, height, 1, 1);                      // Destination
+
+            commandList.End();
+
+            graphicsDevice.SubmitCommands(commandList);
+            graphicsDevice.DisposeWhenIdle(commandList);
+
+            graphicsDevice.WaitForIdle();
+
+            return imageTexture;
+        }
+
+        /// <summary>
         /// Creates a texture from a mapped image. We need to do this to avoid alpha bleeding artifacts
         /// when blitting a portion of a texture.
         /// </summary>


### PR DESCRIPTION
A user on our discord server recognized that Wnd images are a bit blurry / not the full resolution.
There are multiple recognized:
- The texture size depends on the size of the Wnd control, but we always want the full resolution
- The images do get rendered into a framebuffer and then rendered again. I'm not sure if this lowers quality, but it definetly is less efficient than a plain `commandList.CopyTexture` 

I solved this by using the original texture data when possible. However not sure how to solve this for stretchable images. 
Also i think we need to reconsider the **ImageSource** interface. Opinions welcome
