### PR TITLE
Fixed bone weight issue

### DIFF
--- a/src/OpenSage.FileFormats.W3d/W3dVertexInfluence.cs
+++ b/src/OpenSage.FileFormats.W3d/W3dVertexInfluence.cs
@@ -24,8 +24,8 @@ namespace OpenSage.FileFormats.W3d
                 BoneWeight1 = reader.ReadUInt16()
             };
 
-            //sometimes both weights are 0 and sometimes weight0 is 100
-            if (result.BoneWeight0 == 0)
+            //sometimes both weights are 0
+            if (result.BoneWeight0 == 0 && result.BoneWeight1 == 0)
             {
                 result.BoneWeight0 = 100;
             }


### PR DESCRIPTION
Sometimes both bone weights are 0, set bone weight 1 to 100 in that case.

before:
![before](https://user-images.githubusercontent.com/10086882/88585658-a2c67700-d053-11ea-8723-a09b111a5b20.PNG)

after:
![after](https://user-images.githubusercontent.com/10086882/88585664-a659fe00-d053-11ea-96e9-8443b4136701.PNG)
