### PR TITLE
Linux fixes

### DIFF
--- a/src/OpenSage.Game/Input/Cursors/Cursor.cs
+++ b/src/OpenSage.Game/Input/Cursors/Cursor.cs
@@ -34,55 +34,55 @@ namespace OpenSage.Input.Cursors
             {
                 var image = cursorFile.Images[i];
 
-                var width = (int)image.Width;
-                var height = (int)image.Height;
+                var width = (int) image.Width;
+                var height = (int) image.Height;
 
-                fixed (byte* pixelsPtr = image.PixelsBgra)
+                Sdl2Interop.SDL_Surface surface;
+                if (windowScale == 1.0f )
                 {
-                    Sdl2Interop.SDL_Surface surface;
-                    if (windowScale == 1.0f)
+                    fixed (byte* pixelsPtr = image.PixelsBgra)
                     {
                         surface = Sdl2Interop.SDL_CreateRGBSurfaceWithFormatFrom(
-                            pixelsPtr,
-                            width,
-                            height,
-                            32,
-                            width * 4,
-                            Sdl2Interop.SDL_PixelFormat.SDL_PIXELFORMAT_ABGR8888);
+                                pixelsPtr,
+                                width,
+                                height,
+                                32,
+                                width * 4,
+                                Sdl2Interop.SDL_PixelFormat.SDL_PIXELFORMAT_ABGR8888);
                     }
-                    else
-                    {
-                        var scaledWidth = (int)(windowScale * width);
-                        var scaledHeight = (int)(windowScale * height);
-
-                        var scaledImage = Image.LoadPixelData<Argb32>(image.PixelsBgra, width, height);
-                        scaledImage.Mutate(x => x.Resize(scaledWidth, scaledHeight));
-
-                        if (!scaledImage.TryGetSinglePixelSpan(out Span<Argb32> pixelSpan))
-                        {
-                            throw new InvalidOperationException("Unable to get image pixelspan.");
-                        }
-                        fixed (void* pin = &MemoryMarshal.GetReference(pixelSpan))
-                        {
-                            surface = Sdl2Interop.SDL_CreateRGBSurfaceWithFormatFrom(
-                               (byte*)pin,
-                               scaledWidth,
-                               scaledHeight,
-                               32,
-                               scaledWidth * 4,
-                               Sdl2Interop.SDL_PixelFormat.SDL_PIXELFORMAT_ABGR8888);
-                        }
-                    }
-
-                    AddDisposeAction(() => Sdl2Interop.SDL_FreeSurface(surface));
-
-                    _surfaces[i] = surface;
                 }
+                else
+                {
+                    var scaledWidth = (int) (windowScale * width);
+                    var scaledHeight = (int) (windowScale * height);
+
+                    var scaledImage = Image.LoadPixelData<Bgra32>(image.PixelsBgra, width, height);
+                    scaledImage.Mutate(x => x.Resize(scaledWidth, scaledHeight));
+
+                    if (!scaledImage.TryGetSinglePixelSpan(out Span<Bgra32> pixelSpan))
+                    {
+                        throw new InvalidOperationException("Unable to get image pixelspan.");
+                    }
+                    fixed (void* pin = &MemoryMarshal.GetReference(pixelSpan))
+                    {
+                        surface = Sdl2Interop.SDL_CreateRGBSurfaceWithFormatFrom(
+                           (byte*) pin,
+                           scaledWidth,
+                           scaledHeight,
+                           32,
+                           scaledWidth * 4,
+                           Sdl2Interop.SDL_PixelFormat.SDL_PIXELFORMAT_ABGR8888);
+                    }
+                }
+
+                AddDisposeAction(() => Sdl2Interop.SDL_FreeSurface(surface));
+
+                _surfaces[i] = surface;
 
                 var cursor = Sdl2Interop.SDL_CreateColorCursor(
                     _surfaces[i],
-                    (int)(image.HotspotX * windowScale),
-                    (int)(image.HotspotY * windowScale));
+                    (int) (image.HotspotX * windowScale),
+                    (int) (image.HotspotY * windowScale));
 
                 AddDisposeAction(() => Sdl2Interop.SDL_FreeCursor(cursor));
 

--- a/src/OpenSage.Game/Utilities/PlatformUtility.cs
+++ b/src/OpenSage.Game/Utilities/PlatformUtility.cs
@@ -35,7 +35,7 @@ namespace OpenSage.Utilities
             }
             else
             {
-                return 1.0f; // TODO: What happens on Linux?
+                return 96.0f; // TODO: For GNOME3 the default DPI is 96
             }
         }
     }

--- a/src/OpenSage.Game/Utilities/Sdl2Interop.cs
+++ b/src/OpenSage.Game/Utilities/Sdl2Interop.cs
@@ -48,13 +48,6 @@ namespace OpenSage.Utilities
 
         public static void SDL_FreeSurface(SDL_Surface Sdl2Surface) => FreeSurfaceImpl(Sdl2Surface);
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate int SDL_BlitScaled_Delegate(SDL_Surface src, SDL_Rect srcRect, SDL_Surface dst, SDL_Rect dstRect);
-
-        // According to the SDL docs, we should use SDL_BlitScaled, but that function isn't found by Sdl2Native.LoadFunction.
-        private static readonly SDL_BlitScaled_Delegate BlitScaledImpl = Sdl2Native.LoadFunction<SDL_BlitScaled_Delegate>("SDL_LowerBlitScaled");
-
-        public static void SDL_BlitScaled(SDL_Surface src, SDL_Rect srcRect, SDL_Surface dst, SDL_Rect dstRect) => BlitScaledImpl(src, srcRect, dst, dstRect);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int SDL_GetWindowDisplayIndex_Delegate(SDL_Window Sdl2Window);


### PR DESCRIPTION
- Use correct platform DPI for Gnome3
- Use ImageSharp to scale the cursor pixeldata, since **BlitSurface** crashes the executable