### PR TITLE
Fix wrong condition state selection

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -149,11 +149,11 @@ namespace OpenSage.Logic.Object
             var firstAnimationBlock = animationState.Animations.FirstOrDefault();
             if (firstAnimationBlock != null)
             {
-                foreach(var animation in firstAnimationBlock.Animations)
+                foreach (var animation in firstAnimationBlock.Animations)
                 {
                     var anim = animation.Value;
                     //Check if the animation does really exist
-                    if(anim != null)
+                    if (anim != null)
                     {
                         var flags = animationState.Flags;
                         var mode = firstAnimationBlock.AnimationMode;
@@ -213,7 +213,7 @@ namespace OpenSage.Logic.Object
                     }
                 }
             };
-            
+
             AnimationState bestAnimationState = null;
             bestIntersections = int.MinValue;
             bestBitCount = int.MinValue;

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -169,7 +169,8 @@ namespace OpenSage.Logic.Object
         public override void UpdateConditionState(BitArray<ModelConditionFlag> flags)
         {
             ModelConditionState bestConditionState = null;
-            var bestMatch = int.MinValue;
+            var bestIntersections = int.MinValue;
+            var bestBitCount = int.MinValue;
 
             // Find best matching ModelConditionState.
             foreach (var conditionState in _conditionStates)
@@ -183,14 +184,16 @@ namespace OpenSage.Logic.Object
                     continue;
                 }
 
-                if (numIntersectionBits > bestMatch)
+                if (numIntersectionBits > bestIntersections ||
+                   ((numIntersectionBits == bestIntersections) && numStateBits < bestBitCount))
                 {
                     bestConditionState = conditionState;
-                    bestMatch = numIntersectionBits;
+                    bestBitCount = numStateBits;
+                    bestIntersections = numIntersectionBits;
                 }
             }
 
-            if (bestConditionState == null || bestMatch == 0)
+            if (bestConditionState == null || bestIntersections == 0)
             {
                 bestConditionState = _defaultConditionState;
             }
@@ -212,7 +215,8 @@ namespace OpenSage.Logic.Object
             };
             
             AnimationState bestAnimationState = null;
-            bestMatch = int.MinValue;
+            bestIntersections = int.MinValue;
+            bestBitCount = int.MinValue;
 
             // Find best matching ModelConditionState.
             foreach (var animationState in _animationStates)
@@ -226,14 +230,16 @@ namespace OpenSage.Logic.Object
                     continue;
                 }
 
-                if (numIntersectionBits > bestMatch)
+                if (numIntersectionBits > bestIntersections ||
+                   ((numIntersectionBits == bestIntersections) && numStateBits < bestBitCount))
                 {
                     bestAnimationState = animationState;
-                    bestMatch = numIntersectionBits;
+                    bestBitCount = numStateBits;
+                    bestIntersections = numIntersectionBits;
                 }
             }
 
-            if (bestAnimationState == null || bestMatch == 0)
+            if (bestAnimationState == null || bestIntersections == 0)
             {
                 bestAnimationState = _idleAnimationState;
             }


### PR DESCRIPTION
This fixes that some condition states are not drawing incorrectly drawn. @Tarcontar and me found that issue while workying on the chinook. What happened is the following. 
There were the following condition states:
*(CARRYING, RUBBLE)* <-- This was picked
*(DOCKING, CARRYING. RUBBLE)*
*(CARRYING)* <-- This should be picked
*(DOCKING, CARRYING)*

When now selecting **CARRYING** it would just pick the first condition state it found, since all 4 condition states have 1 intersecting bit. However it should always pick the condition state with the least bits.

I think this fixed also multiple other animations, atleast build animations look more correct now sometimes :)