### PR TITLE
Spawn update, SubObjectUpgrade, LumberMill ressource gathering

### DIFF
--- a/src/OpenSage.Game.Tests/DataStructures/QuadtreeTests.cs
+++ b/src/OpenSage.Game.Tests/DataStructures/QuadtreeTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using OpenSage.DataStructures;
 using OpenSage.Logic.Object;
 using OpenSage.Mathematics;
@@ -12,7 +13,7 @@ namespace OpenSage.Tests.DataStructures
         public class MockQuadtreeItem : IHasCollider
         {
             public readonly int Id;
-            public Collider Collider { get; }
+            public Collider Collider { get; set; }
 
             public MockQuadtreeItem(int id, RectangleF bounds)
             {

--- a/src/OpenSage.Game.Tests/Mathematics/RectangleFTests.cs
+++ b/src/OpenSage.Game.Tests/Mathematics/RectangleFTests.cs
@@ -7,11 +7,32 @@ namespace OpenSage.Tests.Mathematics
     public class RectangleFTests
     {
         [Theory]
+        [InlineData(0, 0, 1, 1, true)]
+        [InlineData(1, 1, 4, 4, true)]
+        [InlineData(0, 0, 5, 5, true)]
+        [InlineData(-1, -1, 0.99f, 0.99f, false)]
+        [InlineData(-1, -1, 1, 1, true)]
+        [InlineData(5, 5, 1, 1, true)]
+        [InlineData(5.01f, 5.01f, 1, 1, false)]
+        [InlineData(5.01f, 0, 1, 1, false)]
+        [InlineData(2, 2, 4, 4, true)]
+        public void Intersects(float x, float y, float width, float height, bool expected)
+        {
+            var rect = new RectangleF(0, 0, 5, 5);
+            Assert.Equal(expected, rect.Intersects(new RectangleF(x, y, width, height)));
+        }
+
+        [Theory]
         [InlineData(0, 0, 1, true)]
         [InlineData(-1, -1, 1, false)]
         [InlineData(6, 6, 1, false)]
         [InlineData(2, -1.01f, 1, false)]
         [InlineData(2, -1, 1, true)]
+        [InlineData(2, 2, 1, true)]
+        [InlineData(2.5f, 2.5f, 2.5f, true)]
+        [InlineData(2.5f, 2.5f, 4, true)]
+        [InlineData(2, 6, 1.1f, true)]
+        [InlineData(6, 3, 1, true)]
         public void IntersectsCircle(float x, float y, float radius, bool expected)
         {
             var rect = new RectangleF(0, 0, 5, 5);

--- a/src/OpenSage.Game/Audio/AudioSystem.cs
+++ b/src/OpenSage.Game/Audio/AudioSystem.cs
@@ -208,8 +208,6 @@ namespace OpenSage.Audio
 
         public void PlayAudioEvent(GameObject emitter, BaseAudioEventInfo baseAudioEvent)
         {
-            return;
-
             var source = PlayAudioEventBase(baseAudioEvent);
             if (source == null)
             {

--- a/src/OpenSage.Game/Audio/AudioSystem.cs
+++ b/src/OpenSage.Game/Audio/AudioSystem.cs
@@ -208,6 +208,8 @@ namespace OpenSage.Audio
 
         public void PlayAudioEvent(GameObject emitter, BaseAudioEventInfo baseAudioEvent)
         {
+            return;
+
             var source = PlayAudioEventBase(baseAudioEvent);
             if (source == null)
             {

--- a/src/OpenSage.Game/DataStructures/Quadtree.cs
+++ b/src/OpenSage.Game/DataStructures/Quadtree.cs
@@ -29,21 +29,6 @@ namespace OpenSage.DataStructures
         private bool ReachedDepthLimit => _depth >= MaxDepth;
         private bool IsEmpty => _children == null && _items.Count == 0;
 
-        public List<T> Items()
-        {
-            var result = new List<T>();
-            if (_children != null)
-            {
-                foreach (var child in _children)
-            {
-                result.AddRange(child.Items());
-            }
-            }
-            
-            result.AddRange(_items.ToList());
-            return result;
-        }
-
         public Quadtree(RectangleF bounds)
         {
             Bounds = bounds;

--- a/src/OpenSage.Game/DataStructures/Quadtree.cs
+++ b/src/OpenSage.Game/DataStructures/Quadtree.cs
@@ -64,6 +64,10 @@ namespace OpenSage.DataStructures
 
         public IEnumerable<T> FindIntersecting(in RectangleF bounds) => FindIntersecting(new BoxCollider(bounds));
 
+
+        // TODO
+        //public IEnumerable<T> FindNearby(GameObject obj, float radius) => FindIntersecting(new BoxCollider(bounds));
+
         public IEnumerable<T> FindIntersecting(in Collider collider)
         {
             return !collider.Intersects(Bounds) ? Enumerable.Empty<T>() : FindIntersectingInternal(collider);

--- a/src/OpenSage.Game/Diagnostics/MainView.cs
+++ b/src/OpenSage.Game/Diagnostics/MainView.cs
@@ -138,8 +138,10 @@ namespace OpenSage.Diagnostics
                             {
                                 var random = new Random();
                                 var playableSides = _context.Game.GetPlayableSides().ToList();
-                                var faction1 = playableSides[random.Next(0, playableSides.Count())];
-                                var faction2 = playableSides[random.Next(0, playableSides.Count())];
+                                //var faction1 = playableSides[random.Next(0, playableSides.Count())];
+                                //var faction2 = playableSides[random.Next(0, playableSides.Count())];
+                                var faction1 = playableSides[1];
+                                var faction2 = playableSides[1];
 
                                 if (mapCache.Key.IsMultiplayer)
                                 {

--- a/src/OpenSage.Game/Diagnostics/MainView.cs
+++ b/src/OpenSage.Game/Diagnostics/MainView.cs
@@ -140,8 +140,8 @@ namespace OpenSage.Diagnostics
                                 var playableSides = _context.Game.GetPlayableSides().ToList();
                                 //var faction1 = playableSides[random.Next(0, playableSides.Count())];
                                 //var faction2 = playableSides[random.Next(0, playableSides.Count())];
-                                var faction1 = playableSides[1];
-                                var faction2 = playableSides[1];
+                                var faction1 = playableSides[3];
+                                var faction2 = playableSides[3];
 
                                 if (mapCache.Key.IsMultiplayer)
                                 {

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -188,7 +188,7 @@ namespace OpenSage
 
                 var faction = AssetStore.PlayerTemplates.GetByIndex(factionIndex);
 
-                var color = new ColorRgb(0, 0, 0);
+                ColorRgb color;
 
                 var colorIndex = (int) slot.Color;
                 if (colorIndex >= 0 && colorIndex < AssetStore.MultiplayerColors.Count)

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -652,13 +652,13 @@ namespace OpenSage
                     }
                     else
                     {
-                        var castleBehaviors = new List<(CastleBehaviorModule, Logic.Team)>();
+                        var castleBehaviors = new List<(CastleBehavior, Logic.Team)>();
                         foreach (var gameObject in Scene3D.GameObjects.Items)
                         {
                             var team = gameObject.Team;
                             if (team?.Name == $"Player_{startPos}_Inherit")
                             {
-                                var castleBehavior = gameObject.FindBehavior<CastleBehaviorModule>();
+                                var castleBehavior = gameObject.FindBehavior<CastleBehavior>();
                                 if (castleBehavior != null)
                                 {
                                     castleBehaviors.Add((castleBehavior, team));
@@ -667,7 +667,7 @@ namespace OpenSage
                         }
                         foreach (var (castleBehavior, team) in castleBehaviors)
                         {
-                            castleBehavior.Unpack(player, team);
+                            castleBehavior.Unpack(player, instant: true);
                         }
                     }
                 }

--- a/src/OpenSage.Game/Graphics/ModelInstance.cs
+++ b/src/OpenSage.Game/Graphics/ModelInstance.cs
@@ -132,7 +132,7 @@ namespace OpenSage.Graphics
             }
         }
 
-        public void Update(in TimeInterval gameTime)
+        public void Update(in TimeInterval gameTime, List<string> hiddenSubObjects = null)
         {
             // TODO: Don't update animations if model isn't visible.
 
@@ -171,7 +171,7 @@ namespace OpenSage.Graphics
 
                     var parentVisible = bone.Parent == null || BoneVisibilities[bone.Parent.Index];
 
-                    BoneFrameVisibilities[i] = BoneVisibilities[i] && parentVisible && ModelBoneInstances[i].Visible;
+                    BoneFrameVisibilities[i] = BoneVisibilities[i]  && parentVisible && ModelBoneInstances[i].Visible;
                 }
             }
 
@@ -210,11 +210,18 @@ namespace OpenSage.Graphics
             RenderList renderList,
             Camera camera,
             bool castsShadow,
-            MeshShaderResources.RenderItemConstantsPS? renderItemConstantsPS)
+            MeshShaderResources.RenderItemConstantsPS? renderItemConstantsPS,
+            List<string> hiddenSubObjects = null)
         {
             for (var i = 0; i < Model.SubObjects.Length; i++)
             {
                 var subObject = Model.SubObjects[i];
+                var name = subObject.Name.Split('.').Last();
+
+                if (hiddenSubObjects != null && hiddenSubObjects.Contains(name))
+                {
+                    continue;
+                }
 
                 subObject.RenderObject.BuildRenderList(
                     renderList,

--- a/src/OpenSage.Game/Graphics/ModelInstance.cs
+++ b/src/OpenSage.Game/Graphics/ModelInstance.cs
@@ -164,10 +164,7 @@ namespace OpenSage.Graphics
                         ? RelativeBoneTransforms[bone.Parent.Index]
                         : Matrix4x4.Identity;
 
-                    RelativeBoneTransforms[i] =
-
-                        ModelBoneInstances[i].Matrix *
-                        parentTransform;
+                    RelativeBoneTransforms[i] = ModelBoneInstances[i].Matrix * parentTransform;
 
                     var parentVisible = bone.Parent == null || BoneVisibilities[bone.Parent.Index];
 
@@ -185,12 +182,9 @@ namespace OpenSage.Graphics
                 return;
             }
 
-            // If the model has skinned meshes, convert relative bone transforms
-            // to Matrix4x3 to send to shader.
             for (var i = 0; i < Model.BoneHierarchy.Bones.Length; i++)
             {
                 _skinningBones[i] = RelativeBoneTransforms[i];
-                //RelativeBoneTransforms[i].ToMatrix4x3(out _skinningBones[i]);
             }
 
             _graphicsDevice.UpdateBuffer(_skinningBuffer, 0, _skinningBones);

--- a/src/OpenSage.Game/Graphics/ModelInstance.cs
+++ b/src/OpenSage.Game/Graphics/ModelInstance.cs
@@ -168,7 +168,7 @@ namespace OpenSage.Graphics
 
                     var parentVisible = bone.Parent == null || BoneVisibilities[bone.Parent.Index];
 
-                    BoneFrameVisibilities[i] = BoneVisibilities[i]  && parentVisible && ModelBoneInstances[i].Visible;
+                    BoneFrameVisibilities[i] = BoneVisibilities[i] && parentVisible && ModelBoneInstances[i].Visible;
                 }
             }
 

--- a/src/OpenSage.Game/Gui/CommandButtonCallback.cs
+++ b/src/OpenSage.Game/Gui/CommandButtonCallback.cs
@@ -15,10 +15,19 @@ namespace OpenSage.Gui
             Order CreateOrder(OrderType type) => new Order(playerIndex, type);
 
             var selection = game.Scene3D.LocalPlayer.SelectedUnits;
+            var selectedObject = selection.FirstOrDefault();
 
             Order order = null;
             switch (commandButton.Command)
             {
+                case CommandType.CastleUnpack:
+                    var castleBehavior = selectedObject.FindBehavior<CastleBehavior>();
+                    if (castleBehavior != null)
+                    {
+                        castleBehavior.Unpack(selectedObject.Owner);
+                    }
+                    break;
+
                 case CommandType.FoundationConstruct:
                     //TODO: figure this out correctly
                     if (selection.Count == 0)
@@ -26,12 +35,12 @@ namespace OpenSage.Gui
                         break;
                     }
 
-                    var selectedObject = selection.First();
                     order = CreateOrder(OrderType.BuildObject);
                     order.AddIntegerArgument(objectDefinition.InternalId);
                     order.AddPositionArgument(selectedObject.Translation);
                     order.AddFloatArgument(selectedObject.Yaw + MathUtility.ToRadians(objectDefinition.PlacementViewAngle));
                     break;
+
                 case CommandType.DozerConstruct:
                     game.OrderGenerator.StartConstructBuilding(objectDefinition);
                     break;

--- a/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
@@ -88,14 +88,15 @@ namespace OpenSage.Logic.Object
                     Unpack(_gameObject.Owner, instant: true);
                 }
 
-                var nearbyUnits = context.GameContext.Quadtree.FindIntersecting(new SphereCollider(_gameObject.Transform, _moduleData.ScanDistance));
+                var nearbyUnits = context.GameContext.Quadtree.FindNearby(_gameObject, _gameObject.Transform, _moduleData.ScanDistance);
 
-                if (nearbyUnits.Count() < 2)
+                if (nearbyUnits.Count() == 0)
                 {
                     _gameObject.Owner = _nativePlayer;
                     return;
                 }
-  
+
+                // TODO: check if all nearby units are from the same owner
                 foreach (var unit in nearbyUnits)
                 {
                     if (unit == _gameObject)

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
@@ -42,7 +42,8 @@ namespace OpenSage.Logic.Object
         {
             if (_gameObject.Definition.KindOf.Get(ObjectKinds.Aircraft)
                 || _gameObject.Definition.KindOf.Get(ObjectKinds.Drone)
-                || _gameObject.Definition.KindOf.Get(ObjectKinds.GiantBird))
+                || _gameObject.Definition.KindOf.Get(ObjectKinds.GiantBird)
+                || _gameObject.AIUpdate?.CurrentLocomotor.LocomotorTemplate.Appearance == LocomotorAppearance.GiantBird)
             {
                 if (_gameObject.ModelConditionFlags.Get(ModelConditionFlag.Dying) == false) return;
             }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
@@ -37,7 +37,7 @@ namespace OpenSage.Logic.Object
 
             if (_productionExit != null)
             {
-                spawnedObject.Transform.Translation = _gameObject.ToWorldspace(_productionExit.GetUnitCreatePoint());
+                spawnedObject.SetTranslation(_gameObject.ToWorldspace(_productionExit.GetUnitCreatePoint()));
 
                 var rallyPoint = _productionExit.GetNaturalRallyPoint();
                 if (rallyPoint.HasValue)
@@ -57,6 +57,8 @@ namespace OpenSage.Logic.Object
                 }
                 _initial = false;
             }
+
+            // TODO: respawn killed/dead units
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
@@ -4,7 +4,7 @@ using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class SpawnBehaviorModule : BehaviorModule
+    public sealed class SpawnBehavior : BehaviorModule
     {
         GameObject _gameObject;
         SpawnBehaviorModuleData _moduleData;
@@ -13,7 +13,7 @@ namespace OpenSage.Logic.Object
         private bool _initial;
         private IProductionExit _productionExit;
   
-        internal SpawnBehaviorModule(GameObject gameObject, GameContext context, SpawnBehaviorModuleData moduleData)
+        internal SpawnBehavior(GameObject gameObject, GameContext context, SpawnBehaviorModuleData moduleData)
         {
             _moduleData = moduleData;
             _gameObject = gameObject;
@@ -27,6 +27,7 @@ namespace OpenSage.Logic.Object
             _productionExit ??= _gameObject.FindBehavior<IProductionExit>();
 
             var spawnedObject = _gameObject.Parent.Add(_moduleData.SpawnTemplate.Value);
+            spawnedObject.Owner = _gameObject.Owner;
             _spawnedUnits.Add(spawnedObject);
 
             var slavedUpdate = spawnedObject.FindBehavior<SlavedUpdateModule>();
@@ -47,14 +48,19 @@ namespace OpenSage.Logic.Object
             }
         }
 
+        public void SpawnInitial()
+        {
+            for (var i = 0; i < _moduleData.SpawnNumber; i++)
+            {
+                SpawnUnit();
+            }
+        }
+
         internal override void Update(BehaviorUpdateContext context)
         {
             if (_initial)
             {
-                for (var i = 0; i < _moduleData.SpawnNumber; i++)
-                {
-                    SpawnUnit();
-                }
+                SpawnInitial();
                 _initial = false;
             }
 
@@ -116,7 +122,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new SpawnBehaviorModule(gameObject, context, this);
+            return new SpawnBehavior(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
@@ -58,7 +58,7 @@ namespace OpenSage.Logic.Object
 
         internal override void Update(BehaviorUpdateContext context)
         {
-            if (_initial)
+            if (_initial && !_gameObject.IsBeingConstructed())
             {
                 SpawnInitial();
                 _initial = false;

--- a/src/OpenSage.Game/Logic/Object/Colliders.cs
+++ b/src/OpenSage.Game/Logic/Object/Colliders.cs
@@ -100,7 +100,7 @@ namespace OpenSage.Logic.Object
         {
             WorldBounds = BoundingSphere.Transform(SphereBounds, transform.Matrix);
             var width = SphereBounds.Radius * 2.0f;
-            AxisAlignedBoundingArea = new RectangleF(transform.Translation.Vector2XY(), width, width);
+            AxisAlignedBoundingArea = new RectangleF(transform.Translation.Vector2XY() - new Vector2(SphereBounds.Radius, SphereBounds.Radius), width, width);
             BoundingArea = TransformedRectangle.FromRectangle(AxisAlignedBoundingArea);
         }
 

--- a/src/OpenSage.Game/Logic/Object/Colliders.cs
+++ b/src/OpenSage.Game/Logic/Object/Colliders.cs
@@ -70,6 +70,13 @@ namespace OpenSage.Logic.Object
             Update(transform);
         }
 
+        public SphereCollider(Transform transform, float radius)
+            : base(transform, radius)
+        {
+            SphereBounds = new BoundingSphere(Vector3.Zero, radius);
+            Update(transform);
+        }
+
         protected SphereCollider(Transform transform, float radius, float height)
             : base(transform, height)
         {

--- a/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
@@ -27,7 +27,11 @@ namespace OpenSage.Logic.Object
 
         internal abstract void SetWorldMatrix(in Matrix4x4 worldMatrix);
 
-        internal abstract void BuildRenderList(RenderList renderList, Camera camera, bool castsShadow, MeshShaderResources.RenderItemConstantsPS renderItemConstantsPS);
+        internal abstract void BuildRenderList(RenderList renderList,
+            Camera camera,
+            bool castsShadow,
+            MeshShaderResources.RenderItemConstantsPS renderItemConstantsPS,
+            List<string> hiddenSubObjects = null);
 
         internal abstract (ModelInstance, ModelBone) FindBone(string boneName);
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dDebrisDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dDebrisDraw.cs
@@ -30,10 +30,11 @@ namespace OpenSage.Logic.Object
         public override IEnumerable<BitArray<ModelConditionFlag>> ModelConditionStates { get; } = Array.Empty<BitArray<ModelConditionFlag>>();
 
         internal override void BuildRenderList(
-            RenderList renderList,
-            Camera camera,
-            bool castsShadow,
-            MeshShaderResources.RenderItemConstantsPS renderItemConstantsPS)
+                RenderList renderList,
+                Camera camera,
+                bool castsShadow,
+                MeshShaderResources.RenderItemConstantsPS renderItemConstantsPS,
+                List<string> hiddenSubObjects)
         {
             _modelInstance.BuildRenderList(
                 renderList,

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dDebrisDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dDebrisDraw.cs
@@ -34,13 +34,14 @@ namespace OpenSage.Logic.Object
                 Camera camera,
                 bool castsShadow,
                 MeshShaderResources.RenderItemConstantsPS renderItemConstantsPS,
-                List<string> hiddenSubObjects)
+                List<string> hiddenSubObjects = null)
         {
             _modelInstance.BuildRenderList(
                 renderList,
                 camera,
                 castsShadow,
-                renderItemConstantsPS);
+                renderItemConstantsPS,
+                hiddenSubObjects);
         }
 
         internal override (ModelInstance, ModelBone) FindBone(string boneName)

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dFloorDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dFloorDraw.cs
@@ -30,7 +30,12 @@ namespace OpenSage.Logic.Object
             _modelInstance = AddDisposable(_moduleData.Model.Value.CreateInstance(_gameContext.AssetLoadContext));
         }
 
-        internal override void BuildRenderList(RenderList renderList, Camera camera, bool castsShadow, MeshShaderResources.RenderItemConstantsPS renderItemConstantsPS)
+        internal override void BuildRenderList(
+                RenderList renderList,
+                Camera camera,
+                bool castsShadow,
+                MeshShaderResources.RenderItemConstantsPS renderItemConstantsPS,
+                List<string> hiddenSubObjects = null)
         {
             foreach (var hideFlag in _moduleData.HideIfModelConditions)
             {
@@ -44,7 +49,8 @@ namespace OpenSage.Logic.Object
                 renderList,
                 camera,
                 castsShadow,
-                renderItemConstantsPS);
+                renderItemConstantsPS,
+                hiddenSubObjects);
         }
 
         internal override (ModelInstance, ModelBone) FindBone(string boneName)

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -295,7 +295,6 @@ namespace OpenSage.Logic.Object
                     {
                         modelInstance.BoneVisibilities[item.i] = false;
                     }
-
                 }
             }
             if (conditionState.ShowSubObject != null)
@@ -307,7 +306,6 @@ namespace OpenSage.Logic.Object
                     {
                         modelInstance.BoneVisibilities[item.i] = true;
                     }
-
                 }
             }
 
@@ -344,16 +342,18 @@ namespace OpenSage.Logic.Object
         }
 
         internal override void BuildRenderList(
-            RenderList renderList,
-            Camera camera,
-            bool castsShadow,
-            MeshShaderResources.RenderItemConstantsPS renderItemConstantsPS)
+                RenderList renderList,
+                Camera camera,
+                bool castsShadow,
+                MeshShaderResources.RenderItemConstantsPS renderItemConstantsPS,
+                List<string> hiddenSubObjects = null)
         {
             _activeModelDrawConditionState?.BuildRenderList(
                 renderList,
                 camera,
                 castsShadow,
-                renderItemConstantsPS);
+                renderItemConstantsPS,
+                hiddenSubObjects);
         }
 
         internal override void DrawInspector()
@@ -422,13 +422,15 @@ namespace OpenSage.Logic.Object
             RenderList renderList,
             Camera camera,
             bool castsShadow,
-            MeshShaderResources.RenderItemConstantsPS renderItemConstantsPS)
+            MeshShaderResources.RenderItemConstantsPS renderItemConstantsPS,
+            List<string> hiddenSubObjects = null)
         {
             Model.BuildRenderList(
                 renderList,
                 camera,
                 castsShadow,
-                renderItemConstantsPS);
+                renderItemConstantsPS,
+                hiddenSubObjects);
         }
 
         protected override void Dispose(bool disposeManagedResources)

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTankDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTankDraw.cs
@@ -1,4 +1,5 @@
-﻿using OpenSage.Content;
+﻿using System.Collections.Generic;
+using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.Graphics.ParticleSystems;
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTankDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTankDraw.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using OpenSage.Content;
+﻿using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.Graphics.ParticleSystems;
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTreeDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTreeDraw.cs
@@ -30,13 +30,19 @@ namespace OpenSage.Logic.Object
             //TODO: overwrite texture somehow & take care of other fields
         }
 
-        internal override void BuildRenderList(RenderList renderList, Camera camera, bool castsShadow, MeshShaderResources.RenderItemConstantsPS renderItemConstantsPS)
+        internal override void BuildRenderList(
+                RenderList renderList,
+                Camera camera,
+                bool castsShadow,
+                MeshShaderResources.RenderItemConstantsPS renderItemConstantsPS,
+                List<string> hiddenSubObjects)
         {
             _modelInstance.BuildRenderList(
                 renderList,
                 camera,
                 castsShadow,
-                renderItemConstantsPS);
+                renderItemConstantsPS,
+                hiddenSubObjects);
         }
 
         internal override (ModelInstance, ModelBone) FindBone(string boneName)

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTreeDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTreeDraw.cs
@@ -35,7 +35,7 @@ namespace OpenSage.Logic.Object
                 Camera camera,
                 bool castsShadow,
                 MeshShaderResources.RenderItemConstantsPS renderItemConstantsPS,
-                List<string> hiddenSubObjects)
+                List<string> hiddenSubObjects = null)
         {
             _modelInstance.BuildRenderList(
                 renderList,

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Numerics;
 using OpenSage.Data.Ini;
 using OpenSage.Graphics;

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Numerics;
 using OpenSage.Data.Ini;
 using OpenSage.Graphics;

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -380,6 +380,11 @@ namespace OpenSage.Logic.Object
             Upgrades = new List<UpgradeTemplate>();
             ConflictingUpgrades = new List<UpgradeTemplate>();
 
+            if (Definition.KindOf.Get(ObjectKinds.Structure))
+            {
+                Upgrades.Add(GameContext.AssetLoadContext.AssetStore.Upgrades.GetByName("Upgrade_StructureLevel1"));
+            }
+
             ExperienceMultiplier = 1.0f;
             ExperienceValue = 0;
         }
@@ -461,20 +466,16 @@ namespace OpenSage.Logic.Object
             }
         }
 
-        public bool CanRecruitHero(ObjectDefinition definition, int maxCount)
+        public bool CanRecruitHero(ObjectDefinition definition)
         {
-            var count = 0;
             foreach (var obj in Parent.Items)
             {
                 if (obj.Definition == definition && obj.Owner == Owner)
                 {
-                    if (++count >= maxCount)
-                    {
-                        return false;
-                    }
+                    return false;
                 }
             }
-            return count < maxCount;
+            return true;
         }
 
         public bool CanProduceObject(ObjectDefinition definition)
@@ -584,13 +585,6 @@ namespace OpenSage.Logic.Object
         internal void FinishConstruction()
         {
             ClearModelConditionFlags();
-
-            var spawnBehavior = FindBehavior<SpawnBehavior>();
-            if (spawnBehavior != null)
-            {
-                spawnBehavior.SpawnInitial();
-            }
-
             EnergyProduction += Definition.EnergyProduction;
         }
 
@@ -822,6 +816,7 @@ namespace OpenSage.Logic.Object
         public bool CanConstructUnit(ObjectDefinition objectDefinition)
         {
             return objectDefinition != null
+                && Owner.Money >= objectDefinition.BuildCost
                 && Owner.CanProduceObject(Parent, objectDefinition)
                 && CanProduceObject(objectDefinition);
         }

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -450,16 +450,20 @@ namespace OpenSage.Logic.Object
             }
         }
 
-        public bool CanRecruitHero(ObjectDefinition definition)
+        public bool CanRecruitHero(ObjectDefinition definition, int maxCount)
         {
+            var count = 0;
             foreach (var obj in Parent.Items)
             {
                 if (obj.Definition == definition && obj.Owner == Owner)
                 {
-                    return false;
+                    if (++count >= maxCount)
+                    {
+                        return false;
+                    }
                 }
             }
-            return true;
+            return count < maxCount;
         }
 
         public bool CanProduceObject(ObjectDefinition definition)

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -196,6 +196,8 @@ namespace OpenSage.Logic.Object
 
         public int Supply { get; set; }
 
+        public List<string> HiddenSubObjects;
+
         private string _name;
 
         public string Name
@@ -374,6 +376,7 @@ namespace OpenSage.Logic.Object
                 Supply = Definition.SupplyOverride > 0 ? Definition.SupplyOverride : gameContext.AssetLoadContext.AssetStore.GameData.Current.SupplyBoxesPerTree;
             }
 
+            HiddenSubObjects = new List<string>();
             Upgrades = new List<UpgradeTemplate>();
             ConflictingUpgrades = new List<UpgradeTemplate>();
 
@@ -557,12 +560,7 @@ namespace OpenSage.Logic.Object
 
         public bool ConflictingUpgradeAvailable(UpgradeTemplate upgrade)
         {
-            if (upgrade == null)
-            {
-                return false;
-            }
-
-            if (upgrade.Type == UpgradeType.Player)
+            if (upgrade == null || upgrade.Type == UpgradeType.Player)
             {
                 return false; // TODO: player invalid upgrades?
             }
@@ -699,7 +697,8 @@ namespace OpenSage.Logic.Object
                     renderList,
                     camera,
                     castsShadow,
-                    renderItemConstantsPS);
+                    renderItemConstantsPS,
+                    HiddenSubObjects);
             }
 
             if ((IsSelected || IsPlacementPreview) && _rallyPointMarker != null && RallyPoint != null)

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -132,6 +132,7 @@ namespace OpenSage.Logic.Object
             _gameContext.Quadtree.Update(this);
         }
 
+        public Transform Transform => _transform;
         public float Yaw => _transform.Yaw;
         public Vector3 EulerAngles => _transform.EulerAngles;
         public Vector3 LookDirection => _transform.LookDirection;
@@ -192,6 +193,8 @@ namespace OpenSage.Logic.Object
         public Player Owner { get; internal set; }
 
         public GameObject ParentHorde { get; set; }
+
+        public int Supply { get; set; }
 
         private string _name;
 
@@ -364,6 +367,11 @@ namespace OpenSage.Logic.Object
             if (Definition.KindOf.Get(ObjectKinds.Projectile))
             {
                 IsProjectile = true;
+            }
+
+            if (Definition.KindOf.Get(ObjectKinds.Tree))
+            {
+                Supply = Definition.SupplyOverride > 0 ? Definition.SupplyOverride : gameContext.AssetLoadContext.AssetStore.GameData.Current.SupplyBoxesPerTree;
             }
 
             Upgrades = new List<UpgradeTemplate>();
@@ -579,12 +587,10 @@ namespace OpenSage.Logic.Object
         {
             ClearModelConditionFlags();
 
-            foreach (var behavior in Definition.Behaviors.Values)
+            var spawnBehavior = FindBehavior<SpawnBehavior>();
+            if (spawnBehavior != null)
             {
-                if (behavior is SpawnBehaviorModuleData spawnBehaviorModuleData)
-                {
-                    ProductionUpdate.Spawn(spawnBehaviorModuleData.SpawnTemplate.Value);
-                }
+                spawnBehavior.SpawnInitial();
             }
 
             EnergyProduction += Definition.EnergyProduction;

--- a/src/OpenSage.Game/Logic/Object/LocomotorTemplate.cs
+++ b/src/OpenSage.Game/Logic/Object/LocomotorTemplate.cs
@@ -210,10 +210,10 @@ namespace OpenSage.Logic.Object
         [AddedIn(SageGame.CncGeneralsZeroHour)]
         public float ElevatorCorrectionRate { get; private set; }
 
-        [AddedIn(SageGame.Bfme2)]
+        [AddedIn(SageGame.Bfme)]
         public float SlowTurnRadius { get; private set; }
 
-        [AddedIn(SageGame.Bfme2)]
+        [AddedIn(SageGame.Bfme)]
         public float FastTurnRadius { get; private set; }
 
         [AddedIn(SageGame.Bfme2)]

--- a/src/OpenSage.Game/Logic/Object/ModelConditionFlag.cs
+++ b/src/OpenSage.Game/Logic/Object/ModelConditionFlag.cs
@@ -369,7 +369,7 @@ namespace OpenSage.Logic.Object
         Wander,
 
         [IniEnum("HARVEST_PREPARATION"), AddedIn(SageGame.Bfme)]
-        HarvestPrepariation,
+        HarvestPreparation,
 
         [IniEnum("HARVEST_ACTION"), AddedIn(SageGame.Bfme)]
         HarvestAction,

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -79,6 +79,10 @@ namespace OpenSage.Logic.Object
             {
                 var start = GameObject.Translation;
                 var path = GameObject.GameContext.Navigation.CalculatePath(start, targetPoint, out var endIsPassable);
+                if (path.Count > 0)
+                {
+                    path.RemoveAt(0);
+                }
                 TargetPoints.AddRange(path);
                 if (TargetPoints.Count > 0 && endIsPassable)
                 {

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -13,7 +13,7 @@ namespace OpenSage.Logic.Object
         private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
         private readonly Dictionary<LocomotorSetType, Locomotor> _locomotors;
-        protected Locomotor _currentLocomotor;
+        public Locomotor CurrentLocomotor { get; protected set; }
 
         private readonly AIUpdateModuleData _moduleData;
 
@@ -58,7 +58,7 @@ namespace OpenSage.Logic.Object
                 }
             }
 
-            _currentLocomotor = locomotor;
+            CurrentLocomotor = locomotor;
         }
 
         internal void AddTargetPoint(in Vector3 targetPoint)
@@ -151,7 +151,7 @@ namespace OpenSage.Logic.Object
 
         internal override void Update(BehaviorUpdateContext context)
         {
-            if (_currentLocomotor == null)
+            if (CurrentLocomotor == null)
             {
                 return;
             }
@@ -170,7 +170,7 @@ namespace OpenSage.Logic.Object
                     nextPoint = TargetPoints[1];
                 }
 
-                var reachedPosition = _currentLocomotor.MoveTowardsPosition(context.Time, TargetPoints[0], context.GameContext.Terrain.HeightMap, nextPoint);
+                var reachedPosition = CurrentLocomotor.MoveTowardsPosition(context.Time, TargetPoints[0], context.GameContext.Terrain.HeightMap, nextPoint);
 
                 // this should be moved to LogicTick
                 if (reachedPosition)
@@ -185,7 +185,7 @@ namespace OpenSage.Logic.Object
             }
             else if (_targetDirection.HasValue)
             {
-                if (!_currentLocomotor.RotateToTargetDirection(context.Time, _targetDirection.Value))
+                if (!CurrentLocomotor.RotateToTargetDirection(context.Time, _targetDirection.Value))
                 {
                     return;
                 }
@@ -196,7 +196,7 @@ namespace OpenSage.Logic.Object
             else
             {
                 // maintain position (jets etc)
-                _currentLocomotor.MaintainPosition(context.Time, context.GameContext.Terrain.HeightMap);
+                CurrentLocomotor.MaintainPosition(context.Time, context.GameContext.Terrain.HeightMap);
             }
         }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/JetAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/JetAIUpdate.cs
@@ -169,12 +169,12 @@ namespace OpenSage.Logic.Object
                     base.SetTargetPoint(endPointPosition);
                     AddTargetPoint(_currentTargetPoint);
                     CurrentJetAIState = JetAIState.Starting;
-                    _currentLocomotor.LiftFactor = 0;
+                    CurrentLocomotor.LiftFactor = 0;
                     break;
 
                 case JetAIState.Starting:
-                    var speedPercentage = GameObject.Speed / _currentLocomotor.GetSpeed();
-                    _currentLocomotor.LiftFactor = speedPercentage;
+                    var speedPercentage = GameObject.Speed / CurrentLocomotor.GetSpeed();
+                    CurrentLocomotor.LiftFactor = speedPercentage;
 
                     if (speedPercentage < _moduleData.TakeoffSpeedForMaxLift)
                     {
@@ -187,7 +187,7 @@ namespace OpenSage.Logic.Object
                 case JetAIState.MovingTowardsTarget:
                     if (isMoving)
                     {
-                        if (_afterburnerEnabled && trans.Z - terrainHeight >= _currentLocomotor.GetLocomotorValue(_ => _.PreferredHeight))
+                        if (_afterburnerEnabled && trans.Z - terrainHeight >= CurrentLocomotor.GetLocomotorValue(_ => _.PreferredHeight))
                         {
                             GameObject.ModelConditionFlags.Set(ModelConditionFlag.JetAfterburner, false);
                             _afterburnerEnabled = false;

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyAIUpdate.cs
@@ -86,6 +86,8 @@ namespace OpenSage.Logic.Object
             }
         }
 
+        internal virtual float GetHarvestActivationRange() => 0.0f;
+
         internal virtual bool SupplySourceHasBoxes(BehaviorUpdateContext context, SupplyWarehouseDockUpdate dockUpdate, GameObject supplySource)
         {
             return dockUpdate?.HasBoxes() ?? false;
@@ -159,7 +161,9 @@ namespace OpenSage.Logic.Object
                         break;
                     }
 
-                    SetTargetPoint(_currentSupplySource.Translation);
+                    var direction = Vector3.Normalize(_currentSupplySource.Translation - GameObject.Translation);
+
+                    SetTargetPoint(_currentSupplySource.Translation - direction * GetHarvestActivationRange());
                     SupplyGatherState = SupplyGatherStates.ApproachingSupplySource;
                     break;
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
@@ -37,6 +37,8 @@ namespace OpenSage.Logic.Object
             return supplySources;
         }
 
+        internal override float GetHarvestActivationRange() => _moduleData.HarvestActivationRange;
+
         internal override bool SupplySourceHasBoxes(BehaviorUpdateContext context, SupplyWarehouseDockUpdate dockUpdate, GameObject supplySource)
         {
             if (_moduleData.HarvestTrees && supplySource.Definition.KindOf.Get(ObjectKinds.Tree))
@@ -69,6 +71,7 @@ namespace OpenSage.Logic.Object
                 var nearbyObjects = context.GameContext.Scene3D.Quadtree.FindNearby(GameObject, GameObject.Transform, _moduleData.SupplyWarehouseScanDistance).ToList();
                 supplyCenters.AddRange(nearbyObjects.Where(x => x.Definition.KindOf.Get(ObjectKinds.SupplyGatheringCenter)).ToList());
             }
+
             return supplyCenters;
         }
 
@@ -76,30 +79,25 @@ namespace OpenSage.Logic.Object
         {
             base.Update(context);
 
-            //if (!(_moduleData.HarvestTrees && _currentSupplySource.Definition.KindOf.Get(ObjectKinds.Tree)))
-            //{
-            //    return;
-            //}
+            if (!(_moduleData.HarvestTrees
+                && _currentSupplySource != null
+                && _currentSupplySource.Definition.KindOf.Get(ObjectKinds.Tree)))
+            {
+                return;
+            }
 
-            //switch (SupplyGatherState)
-            //{
-            //    case SupplyGatherStates.ApproachingSupplySource:
-            //        if ((_currentSupplySource.Translation - GameObject.Translation).Length() < _moduleData.HarvestActivationRange)
-            //        {
-            //            GameObject.ModelConditionFlags.Set(ModelConditionFlag.HarvestPrepariation, true);
-            //        }
-            //        break;
+            switch (SupplyGatherState)
+            {
+                case SupplyGatherStates.GatheringSupplies:
+                    if (context.Time.TotalTime > _waitUntil)
+                    {
+                        _numBoxes++;
+                        SupplyGatherState = SupplyGatherStates.RequestingSupplies;
+                    }
 
-            //    case SupplyGatherStates.GatheringSupplies:
-            //        if (context.Time.TotalTime > _waitUntil)
-            //        {
-            //            _numBoxes++;
-            //            SupplyGatherState = SupplyGatherStates.RequestingSupplies;
-            //        }
-
-            //        GameObject.ModelConditionFlags.Set(ModelConditionFlag.HarvestAction, true);
-            //        break;
-            //}
+                    GameObject.ModelConditionFlags.Set(ModelConditionFlag.HarvestAction, true);
+                    break;
+            }
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
@@ -9,7 +9,6 @@ namespace OpenSage.Logic.Object
     //ValuePerSupplyBox = 5
     //SupplyBoxesPerTree = 90
 
-
     public class WorkerAIUpdate : SupplyAIUpdate
     {
         private WorkerAIUpdateModuleData _moduleData;
@@ -29,28 +28,48 @@ namespace OpenSage.Logic.Object
 
         internal override List<GameObject> GetNearbySupplySources(BehaviorUpdateContext context)
         {
-            var trees = context.GameContext.GameObjects.GetObjectsByKindOf(ObjectKinds.Tree);
-            return trees.Where(x => x.Definition.IsHarvestable == true).ToList();
+            var supplySources = base.GetNearbySupplySources(context);
+            if (_moduleData.HarvestTrees)
+            {
+                var nearbyObjects = context.GameContext.Scene3D.Quadtree.FindNearby(GameObject, GameObject.Transform, _moduleData.SupplyWarehouseScanDistance);
+                supplySources.AddRange(nearbyObjects.Where(x => x.Definition.KindOf.Get(ObjectKinds.Tree) && x.Definition.IsHarvestable).ToList());
+            }
+            return supplySources;
         }
 
         internal override bool SupplySourceHasBoxes(BehaviorUpdateContext context, SupplyWarehouseDockUpdate dockUpdate, GameObject supplySource)
         {
-            var val = supplySource.Supply > 0;
-            if (!val)
+            if (_moduleData.HarvestTrees && supplySource.Definition.KindOf.Get(ObjectKinds.Tree))
             {
+                if (supplySource.Supply > 0)
+                {
+                    return true;
+                }
                 supplySource.Die(DeathType.Normal, context.Time);
+                return false;
             }
-            return val;
+            return base.SupplySourceHasBoxes(context, dockUpdate, supplySource);
         }
 
         internal override void GetBox(BehaviorUpdateContext context)
         {
-            _currentSupplySource.Supply -= context.GameContext.AssetLoadContext.AssetStore.GameData.Current.ValuePerSupplyBox;
+            if (_moduleData.HarvestTrees && _currentSupplySource.Definition.KindOf.Get(ObjectKinds.Tree))
+            {
+                _currentSupplySource.Supply -= context.GameContext.AssetLoadContext.AssetStore.GameData.Current.ValuePerSupplyBox;
+                return;
+            }
+            base.GetBox(context);
         }
 
         internal override List<GameObject> GetNearbySupplyCenters(BehaviorUpdateContext context)
         {
-            return context.GameContext.GameObjects.GetObjectsByKindOf(ObjectKinds.SupplyGatheringCenter);
+            var supplyCenters = base.GetNearbySupplyCenters(context);
+            if (_moduleData.HarvestTrees)
+            {
+                var nearbyObjects = context.GameContext.Scene3D.Quadtree.FindNearby(GameObject, GameObject.Transform, _moduleData.SupplyWarehouseScanDistance).ToList();
+                supplyCenters.AddRange(nearbyObjects.Where(x => x.Definition.KindOf.Get(ObjectKinds.SupplyGatheringCenter)).ToList());
+            }
+            return supplyCenters;
         }
 
         internal override void Update(BehaviorUpdateContext context)

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
@@ -16,7 +16,7 @@ namespace OpenSage.Logic.Object
         internal WorkerAIUpdate(GameObject gameObject, WorkerAIUpdateModuleData moduleData) : base(gameObject, moduleData)
         {
             _moduleData = moduleData;
-            base.SupplyGatherState = SupplyGatherStates.SearchForSupplySource;
+            base.SupplyGatherState = SupplyGatherStates.SearchingForSupplySource;
         }
 
         protected override int GetAdditionalValuePerSupplyBox(ScopedAssetCollection<UpgradeTemplate> upgrades)
@@ -75,6 +75,31 @@ namespace OpenSage.Logic.Object
         internal override void Update(BehaviorUpdateContext context)
         {
             base.Update(context);
+
+            //if (!(_moduleData.HarvestTrees && _currentSupplySource.Definition.KindOf.Get(ObjectKinds.Tree)))
+            //{
+            //    return;
+            //}
+
+            //switch (SupplyGatherState)
+            //{
+            //    case SupplyGatherStates.ApproachingSupplySource:
+            //        if ((_currentSupplySource.Translation - GameObject.Translation).Length() < _moduleData.HarvestActivationRange)
+            //        {
+            //            GameObject.ModelConditionFlags.Set(ModelConditionFlag.HarvestPrepariation, true);
+            //        }
+            //        break;
+
+            //    case SupplyGatherStates.GatheringSupplies:
+            //        if (context.Time.TotalTime > _waitUntil)
+            //        {
+            //            _numBoxes++;
+            //            SupplyGatherState = SupplyGatherStates.RequestingSupplies;
+            //        }
+
+            //        GameObject.ModelConditionFlags.Set(ModelConditionFlag.HarvestAction, true);
+            //        break;
+            //}
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/DockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DockUpdate.cs
@@ -67,7 +67,7 @@ namespace OpenSage.Logic.Object
             for (var i = 0; i < units.Count; i++)
             {
                 var aiUpdate = units[i];
-                aiUpdate.SupplyGatherState = SupplyAIUpdate.SupplyGatherStates.ApproachSupplyTarget;
+                aiUpdate.SupplyGatherState = SupplyAIUpdate.SupplyGatherStates.ApproachingSupplyTarget;
 
                 if (i == 0)
                 {
@@ -98,7 +98,7 @@ namespace OpenSage.Logic.Object
                         break;
                     case SupplyAIUpdate.SupplyGatherStates.FinishedDumpingSupplies:
                         _gameObject.ModelConditionFlags.Set(ModelConditionFlag.DockingActive, true);
-                        aiUpdate.SupplyGatherState = SupplyAIUpdate.SupplyGatherStates.SearchForSupplySource;
+                        aiUpdate.SupplyGatherState = SupplyAIUpdate.SupplyGatherStates.SearchingForSupplySource;
                         _unitsApproaching.Dequeue();
                         MoveObjectsForward();
                         break;

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -304,6 +304,7 @@ namespace OpenSage.Logic.Object
             }
 
             _producedUnit = _gameObject.Parent.Add(objectDefinition, _gameObject.Owner);
+            _producedUnit.Owner = _gameObject.Owner;
             _producedUnit.ParentHorde = ParentHorde;
 
             var isHorde = _producedUnit.Definition.KindOf.Get(ObjectKinds.Horde);

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -400,7 +400,7 @@ namespace OpenSage.Logic.Object
                 return;
             }
 
-            supplyUpdate.SupplyGatherState = SupplyAIUpdate.SupplyGatherStates.SearchForSupplySource;
+            supplyUpdate.SupplyGatherState = SupplyAIUpdate.SupplyGatherStates.SearchingForSupplySource;
             supplyUpdate.CurrentSupplyTarget = _gameObject;
         }
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/GeometryUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/GeometryUpgrade.cs
@@ -3,6 +3,30 @@
 namespace OpenSage.Logic.Object
 {
     [AddedIn(SageGame.Bfme)]
+    public class GeometryUpgrade : UpgradeModule
+    {
+        private readonly GeometryUpgradeModuleData _moduleData;
+
+        internal GeometryUpgrade(GameObject gameObject, GeometryUpgradeModuleData moduleData) : base(gameObject, moduleData)
+        {
+            _moduleData = moduleData;
+        }
+
+        internal override void OnTrigger(BehaviorUpdateContext context, bool triggered)
+        {
+            // TODO:
+            //foreach (var showGeometry in _moduleData.ShowGeometry)
+            //{
+
+            //}
+            //foreach (var hideGeometry in _moduleData.HideGeometry)
+            //{
+
+            //}
+        }
+    }
+
+
     public sealed class GeometryUpgradeModuleData : UpgradeModuleData
     {
         internal static GeometryUpgradeModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -10,17 +34,22 @@ namespace OpenSage.Logic.Object
         private static new readonly IniParseTable<GeometryUpgradeModuleData> FieldParseTable = UpgradeModuleData.FieldParseTable
             .Concat(new IniParseTable<GeometryUpgradeModuleData>
             {
-                { "ShowGeometry", (parser, x) => x.ShowGeometry = parser.ParseAssetReference() },
-                { "HideGeometry", (parser, x) => x.HideGeometry = parser.ParseAssetReference() },
+                { "ShowGeometry", (parser, x) => x.ShowGeometry = parser.ParseAssetReferenceArray() },
+                { "HideGeometry", (parser, x) => x.HideGeometry = parser.ParseAssetReferenceArray() },
                 { "WallBoundsMesh", (parser,x) => x.WallBoundsMesh = parser.ParseAssetReference() },
                 { "RampMesh1", (parser, x) => x.RampMesh1 = parser.ParseAssetReference() },
                 { "RampMesh2", (parser, x) => x.RampMesh2 = parser.ParseAssetReference() },
             });
 
-        public string ShowGeometry { get; private set; }
-        public string HideGeometry { get; private set; }
+        public string[] ShowGeometry { get; private set; }
+        public string[] HideGeometry { get; private set; }
         public string WallBoundsMesh { get; private set; }
         public string RampMesh1 { get; private set; }
         public string RampMesh2 { get; private set; }
+
+        internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+        {
+            return new GeometryUpgrade(gameObject, this);
+        }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/SubObjectsUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/SubObjectsUpgrade.cs
@@ -6,6 +6,36 @@ namespace OpenSage.Logic.Object
     /// <summary>
     /// Shows/hides sub-objects on this object's model via upgrading.
     /// </summary>
+    public class SubObjectsUpgrade : UpgradeModule
+    {
+        private readonly SubObjectsUpgradeModuleData _moduleData;
+
+        internal SubObjectsUpgrade(GameObject gameObject, SubObjectsUpgradeModuleData moduleData) : base(gameObject, moduleData)
+        {
+            _moduleData = moduleData;
+        }
+
+        internal override void OnTrigger(BehaviorUpdateContext context, bool triggered)
+        {
+            if (_moduleData.ShowSubObjects != null)
+            {
+                foreach (var showSubObject in _moduleData.ShowSubObjects)
+                {
+                    _gameObject.HiddenSubObjects.Remove(showSubObject);
+                }
+            }
+
+            if (_moduleData.HideSubObjects != null)
+            {
+                foreach (var hideSubObject in _moduleData.HideSubObjects)
+                {
+                    _gameObject.HiddenSubObjects.Add(hideSubObject);
+                }
+            }
+        }
+    }
+
+
     public sealed class SubObjectsUpgradeModuleData : UpgradeModuleData
     {
         internal static SubObjectsUpgradeModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -51,5 +81,10 @@ namespace OpenSage.Logic.Object
 
         [AddedIn(SageGame.Bfme2)]
         public bool HideSubObjectsOnRemove { get; private set; }
+
+        internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+        {
+            return new SubObjectsUpgrade(gameObject, this);
+        }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
@@ -2,7 +2,6 @@
 using ImGuiNET;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
-using OpenSage.Diagnostics.Util;
 using OpenSage.FileFormats;
 
 namespace OpenSage.Logic.Object

--- a/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
@@ -24,22 +24,34 @@ namespace OpenSage.Logic.Object
 
         private bool AnyUpgradeAvailable(LazyAssetReference<UpgradeTemplate>[] upgrades)
         {
-            if (upgrades == null) return true;
+            if (upgrades == null)
+            {
+                return false;
+            }
 
             foreach (var trigger in upgrades)
             {
-                if (_gameObject.UpgradeAvailable(trigger.Value)) return true;
+                if (_gameObject.UpgradeAvailable(trigger.Value))
+                {
+                    return true;
+                }
             }
             return false;
         }
 
         private bool AllUpgradesAvailable(LazyAssetReference<UpgradeTemplate>[] upgrades)
         {
-            if (upgrades == null) return true;
+            if (upgrades == null)
+            {
+                return true;
+            }
 
             foreach (var trigger in upgrades)
             {
-                if (_gameObject.UpgradeAvailable(trigger.Value) == false) return false;
+                if (_gameObject.UpgradeAvailable(trigger.Value) == false)
+                {
+                    return false;
+                }
             }
             return true;
         }
@@ -48,9 +60,13 @@ namespace OpenSage.Logic.Object
         {
             var triggered = _moduleData.RequiresAllTriggers ? AllUpgradesAvailable(_moduleData.TriggeredBy) : AnyUpgradeAvailable(_moduleData.TriggeredBy);
             var conflicts = _moduleData.RequiresAllConflictingTriggers ? AllUpgradesAvailable(_moduleData.ConflictsWith) : AnyUpgradeAvailable(_moduleData.ConflictsWith);
-            if (conflicts) triggered = false;
+            if (conflicts)
+            {
+                triggered = false;
+            }
 
-            if (triggered != _triggered || _initial)
+            // what objects do use initial here?
+            if (triggered != _triggered)
             {
                 _initial = false;
                 _triggered = triggered;

--- a/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
@@ -56,7 +56,7 @@ namespace OpenSage.Logic.Orders
                             player.SpendMoney((uint) objectDefinition.BuildCost);
 
                             var gameObject = _game.Scene3D.GameObjects.Add(objectDefinition, player);
-
+                            gameObject.Owner = player;
                             gameObject.UpdateTransform(position, Quaternion.CreateFromAxisAngle(Vector3.UnitZ, angle));
                             gameObject.StartConstruction(_game.MapTime);
                         }

--- a/src/OpenSage.Mathematics/Rectangle.cs
+++ b/src/OpenSage.Mathematics/Rectangle.cs
@@ -43,29 +43,28 @@ namespace OpenSage.Mathematics
             Height = (int) Math.Round(rect.Height);
         }
 
-        public bool Intersects(in Rectangle value)
-        {
-            return value.Left < Right &&
-                Left < value.Right &&
-                value.Top < Bottom &&
-                Top < value.Bottom;
-        }
+        // TODO: remove this?
+        //public bool Intersects(in Rectangle value)
+        //{
+        //    return value.Left < Right &&
+        //        Left < value.Right &&
+        //        value.Top < Bottom &&
+        //        Top < value.Bottom;
+        //}
 
-        public static Rectangle Intersect(in Rectangle value1, in Rectangle value2)
-        {
-            if (value1.Intersects(value2))
-            {
-                var rightSide = Math.Min(value1.X + value1.Width, value2.X + value2.Width);
-                var leftSide = Math.Max(value1.X, value2.X);
-                var topSide = Math.Max(value1.Y, value2.Y);
-                var bottomSize = Math.Min(value1.Y + value1.Height, value2.Y + value2.Height);
-                return new Rectangle(leftSide, topSide, rightSide - leftSide, bottomSize - topSide);
-            }
-            else
-            {
-                return new Rectangle(0, 0, 0, 0);
-            }
-        }
+        
+        //public static Rectangle Intersect(in Rectangle value1, in Rectangle value2)
+        //{
+        //    if (value1.Intersects(value2))
+        //    {
+        //        var rightSide = Math.Min(value1.X + value1.Width, value2.X + value2.Width);
+        //        var leftSide = Math.Max(value1.X, value2.X);
+        //        var topSide = Math.Max(value1.Y, value2.Y);
+        //        var bottomSize = Math.Min(value1.Y + value1.Height, value2.Y + value2.Height);
+        //        return new Rectangle(leftSide, topSide, rightSide - leftSide, bottomSize - topSide);
+        //    }
+        //    return new Rectangle(0, 0, 0, 0);
+        //}
 
         public static Rectangle FromCorners(in Point2D topLeft, in Point2D bottomRight)
         {
@@ -80,15 +79,9 @@ namespace OpenSage.Mathematics
                 && point.Y <= Bottom;
         }
 
-        public Rectangle WithLocation(in Point2D location)
-        {
-            return new Rectangle(location, Size);
-        }
+        public Rectangle WithLocation(in Point2D location) => new Rectangle(location, Size);
 
-        public RectangleF ToRectangleF()
-        {
-            return new RectangleF(X, Y, Width, Height);
-        }
+        public RectangleF ToRectangleF() => new RectangleF(X, Y, Width, Height);
 
         public override bool Equals(object obj)
         {

--- a/src/OpenSage.Mods.Bfme/Gui/RadialUnitOverlay.cs
+++ b/src/OpenSage.Mods.Bfme/Gui/RadialUnitOverlay.cs
@@ -41,7 +41,8 @@ namespace OpenSage.Mods.Bfme.Gui
             }
 
             var selectedUnit = player.SelectedUnits.First();
-            if (selectedUnit.BuildProgress < 0.999f
+            if (selectedUnit.Owner != player
+                || selectedUnit.BuildProgress < 0.999f
                 || !selectedUnit.Definition.KindOf.Get(ObjectKinds.Structure)
                 || selectedUnit.Definition.CommandSet == null)
             {

--- a/src/OpenSage.Mods.Bfme/Gui/RadialUnitOverlay.cs
+++ b/src/OpenSage.Mods.Bfme/Gui/RadialUnitOverlay.cs
@@ -49,6 +49,7 @@ namespace OpenSage.Mods.Bfme.Gui
                 return;
             }
 
+            var playerTemplate = selectedUnit.Owner.Template;
             _visible = true;
 
             var screenPosition = _game.Scene3D.Camera.WorldToScreenPoint(selectedUnit.Collider.WorldBounds.Center);
@@ -58,7 +59,6 @@ namespace OpenSage.Mods.Bfme.Gui
             if (_selectedUnit != selectedUnit && _commandSet != null)
             {
                 //Update button list
-                var playerTeamplate = selectedUnit.Owner.Template;
                 var heroIndex = 0;
 
                 var commandButtons = new List<CommandButton>();
@@ -66,9 +66,9 @@ namespace OpenSage.Mods.Bfme.Gui
                 {
                     if (button.Value.Command == CommandType.Revive)
                     {
-                        if (heroIndex < playerTeamplate.BuildableHeroesMP.Count())
+                        if (heroIndex < playerTemplate.BuildableHeroesMP.Count())
                         {
-                            var heroDefinition = playerTeamplate.BuildableHeroesMP[heroIndex++];
+                            var heroDefinition = playerTemplate.BuildableHeroesMP[heroIndex++];
                             commandButtons.Add(new CommandButton(CommandType.UnitBuild, heroDefinition));
                         }
                     }
@@ -95,7 +95,12 @@ namespace OpenSage.Mods.Bfme.Gui
                 radialButton.IsVisible = true;
                 if (radialButton.IsRecruitHeroButton)
                 {
-                    radialButton.IsVisible = selectedUnit.CanRecruitHero(radialButton.CommandButton.Object.Value);
+                    var definition = radialButton.CommandButton.Object.Value;
+                    var maxSimultaneous = definition.MaxSimultaneousOfType.ExplicitCount;
+                    var maxCount = maxSimultaneous > 0
+                        ? maxSimultaneous
+                        : playerTemplate.BuildableHeroesMP.Where(x => x.Value == definition).Count();
+                    radialButton.IsVisible = selectedUnit.CanRecruitHero(definition, maxCount);
                 }
 
                 var (count, progress) = isProducing ? selectedUnit.ProductionUpdate.GetCountAndProgress(radialButton.CommandButton) : (0, 0.0f);

--- a/src/OpenSage.Mods.Bfme/Gui/RadialUnitOverlay.cs
+++ b/src/OpenSage.Mods.Bfme/Gui/RadialUnitOverlay.cs
@@ -42,7 +42,7 @@ namespace OpenSage.Mods.Bfme.Gui
 
             var selectedUnit = player.SelectedUnits.First();
             if (selectedUnit.Owner != player
-                || selectedUnit.BuildProgress < 0.999f
+                || selectedUnit.IsBeingConstructed()
                 || !selectedUnit.Definition.KindOf.Get(ObjectKinds.Structure)
                 || selectedUnit.Definition.CommandSet == null)
             {
@@ -97,11 +97,7 @@ namespace OpenSage.Mods.Bfme.Gui
                 if (radialButton.IsRecruitHeroButton)
                 {
                     var definition = radialButton.CommandButton.Object.Value;
-                    var maxSimultaneous = definition.MaxSimultaneousOfType.ExplicitCount;
-                    var maxCount = maxSimultaneous > 0
-                        ? maxSimultaneous
-                        : playerTemplate.BuildableHeroesMP.Where(x => x.Value == definition).Count();
-                    radialButton.IsVisible = selectedUnit.CanRecruitHero(definition, maxCount);
+                    radialButton.IsVisible = selectedUnit.CanRecruitHero(definition);
                 }
 
                 var (count, progress) = isProducing ? selectedUnit.ProductionUpdate.GetCountAndProgress(radialButton.CommandButton) : (0, 0.0f);


### PR DESCRIPTION
*  [x] fix quadtree "findNearby"
* [x] spawn initial units based on SpawnUpdate
* [x] show and hide SubObjects based on SubObjectUpgrade
* [x] scan for nearby units in CastleBehavior and unpack respective building
* [x] fix lumbermill worker ressource gathering