### PR TITLE
Fix bone visibility

### DIFF
--- a/src/OpenSage.Game/Graphics/ModelInstance.cs
+++ b/src/OpenSage.Game/Graphics/ModelInstance.cs
@@ -162,7 +162,7 @@ namespace OpenSage.Graphics
                         parentTransform;
 
                     var parentVisible = bone.Parent != null
-                        ? BoneVisibilities[i]
+                        ? BoneVisibilities[bone.Parent.Index]
                         : true;
 
                     BoneVisibilities[i] = parentVisible && ModelBoneInstances[i].Visible;


### PR DESCRIPTION
The visibility animations for the SupplyCenter (hiding & showing the boxes) didn't work. 
I think the current code did not check the parent visibility correctly