### PR TITLE
Music playback via Skirmish Scripts

### DIFF
--- a/src/OpenSage.Core/NLog.config
+++ b/src/OpenSage.Core/NLog.config
@@ -8,14 +8,15 @@
   </extensions>
 
   <targets>
-        <target name="file" xsi:type="File" fileName="output.log" />
-        <target name="console" xsi:type="ColoredConsole" layout="[${time}][${level}] ${message}"/>
-        <target name="internal" xsi:type="OpenSage" layout="[${time}][${level}] ${message}"/>
+    <target name="file" xsi:type="File" fileName="output.log" />
+    <target name="console" xsi:type="ColoredConsole" layout="[${time}][${level}] ${message}"/>
+    <target name="internal" xsi:type="OpenSage" layout="[${time}][${level}] ${message}"/>
   </targets>
 
-    <rules>
-        <logger name="*" minlevel="Info" writeTo="console" />
-        <logger name="*" minlevel="Debug" writeTo="file" />
-        <logger name="*" minlevel="Trace" writeTo="internal" />
-    </rules>
+  <rules>
+    <logger name="OpenSage.Scripting.*" writeTo="" final="true"/>
+    <logger name="*" minlevel="Info" writeTo="console" />
+    <logger name="*" minlevel="Debug" writeTo="file" />
+    <logger name="*" minlevel="Trace" writeTo="internal" />
+  </rules>
 </nlog>

--- a/src/OpenSage.Game/Audio/AudioSystem.cs
+++ b/src/OpenSage.Game/Audio/AudioSystem.cs
@@ -23,6 +23,9 @@ namespace OpenSage.Audio
 
         private readonly Dictionary<string, int> _musicTrackFinishedCounts = new Dictionary<string, int>();
 
+        private string _currentTrackName;
+        private SoundStream _currentTrack;
+
         public AudioSystem(Game game) : base(game)
         {
             _engine = AudioEngine.CreateDefault();
@@ -48,6 +51,15 @@ namespace OpenSage.Audio
             if (camera != null)
             {
                 UpdateListener(camera);
+            }
+
+            if (_currentTrack != null && !_currentTrack.IsPlaying)
+            {
+                _musicTrackFinishedCounts.TryGetValue(_currentTrackName, out var count);
+                _musicTrackFinishedCounts[_currentTrackName] = count + 1;
+                _currentTrack.Dispose();
+                _currentTrack = null;
+                _currentTrackName = null;
             }
         }
 
@@ -221,11 +233,16 @@ namespace OpenSage.Audio
         {
             // TODO: fading
 
-            var stream = GetStream(musicTrack.File.Value.Entry);
-            stream.Volume = (float) musicTrack.Volume;
-            stream.Play();
+            if (_currentTrack != null)
+            {
+                _currentTrack.Stop();
+                _currentTrack.Dispose();
+            }
 
-            // TODO: how do we know when a track has finished?
+            _currentTrackName = musicTrack.Name;
+            _currentTrack = GetStream(musicTrack.File.Value.Entry);
+            _currentTrack.Volume = (float) musicTrack.Volume;
+            _currentTrack.Play();
         }
 
         public int GetFinishedCount(string musicTrackName)

--- a/src/OpenSage.Game/Audio/AudioSystem.cs
+++ b/src/OpenSage.Game/Audio/AudioSystem.cs
@@ -7,6 +7,9 @@ using OpenSage.Logic.Object;
 using SharpAudio;
 using SharpAudio.Codec;
 using SharpAudio.Codec.Wave;
+using SharpAudio.Util;
+using SharpAudio.Util.Mp3;
+using SharpAudio.Util.Wave;
 
 namespace OpenSage.Audio
 {
@@ -137,7 +140,7 @@ namespace OpenSage.Audio
             }
 
             PlayAudioEvent(audioEvent);
-        }
+        }        
 
         private bool ValidateAudioEvent(BaseAudioEventInfo baseAudioEvent)
         {
@@ -205,6 +208,13 @@ namespace OpenSage.Audio
             }
 
             source.Play();
+        }
+
+        public void PlayMusicTrack(MusicTrack musicTrack)
+        {
+            var stream = GetStream(musicTrack.File.Value.Entry);
+            stream.Volume = (float) musicTrack.Volume;
+            stream.Play();            
         }
     }
 }

--- a/src/OpenSage.Game/Audio/AudioSystem.cs
+++ b/src/OpenSage.Game/Audio/AudioSystem.cs
@@ -12,6 +12,8 @@ namespace OpenSage.Audio
 {
     public sealed class AudioSystem : GameSystem
     {
+        private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
         private readonly List<AudioSource> _sources;
         private readonly Dictionary<string, AudioBuffer> _cached;
         private readonly AudioEngine _engine;
@@ -143,10 +145,9 @@ namespace OpenSage.Audio
         /// </summary>
         public SoundStream GetStream(FileSystemEntry entry)
         {
+            // TODO: Use submixer (currently not possible)
             return new SoundStream(entry.Open(), _engine);
         }
-
-        private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
         public void PlayAudioEvent(string eventName)
         {
@@ -159,7 +160,7 @@ namespace OpenSage.Audio
             }
 
             PlayAudioEvent(audioEvent);
-        }        
+        }
 
         private bool ValidateAudioEvent(BaseAudioEventInfo baseAudioEvent)
         {

--- a/src/OpenSage.Game/Audio/AudioSystem.cs
+++ b/src/OpenSage.Game/Audio/AudioSystem.cs
@@ -7,9 +7,6 @@ using OpenSage.Logic.Object;
 using SharpAudio;
 using SharpAudio.Codec;
 using SharpAudio.Codec.Wave;
-using SharpAudio.Util;
-using SharpAudio.Util.Mp3;
-using SharpAudio.Util.Wave;
 
 namespace OpenSage.Audio
 {
@@ -41,7 +38,10 @@ namespace OpenSage.Audio
 
         public void Update(Camera camera)
         {
-            UpdateListener(camera);
+            if (camera != null)
+            {
+                UpdateListener(camera);
+            }
         }
 
         private void CreateSubmixers()

--- a/src/OpenSage.Game/Audio/AudioSystem.cs
+++ b/src/OpenSage.Game/Audio/AudioSystem.cs
@@ -21,6 +21,8 @@ namespace OpenSage.Audio
 
         private readonly Random _random;
 
+        private readonly Dictionary<string, int> _musicTrackFinishedCounts = new Dictionary<string, int>();
+
         public AudioSystem(Game game) : base(game)
         {
             _engine = AudioEngine.CreateDefault();
@@ -34,6 +36,11 @@ namespace OpenSage.Audio
 
             // TODO: Sync RNG seed from replay?
             _random = new Random();
+        }
+
+        internal override void OnSceneChanged()
+        {
+            _musicTrackFinishedCounts.Clear();
         }
 
         public void Update(Camera camera)
@@ -210,11 +217,20 @@ namespace OpenSage.Audio
             source.Play();
         }
 
-        public void PlayMusicTrack(MusicTrack musicTrack)
+        public void PlayMusicTrack(MusicTrack musicTrack, bool fadeIn, bool fadeOut)
         {
+            // TODO: fading
+
             var stream = GetStream(musicTrack.File.Value.Entry);
             stream.Volume = (float) musicTrack.Volume;
-            stream.Play();            
+            stream.Play();
+
+            // TODO: how do we know when a track has finished?
+        }
+
+        public int GetFinishedCount(string musicTrackName)
+        {
+            return _musicTrackFinishedCounts.TryGetValue(musicTrackName, out var number) ? number : 0;
         }
     }
 }

--- a/src/OpenSage.Game/Content/ContentManager.cs
+++ b/src/OpenSage.Game/Content/ContentManager.cs
@@ -148,5 +148,7 @@ namespace OpenSage.Content
                 return FileSystem.GetFile(mapPath);
             }
         }
+
+        internal FileSystemEntry GetScriptEntry(string scriptPath) => FileSystem.GetFile(scriptPath);
     }
 }

--- a/src/OpenSage.Game/Content/Loaders/OnDemandAudioFileLoader.cs
+++ b/src/OpenSage.Game/Content/Loaders/OnDemandAudioFileLoader.cs
@@ -8,22 +8,31 @@ namespace OpenSage.Content.Loaders
     {
         public AudioFile Load(string key, AssetLoadContext context)
         {
-            var audioSettings = context.AssetStore.AudioSettings.Current;
-
-            var soundFileName = $"{key}.{audioSettings.SoundsExtension}";
-
-            var localisedAudioRoot = Path.Combine(audioSettings.AudioRoot, audioSettings.SoundsFolder, context.Language);
-            var audioRoot = Path.Combine(audioSettings.AudioRoot, audioSettings.SoundsFolder);
-
             FileSystemEntry entry = null;
-            foreach (var rootPath in new[] { localisedAudioRoot, audioRoot })
+
+            // audio events
+            if (string.IsNullOrEmpty(Path.GetExtension(key)))
             {
-                var fullPath = Path.Combine(rootPath, soundFileName);
-                entry = context.FileSystem.GetFile(fullPath);
-                if (entry != null)
+                var audioSettings = context.AssetStore.AudioSettings.Current;
+
+                var soundFileName = $"{key}.{audioSettings.SoundsExtension}";
+
+                var localisedAudioRoot = Path.Combine(audioSettings.AudioRoot, audioSettings.SoundsFolder, context.Language);
+                var audioRoot = Path.Combine(audioSettings.AudioRoot, audioSettings.SoundsFolder);
+
+                foreach (var rootPath in new[] { localisedAudioRoot, audioRoot })
                 {
-                    break;
+                    var fullPath = Path.Combine(rootPath, soundFileName);
+                    entry = context.FileSystem.GetFile(fullPath);
+                    if (entry != null)
+                    {
+                        break;
+                    }
                 }
+            }
+            else // music tracks
+            {
+                entry = context.FileSystem.GetFile(Path.Combine(@"Data\Audio\Tracks", key));
             }
 
             if (entry == null)

--- a/src/OpenSage.Game/Content/SubsystemLoader.cs
+++ b/src/OpenSage.Game/Content/SubsystemLoader.cs
@@ -42,7 +42,8 @@ namespace OpenSage.Content
                         @"Data\INI\AudioSettings.ini",
                         @"Data\INI\SoundEffects.ini",
                         @"Data\INI\MiscAudio.ini",
-                        @"Data\INI\Voice.ini");
+                        @"Data\INI\Voice.ini",
+                        @"Data\Ini\Music.ini");
                     break;
                 case Subsystem.ObjectCreation:
                     LoadFiles(

--- a/src/OpenSage.Game/Diagnostics/MainView.cs
+++ b/src/OpenSage.Game/Diagnostics/MainView.cs
@@ -148,8 +148,8 @@ namespace OpenSage.Diagnostics
                                         new EchoConnection(),
                                         new PlayerSetting?[]
                                         {
-                                            new PlayerSetting(null, faction1, new ColorRgb(255, 0, 0)),
-                                            new PlayerSetting(null, faction2, new ColorRgb(255, 255, 255)),
+                                            new PlayerSetting(null, faction1, new ColorRgb(255, 0, 0), PlayerOwner.Player),
+                                            new PlayerSetting(null, faction2, new ColorRgb(255, 255, 255), PlayerOwner.EasyAi),
                                         },
                                         0
                                     );

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -672,8 +672,9 @@ namespace OpenSage
                     }
                 }
 
-                Scene3D.SetPlayers(players, players[localPlayerIndex]);
-                Scripting.LoadDefaultScripts();
+                // TODO: Theoretically, there could be multiple civilian players
+                Scene3D.SetSkirmishPlayers(players, players[localPlayerIndex]);
+                Scripting.InitializeSkirmishGame();
             }
 
             if (Definition.ControlBar != null)

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -11,6 +11,7 @@ using OpenSage.Data.Apt;
 using OpenSage.Data.Map;
 using OpenSage.Data.Rep;
 using OpenSage.Data.Sav;
+using OpenSage.Data.Scb;
 using OpenSage.Data.Wnd;
 using OpenSage.Diagnostics;
 using OpenSage.Graphics;
@@ -469,7 +470,14 @@ namespace OpenSage
                 if (playerTemplate != null)
                 {
                     var gameData = AssetStore.GameData.Current;
-                    CivilianPlayer = Player.FromTemplate(gameData, playerTemplate);
+
+                    // TODO: Should this be hardcoded? What about other games?
+                    CivilianPlayer = Player.FromTemplate(gameData, playerTemplate, new PlayerSetting()
+                    {
+                        Name = "PlyrCivilian",
+                        Color = new ColorRgb(255, 255, 255),
+                        Owner = PlayerOwner.None
+                    });
                 }
 
                 _developerModeView = AddDisposable(new DeveloperModeView(this));
@@ -665,6 +673,7 @@ namespace OpenSage
                 }
 
                 Scene3D.SetPlayers(players, players[localPlayerIndex]);
+                Scripting.LoadDefaultScripts();
             }
 
             if (Definition.ControlBar != null)

--- a/src/OpenSage.Game/Logic/PlayerSettings.cs
+++ b/src/OpenSage.Game/Logic/PlayerSettings.cs
@@ -20,7 +20,7 @@ namespace OpenSage.Logic
         public int? StartPosition { get; }
         public PlayerTemplate Template { get; set; }
         public PlayerOwner Owner { get; set; }
-        public string Name { get; private set; }
+        public string Name { get; set; }
 
         public PlayerSetting(int? startPosition, PlayerTemplate template, ColorRgb color, PlayerOwner owner = PlayerOwner.None, string name = "")
         {

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -69,7 +69,7 @@ namespace OpenSage
         public readonly Bridge[] Bridges;
         public bool ShowBridges { get; set; } = true;
 
-        public ScriptList[] PlayerScripts { get; }
+        public ScriptList[] PlayerScripts { get; private set; }
 
         public readonly GameObjectCollection GameObjects;
         public bool ShowObjects { get; set; } = true;
@@ -362,7 +362,7 @@ namespace OpenSage
             AddDisposeAction(() => inputMessageBuffer.Handlers.Remove(handler));
         }
 
-        public void SetPlayers(IEnumerable<Player> players, Player localPlayer)
+        public void SetSkirmishPlayers(IEnumerable<Player> players, Player localPlayer)
         {
             _players = players.ToList();
 

--- a/src/OpenSage.Game/Scripting/Actions/ScriptActions.Multimedia.cs
+++ b/src/OpenSage.Game/Scripting/Actions/ScriptActions.Multimedia.cs
@@ -1,0 +1,11 @@
+﻿namespace OpenSage.Scripting
+{
+    partial class ScriptActions
+    {
+        [ScriptAction(ScriptActionType.MusicSetTrack, "Multimedia/Music/Play a music track", "Play '{0}' using fadeout ({1}) and fadein ({2})")]
+        public static void MusicSetTrack(ScriptExecutionContext context, [ScriptArgumentType(ScriptArgumentType.MusicName)] string trackName, bool fadeOut, bool fadeIn)
+        {
+            context.Scene.Audio.PlayMusicTrack(context.Scene.AssetLoadContext.AssetStore.MusicTracks.GetByName(trackName), fadeIn, fadeOut);
+        }
+    }
+}

--- a/src/OpenSage.Game/Scripting/Conditions/ScriptConditions.Multimedia.cs
+++ b/src/OpenSage.Game/Scripting/Conditions/ScriptConditions.Multimedia.cs
@@ -1,0 +1,11 @@
+﻿namespace OpenSage.Scripting
+{
+    partial class ScriptConditions
+    {
+        [ScriptCondition(ScriptConditionType.MusicTrackHasCompleted, "Multimedia/Finished/Music track has completed some number of times", "'{0}' has completed at least {1} times. (NOTE: This can only be used to start other music. USING THIS SCRIPT IN ANY OTHER WAY WILL CAUSE REPLAYS TO NOT WORK.)")]
+        public static bool MusicTrackHasCompleted(ScriptExecutionContext context, [ScriptArgumentType(ScriptArgumentType.MusicName)] string trackName, [ScriptArgumentType(ScriptArgumentType.Integer)] int count)
+        {
+            return context.Scene.Audio.GetFinishedCount(trackName) >= count;
+        }
+    }
+}

--- a/src/OpenSage.Game/Scripting/Conditions/ScriptConditions.Skirmish.cs
+++ b/src/OpenSage.Game/Scripting/Conditions/ScriptConditions.Skirmish.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace OpenSage.Scripting
+{
+    partial class ScriptConditions
+    {
+        [ScriptCondition(ScriptConditionType.SkirmishPlayerFaction, "Skirmish/Player/Player is faction", "Player {0} is Faction Name: {1}")]
+        public static bool SkirmishPlayerFaction(ScriptExecutionContext context, [ScriptArgumentType(ScriptArgumentType.PlayerName)] string playerName, [ScriptArgumentType(ScriptArgumentType.FactionName)] string factionName)
+        {
+            if (playerName.Equals(ScriptArgumentPlaceholders.LocalPlayer, StringComparison.OrdinalIgnoreCase))
+            {
+                return context.Scene.LocalPlayer.Side.Equals(factionName, StringComparison.OrdinalIgnoreCase);
+            }
+
+            foreach (var player in context.Scene.Players)
+            {
+                if (player.Name.Equals(playerName, StringComparison.Ordinal))
+                {
+                    return player.Side.Equals(factionName, StringComparison.Ordinal);
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/OpenSage.Game/Scripting/Script.cs
+++ b/src/OpenSage.Game/Scripting/Script.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using OpenSage.Data.Map;
 using OpenSage.FileFormats;
 
@@ -323,6 +324,37 @@ namespace OpenSage.Scripting
         {
             var version = reader.ReadVersion();
             IsActive = reader.ReadBooleanChecked();
+        }
+
+        public Script Copy(string appendix)
+        {
+            return new Script()
+            {
+                ActionsComment = ActionsComment,
+                ActionsFireSequentially = ActionsFireSequentially,
+                ActionsIfFalse = ActionsIfFalse.Select(a => a.Copy(appendix)).ToArray(),
+                ActionsIfTrue = ActionsIfTrue.Select(a => a.Copy(appendix)).ToArray(),
+                ActiveInEasy = ActiveInEasy,
+                ActiveInHard = ActiveInHard,
+                ActiveInMedium = ActiveInMedium,
+                Comment = Comment,
+                ConditionsComment = ConditionsComment,
+                DeactivateUponSuccess = DeactivateUponSuccess,
+                EvaluationInterval = EvaluationInterval,
+                EvaluationIntervalType = EvaluationIntervalType,
+                IsActive = IsActive,
+                IsSubroutine = IsSubroutine,
+                LoopActions = LoopActions,
+                LoopCount = LoopCount,
+                Name = Name + appendix,
+                OrConditions = OrConditions.Select(c => c.Copy(appendix)).ToArray(),
+                SequentialTargetName = SequentialTargetName, // TODO: appendix?
+                SequentialTargetType = SequentialTargetType,
+                Unknown = Unknown,
+                Unknown2 = Unknown2,
+                Unknown3 = Unknown3,
+                UsesEvaluationIntervalType = UsesEvaluationIntervalType,
+            };
         }
     }
 

--- a/src/OpenSage.Game/Scripting/ScriptAction.cs
+++ b/src/OpenSage.Game/Scripting/ScriptAction.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using OpenSage.Data.Map;
 
 namespace OpenSage.Scripting
@@ -19,6 +20,17 @@ namespace OpenSage.Scripting
         internal void WriteTo(BinaryWriter writer, AssetNameCollection assetNames)
         {
             WriteTo(writer, assetNames, MinimumVersionThatHasInternalName, MinimumVersionThatHasEnabledFlag);
+        }
+
+        public ScriptAction Copy(string appendix)
+        {
+            return new ScriptAction()
+            {
+                Arguments = Arguments.Select(a => a.Copy(appendix)).ToArray(),
+                ContentType = ContentType,
+                Enabled = Enabled,
+                InternalName = InternalName
+            };
         }
     }
 }

--- a/src/OpenSage.Game/Scripting/ScriptArgument.cs
+++ b/src/OpenSage.Game/Scripting/ScriptArgument.cs
@@ -113,5 +113,25 @@ namespace OpenSage.Scripting
 
             return $"({ArgumentType}) {value}";
         }
+
+        public ScriptArgument Copy(string appendix)
+        {
+            return new ScriptArgument()
+            {
+                ArgumentType = ArgumentType,
+                FloatValue = FloatValue,
+                PositionValue = PositionValue,
+                IntValue = IntValue,
+                StringValue = ArgumentType switch
+                {
+                    ScriptArgumentType.CounterName => StringValue + appendix,
+                    ScriptArgumentType.FlagName => StringValue + appendix,
+                    ScriptArgumentType.ScriptName => StringValue + appendix,
+                    ScriptArgumentType.SubroutineName => StringValue + appendix,
+                    ScriptArgumentType.TeamName => StringValue + appendix,
+                    _ => StringValue
+                }
+            };
+        }
     }
 }

--- a/src/OpenSage.Game/Scripting/ScriptArgumentPlaceholders.cs
+++ b/src/OpenSage.Game/Scripting/ScriptArgumentPlaceholders.cs
@@ -1,0 +1,7 @@
+﻿namespace OpenSage.Scripting
+{
+    public static class ScriptArgumentPlaceholders
+    {
+        public const string LocalPlayer = "<Local Player>";
+    }
+}

--- a/src/OpenSage.Game/Scripting/ScriptCondition.cs
+++ b/src/OpenSage.Game/Scripting/ScriptCondition.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using OpenSage.Data.Map;
 using OpenSage.FileFormats;
 
@@ -53,6 +54,18 @@ namespace OpenSage.Scripting
                         writer.WriteBooleanUInt32(IsInverted);
                     }
                 });
+        }
+
+        public ScriptCondition Copy(string appendix)
+        {
+            return new ScriptCondition()
+            {
+                Arguments = Arguments.Select(a => a.Copy(appendix)).ToArray(),
+                ContentType = ContentType,
+                Enabled = Enabled,
+                InternalName = InternalName,
+                IsInverted = IsInverted
+            };
         }
     }
 }

--- a/src/OpenSage.Game/Scripting/ScriptContent.cs
+++ b/src/OpenSage.Game/Scripting/ScriptContent.cs
@@ -10,11 +10,11 @@ namespace OpenSage.Scripting
         where TContentType : struct
     {
         public TContentType ContentType { get; set; }
-        public AssetPropertyKey InternalName { get; private set; }
+        public AssetPropertyKey InternalName { get; protected set; }
 
         public ScriptArgument[] Arguments { get; set; }
 
-        public bool Enabled { get; private set; }
+        public bool Enabled { get; protected set; }
 
         protected ScriptContent()
         {

--- a/src/OpenSage.Game/Scripting/ScriptGroup.cs
+++ b/src/OpenSage.Game/Scripting/ScriptGroup.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using OpenSage.Data.Map;
 using OpenSage.FileFormats;
 
@@ -133,6 +134,18 @@ namespace OpenSage.Scripting
             {
                 Scripts[i].Load(reader);
             }
+        }
+
+        public ScriptGroup Copy(string appendix)
+        {
+            return new ScriptGroup()
+            {
+                Groups = Groups.Select(g => g.Copy(appendix)).ToArray(),
+                IsActive = IsActive,
+                IsSubroutine = IsSubroutine,
+                Name = Name + appendix,
+                Scripts = Scripts.Select(s => s.Copy(appendix)).ToArray()
+            };
         }
     }
 }

--- a/src/OpenSage.Game/Scripting/ScriptList.cs
+++ b/src/OpenSage.Game/Scripting/ScriptList.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using OpenSage.Data.Map;
 using OpenSage.FileFormats;
 
@@ -135,10 +136,11 @@ namespace OpenSage.Scripting
 
         internal ScriptList Copy(string appendix)
         {
-            // TODO
             return new ScriptList()
             {
-
+                Scripts = Scripts.Select(s => s.Copy(appendix)).ToArray(),
+                ScriptGroups = ScriptGroups.Select(s => s.Copy(appendix)).ToArray()
+                // TODO: how to set Version correctly?
             };
         }
     }

--- a/src/OpenSage.Game/Scripting/ScriptList.cs
+++ b/src/OpenSage.Game/Scripting/ScriptList.cs
@@ -132,5 +132,14 @@ namespace OpenSage.Scripting
                 ScriptGroups[i].Load(reader);
             }
         }
+
+        internal ScriptList Copy(string appendix)
+        {
+            // TODO
+            return new ScriptList()
+            {
+
+            };
+        }
     }
 }

--- a/src/OpenSage.Game/Scripting/ScriptOrCondition.cs
+++ b/src/OpenSage.Game/Scripting/ScriptOrCondition.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using OpenSage.Data.Map;
 
 namespace OpenSage.Scripting
@@ -46,6 +47,14 @@ namespace OpenSage.Scripting
                     condition.WriteTo(writer, assetNames);
                 }
             });
+        }
+
+        public ScriptOrCondition Copy(string appendix)
+        {
+            return new ScriptOrCondition()
+            {
+                Conditions = Conditions.Select(c => c.Copy(appendix)).ToArray()
+            };
         }
     }
 }

--- a/src/OpenSage.Game/Scripting/ScriptingSystem.cs
+++ b/src/OpenSage.Game/Scripting/ScriptingSystem.cs
@@ -379,7 +379,6 @@ namespace OpenSage.Scripting
                     }
                 }
             }
-            // Audio.PlayMusicTrack(AssetStore.MusicTracks.GetByName("End_USA_Failure"));
         }
 
         /// <summary>

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -188,8 +188,8 @@ namespace OpenSage.Launcher
                         {
                             var pSettings = new PlayerSetting?[]
                             {
-                            new PlayerSetting(null, game.AssetStore.PlayerTemplates.GetByName("FactionAmerica"), new ColorRgb(255, 0, 0)),
-                            new PlayerSetting(null, game.AssetStore.PlayerTemplates.GetByName("FactionGLA"), new ColorRgb(255, 255, 255)),
+                                new PlayerSetting(null, game.AssetStore.PlayerTemplates.GetByName("FactionAmerica"), new ColorRgb(255, 0, 0), PlayerOwner.Player),
+                                new PlayerSetting(null, game.AssetStore.PlayerTemplates.GetByName("FactionGLA"), new ColorRgb(0, 255, 0), PlayerOwner.EasyAi),
                             };
 
                             logger.Debug("Starting multiplayer game");


### PR DESCRIPTION
Music playback is controlled via the SkirmishScripts (at least in Generals and Zero Hour). I added code for loading and "instatiating" these scripts (copying them for each player and making sure script-, variable- and team-names are unique) and implemented the script actions and conditions necessary for music playback.

There's probably still a lot missing (e.g. I didn't import teams for now, I don't check if there are already scripts in the map file that need to be preserved, there's no fade-in or fade-out, and so on). But I think the PR is big enough already and basic playback works for Generals and Zero Hour. :)