### PR TITLE
Fixed multi selection

### DIFF
--- a/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
@@ -19,7 +19,6 @@ namespace OpenSage.Logic.Orders
 
         public void Process(IEnumerable<Order> orders)
         {
-            
             foreach (var order in orders)
             {
                 Player player = null;


### PR DESCRIPTION
At the moment units and buildings can be selected at the same time. 
After this fix units are prioritized in order to still be able to set waypoints for them etc.
If multiple structures are in the selected region, only the first one in the list will be selected.