### PR TITLE
Handle all radius decals, not only the ones in InGameUI.ini

### DIFF
--- a/src/OpenSage.Game/Logic/OrderGenerators/SpecialPowerOrderGenerator.cs
+++ b/src/OpenSage.Game/Logic/OrderGenerators/SpecialPowerOrderGenerator.cs
@@ -52,7 +52,6 @@ namespace OpenSage.Logic.OrderGenerators
             if (radiusCursors.TryGetValue(radiusCursorName, out var radiusCursor))
             {
                 _decalHandle = scene.Terrain.RadiusCursorDecals.AddDecal(
-                    radiusCursorName,
                     radiusCursor.DecalTemplate,
                     _specialPower.RadiusCursorRadius,
                     time);

--- a/src/OpenSage.Game/Terrain/Terrain.cs
+++ b/src/OpenSage.Game/Terrain/Terrain.cs
@@ -390,7 +390,7 @@ namespace OpenSage.Terrain
                 TextureDescription.Texture2D(
                     largestTextureSize,
                     largestTextureSize,
-                    CalculateMipMapCount(largestTextureSize, largestTextureSize),
+                    TextureMipMapData.CalculateMipMapCount(largestTextureSize, largestTextureSize),
                     numTextures,
                     PixelFormat.R8_G8_B8_A8_UNorm,
                     TextureUsage.Sampled)));
@@ -503,11 +503,6 @@ namespace OpenSage.Terrain
             gd.DisposeWhenIdle(cl);
 
             return staging;
-        }
-
-        private static uint CalculateMipMapCount(uint width, uint height)
-        {
-            return 1u + (uint) MathF.Floor(MathF.Log(Math.Max(width, height), 2));
         }
 
         public Vector3? Intersect(Ray ray)

--- a/src/OpenSage.Game/Utilities/TextureMipMapData.cs
+++ b/src/OpenSage.Game/Utilities/TextureMipMapData.cs
@@ -1,4 +1,6 @@
-﻿namespace OpenSage.Utilities
+﻿using System;
+
+namespace OpenSage.Utilities
 {
     public readonly struct TextureMipMapData
     {
@@ -24,6 +26,17 @@
 
             Width = width;
             Height = height;
+        }
+
+        public static uint CalculateMipMapCount(uint width, uint height)
+        {
+            return 1u + (uint) MathF.Floor(MathF.Log(Math.Max(width, height), 2));
+        }
+
+        public static uint CalculateMipSize(uint mipLevel, uint baseSize)
+        {
+            baseSize >>= (int) mipLevel;
+            return baseSize > 0 ? baseSize : 1;
         }
     }
 }


### PR DESCRIPTION
My initial implementation only supported the radius cursor decals loaded from InGameUI.ini. With this change, we can support all the others such as the ones in `DeliveryDecal`.