### PR TITLE
Bfme upgrades

### DIFF
--- a/src/OpenSage.Game/Content/ContentManager.cs
+++ b/src/OpenSage.Game/Content/ContentManager.cs
@@ -93,6 +93,8 @@ namespace OpenSage.Content
                         SubsystemLoader.Load(Subsystem.Damage);
                         SubsystemLoader.Load(Subsystem.SpecialPower);
                         SubsystemLoader.Load(Subsystem.InGameUI);
+                        SubsystemLoader.Load(Subsystem.ExperienceLevels);
+                        SubsystemLoader.Load(Subsystem.AttributeModifiers);
                         break;
 
                     case SageGame.Cnc3:

--- a/src/OpenSage.Game/Content/ContentManager.cs
+++ b/src/OpenSage.Game/Content/ContentManager.cs
@@ -4,7 +4,6 @@ using OpenSage.Content.Translation;
 using OpenSage.Data;
 using OpenSage.Data.Ini;
 using OpenSage.Diagnostics;
-using OpenSage.Gui.Wnd.Images;
 using OpenSage.Utilities;
 using Veldrid;
 
@@ -70,14 +69,10 @@ namespace OpenSage.Content
                 switch (sageGame)
                 {
                     // Only load these INI files for a subset of games, because we can't parse them for others yet.
+                    // TODO: Defer subsystem loading until necessary
                     case SageGame.CncGenerals:
                     case SageGame.CncGeneralsZeroHour:
-                    case SageGame.Bfme:
-                    case SageGame.Bfme2:
-                    case SageGame.Bfme2Rotwk:
                         SubsystemLoader.Load(Subsystem.Core);
-
-                        // TODO: Defer subsystem loading until necessary
                         SubsystemLoader.Load(Subsystem.Audio);
                         SubsystemLoader.Load(Subsystem.Players);
                         SubsystemLoader.Load(Subsystem.ParticleSystems);
@@ -93,6 +88,28 @@ namespace OpenSage.Content
                         SubsystemLoader.Load(Subsystem.Damage);
                         SubsystemLoader.Load(Subsystem.SpecialPower);
                         SubsystemLoader.Load(Subsystem.InGameUI);
+                        break;
+
+                    case SageGame.Bfme:
+                    case SageGame.Bfme2:
+                    case SageGame.Bfme2Rotwk:
+                        SubsystemLoader.Load(Subsystem.Core);
+                        SubsystemLoader.Load(Subsystem.Audio);
+                        SubsystemLoader.Load(Subsystem.Players);
+                        SubsystemLoader.Load(Subsystem.ParticleSystems);
+                        SubsystemLoader.Load(Subsystem.ObjectCreation);
+                        SubsystemLoader.Load(Subsystem.Locomotors);
+                        SubsystemLoader.Load(Subsystem.Weapons);
+                        SubsystemLoader.Load(Subsystem.FXList);
+                        SubsystemLoader.Load(Subsystem.Multiplayer);
+                        SubsystemLoader.Load(Subsystem.LinearCampaign);
+                        SubsystemLoader.Load(Subsystem.Wnd);
+                        SubsystemLoader.Load(Subsystem.Terrain);
+                        SubsystemLoader.Load(Subsystem.Credits);
+                        SubsystemLoader.Load(Subsystem.Damage);
+                        SubsystemLoader.Load(Subsystem.SpecialPower);
+                        SubsystemLoader.Load(Subsystem.InGameUI);
+
                         SubsystemLoader.Load(Subsystem.ExperienceLevels);
                         SubsystemLoader.Load(Subsystem.AttributeModifiers);
                         break;

--- a/src/OpenSage.Game/Content/SubsystemLoader.cs
+++ b/src/OpenSage.Game/Content/SubsystemLoader.cs
@@ -190,6 +190,7 @@ namespace OpenSage.Content
                         case SageGame.Bfme:
                         case SageGame.Bfme2:
                         case SageGame.Bfme2Rotwk:
+                            _contentManager.LoadIniFile(@"Data\INI\Attributemodifier.ini");
                             _contentManager.LoadIniFile(@"Data\INI\Experiencelevels.ini");
                             break;
                     }

--- a/src/OpenSage.Game/Content/SubsystemLoader.cs
+++ b/src/OpenSage.Game/Content/SubsystemLoader.cs
@@ -108,6 +108,9 @@ namespace OpenSage.Content
                 case Subsystem.InGameUI:
                     LoadFiles(@"Data\INI\InGameUI.ini");
                     break;
+                case Subsystem.AttributeModifiers:
+                case Subsystem.ExperienceLevels:
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(subsystem), subsystem, null);
             }

--- a/src/OpenSage.Game/Content/SubsystemLoader.cs
+++ b/src/OpenSage.Game/Content/SubsystemLoader.cs
@@ -184,18 +184,6 @@ namespace OpenSage.Content
                     }
                     break;
 
-                case Subsystem.ObjectCreation:
-                    switch (_gameDefinition.Game)
-                    {
-                        case SageGame.Bfme:
-                        case SageGame.Bfme2:
-                        case SageGame.Bfme2Rotwk:
-                            _contentManager.LoadIniFile(@"Data\INI\Attributemodifier.ini");
-                            _contentManager.LoadIniFile(@"Data\INI\Experiencelevels.ini");
-                            break;
-                    }
-                    break;
-
                 case Subsystem.Players:
                     switch (_gameDefinition.Game)
                     {
@@ -385,6 +373,12 @@ namespace OpenSage.Content
                     yield break;
                 case Subsystem.InGameUI:
                     yield return "InGameUI";
+                    yield break;
+                case Subsystem.ExperienceLevels:
+                    yield return "TheExperienceLevelSystem";
+                    yield break;
+                case Subsystem.AttributeModifiers:
+                    yield return "TheAttributeModifierStore";
                     yield break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(subsystem), subsystem, null);

--- a/src/OpenSage.Game/Content/SubsystemLoader.cs
+++ b/src/OpenSage.Game/Content/SubsystemLoader.cs
@@ -108,9 +108,6 @@ namespace OpenSage.Content
                 case Subsystem.InGameUI:
                     LoadFiles(@"Data\INI\InGameUI.ini");
                     break;
-                case Subsystem.AttributeModifiers:
-                case Subsystem.ExperienceLevels:
-                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(subsystem), subsystem, null);
             }

--- a/src/OpenSage.Game/Data/Ini/IniParser.cs
+++ b/src/OpenSage.Game/Data/Ini/IniParser.cs
@@ -384,9 +384,12 @@ namespace OpenSage.Data.Ini
             return result.ToArray();
         }
 
-        private float ScanPercentage(in IniToken token) => ScanFloat(token);
+        private float ScanPercentage(in IniToken token)
+        {
+            return token.Text.Contains('.') ? ScanFloat(token) : ScanFloat(token) / 100.0f;
+        }
 
-        public Percentage ParsePercentage() => new Percentage(ScanPercentage(GetNextToken(SeparatorsPercent)) / 100.0f);
+        public Percentage ParsePercentage() => new Percentage(ScanPercentage(GetNextToken(SeparatorsPercent)));
 
         private bool ScanBoolean(in IniToken token)
         {
@@ -533,6 +536,18 @@ namespace OpenSage.Data.Ini
                 var name = token.Value.Text;
                 if (!name.Contains('.')) name = ((ModelConditionState)Temp).Skeleton + "." + name;
                 result.Add(_assetStore.ModelAnimations.GetLazyAssetReferenceByName(name));
+            }
+
+            return result.ToArray();
+        }
+
+        public LazyAssetReference<ModifierList>[] ParseModifierListReferenceArray()
+        {
+            var result = new List<LazyAssetReference<ModifierList>>();
+            IniToken? token;
+            while ((token = GetNextTokenOptional()).HasValue)
+            {
+                result.Add(_assetStore.ModifierLists.GetLazyAssetReferenceByName(token.Value.Text));
             }
 
             return result.ToArray();

--- a/src/OpenSage.Game/Data/Ini/IniParser.cs
+++ b/src/OpenSage.Game/Data/Ini/IniParser.cs
@@ -507,7 +507,7 @@ namespace OpenSage.Data.Ini
 
         public LazyAssetReference<FXList> ParseFXListReference()
         {
-            var name = ParseAssetReference();
+            var name = ParseAssetReference().Replace("FX:", "");
             return (!string.Equals(name, "NONE", StringComparison.OrdinalIgnoreCase))
                 ? _assetStore.FXLists.GetLazyAssetReferenceByName(name)
                 : null;
@@ -525,6 +525,12 @@ namespace OpenSage.Data.Ini
             return (!string.Equals(name, "NONE", StringComparison.OrdinalIgnoreCase))
                 ? _assetStore.ObjectCreationLists.GetLazyAssetReferenceByName(name)
                 : null;
+        }
+
+        public LazyAssetReference<ModifierList> ParseModifierListReference()
+        {
+            var name = ParseAssetReference();
+            return _assetStore.ModifierLists.GetLazyAssetReferenceByName(name);
         }
 
         public LazyAssetReference<Graphics.Animation.W3DAnimation>[] ParseAnimationReferenceArray()

--- a/src/OpenSage.Game/DataStructures/Quadtree.cs
+++ b/src/OpenSage.Game/DataStructures/Quadtree.cs
@@ -67,6 +67,8 @@ namespace OpenSage.DataStructures
 
         public IEnumerable<T> FindIntersecting(in RectangleF bounds) => FindIntersecting(new BoxCollider(bounds));
 
+        public IEnumerable<T> FindIntersecting(T searcher) => FindIntersectingInternal(searcher.Collider, searcher);
+
         public IEnumerable<T> FindIntersecting(in Collider collider, T searcher = null)
         {
             return !collider.Intersects(Bounds) ? Enumerable.Empty<T>() : FindIntersectingInternal(collider, searcher);

--- a/src/OpenSage.Game/Diagnostics/MainView.cs
+++ b/src/OpenSage.Game/Diagnostics/MainView.cs
@@ -140,8 +140,8 @@ namespace OpenSage.Diagnostics
                                 var playableSides = _context.Game.GetPlayableSides().ToList();
                                 //var faction1 = playableSides[random.Next(0, playableSides.Count())];
                                 //var faction2 = playableSides[random.Next(0, playableSides.Count())];
-                                var faction1 = playableSides[1];
-                                var faction2 = playableSides[1];
+                                var faction1 = playableSides[0];
+                                var faction2 = playableSides[0];
 
                                 if (mapCache.Key.IsMultiplayer)
                                 {

--- a/src/OpenSage.Game/Diagnostics/MainView.cs
+++ b/src/OpenSage.Game/Diagnostics/MainView.cs
@@ -140,8 +140,8 @@ namespace OpenSage.Diagnostics
                                 var playableSides = _context.Game.GetPlayableSides().ToList();
                                 //var faction1 = playableSides[random.Next(0, playableSides.Count())];
                                 //var faction2 = playableSides[random.Next(0, playableSides.Count())];
-                                var faction1 = playableSides[3];
-                                var faction2 = playableSides[3];
+                                var faction1 = playableSides[1];
+                                var faction2 = playableSides[1];
 
                                 if (mapCache.Key.IsMultiplayer)
                                 {

--- a/src/OpenSage.Game/Graphics/Animation/AnimationInstance.cs
+++ b/src/OpenSage.Game/Graphics/Animation/AnimationInstance.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Numerics;
 using OpenSage.Logic.Object;
 using OpenSage.Mathematics;
@@ -33,7 +32,7 @@ namespace OpenSage.Graphics.Animation
             _animation = animation;
             _mode = mode;
             _flags = flags;
-            _boneInstances = modelInstance.ModelBoneInstances.ToList().ToArray();
+            _boneInstances = modelInstance.ModelBoneInstances;
 
             _keyframeIndices = new int[animation.Clips.Length];
         }

--- a/src/OpenSage.Game/Graphics/Animation/AnimationInstance.cs
+++ b/src/OpenSage.Game/Graphics/Animation/AnimationInstance.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Numerics;
 using OpenSage.Logic.Object;
 using OpenSage.Mathematics;
@@ -32,7 +33,7 @@ namespace OpenSage.Graphics.Animation
             _animation = animation;
             _mode = mode;
             _flags = flags;
-            _boneInstances = modelInstance.ModelBoneInstances;
+            _boneInstances = modelInstance.ModelBoneInstances.ToList().ToArray();
 
             _keyframeIndices = new int[animation.Clips.Length];
         }

--- a/src/OpenSage.Game/Gui/Apt/SpriteItem.cs
+++ b/src/OpenSage.Game/Gui/Apt/SpriteItem.cs
@@ -155,18 +155,18 @@ namespace OpenSage.Gui.Apt
             State = PlayState.PLAYING;
         }
 
-        private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+        private static NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
         public void Goto(string label)
         {
-            logger.Info($"Goto: {label}");
+            Logger.Info($"Goto: {label}");
             if (FrameLabels.ContainsKey(label))
             {
                 _currentFrame = FrameLabels[label];
             }
             else
             {
-                logger.Warn($"Missing framelabel: {label}");
+                Logger.Warn($"Missing framelabel: {label}");
             }
         }
 

--- a/src/OpenSage.Game/Gui/CommandButtonCallback.cs
+++ b/src/OpenSage.Game/Gui/CommandButtonCallback.cs
@@ -21,11 +21,13 @@ namespace OpenSage.Gui
             switch (commandButton.Command)
             {
                 case CommandType.CastleUnpack:
+                    //TODO: proper castleUnpack order & spend money of the player
                     var castleBehavior = selectedObject.FindBehavior<CastleBehavior>();
                     castleBehavior.Unpack(selectedObject.Owner);
                     game.Scene3D.LocalPlayer.DeselectUnits();
                     break;
 
+                case CommandType.CastleUnpackExplicitObject:
                 case CommandType.FoundationConstruct:
                     //TODO: figure this out correctly
                     if (selection.Count == 0)

--- a/src/OpenSage.Game/Gui/CommandButtonCallback.cs
+++ b/src/OpenSage.Game/Gui/CommandButtonCallback.cs
@@ -51,6 +51,7 @@ namespace OpenSage.Gui
                     order = CreateOrder(OrderType.ToggleOvercharge);
                     break;
 
+                case CommandType.CancelUnitBuild:
                 case CommandType.Sell:
                     order = CreateOrder(OrderType.Sell);
                     break;

--- a/src/OpenSage.Game/Gui/CommandButtonCallback.cs
+++ b/src/OpenSage.Game/Gui/CommandButtonCallback.cs
@@ -29,12 +29,6 @@ namespace OpenSage.Gui
 
                 case CommandType.CastleUnpackExplicitObject:
                 case CommandType.FoundationConstruct:
-                    //TODO: figure this out correctly
-                    if (selection.Count == 0)
-                    {
-                        break;
-                    }
-
                     order = CreateOrder(OrderType.BuildObject);
                     order.AddIntegerArgument(objectDefinition.InternalId);
                     order.AddPositionArgument(selectedObject.Translation);

--- a/src/OpenSage.Game/Gui/ControlBar/CommandButton.cs
+++ b/src/OpenSage.Game/Gui/ControlBar/CommandButton.cs
@@ -60,7 +60,7 @@ namespace OpenSage.Gui.ControlBar
             { "CommandTrigger", (parser, x) => x.CommandTrigger = parser.ParseAssetReference() },
             { "WeaponSlotToggle1", (parser, x) => x.WeaponSlotToggle1 = parser.ParseEnum<WeaponSlot>() },
             { "WeaponSlotToggle2", (parser, x) => x.WeaponSlotToggle2 = parser.ParseEnum<WeaponSlot>() },
-            { "NeededUpgrade", (parser, x) => x.NeededUpgrade = parser.ParseAssetReference() },
+            { "NeededUpgrade", (parser, x) => x.NeededUpgrade = parser.ParseUpgradeReference() },
             { "BuildUpgrades", (parser, x) => x.BuildUpgrades = parser.ParseAssetReference() },
             { "Radial", (parser, x) => x.Radial = parser.ParseBoolean() },
             { "IsClickable", (parser, x) => x.IsClickable = parser.ParseBoolean() },
@@ -152,7 +152,7 @@ namespace OpenSage.Gui.ControlBar
         public WeaponSlot? WeaponSlotToggle2 { get; private set; }
 
         [AddedIn(SageGame.Bfme)]
-        public string NeededUpgrade { get; private set; }
+        public LazyAssetReference<UpgradeTemplate> NeededUpgrade { get; private set; }
 
         [AddedIn(SageGame.Bfme)]
         public string BuildUpgrades { get; private set; }

--- a/src/OpenSage.Game/Gui/ControlBar/CommandButton.cs
+++ b/src/OpenSage.Game/Gui/ControlBar/CommandButton.cs
@@ -93,7 +93,7 @@ namespace OpenSage.Gui.ControlBar
         [AddedIn(SageGame.CncGeneralsZeroHour)]
         public string ConflictingLabel { get; private set; }
 
-        public LazyAssetReference<MappedImage> ButtonImage { get; private set; }
+        public LazyAssetReference<MappedImage> ButtonImage { get; set; }
         public CommandButtonBorderType ButtonBorderType { get; private set; }
         public string DescriptLabel { get; private set; }
         public string RadiusCursorType { get; private set; }
@@ -110,7 +110,7 @@ namespace OpenSage.Gui.ControlBar
         public LazyAssetReference<ObjectDefinition> Object { get; private set; }
 
         [AddedIn(SageGame.Bfme)]
-        public bool InPalantir { get; private set; }
+        public bool InPalantir { get; set; }
 
         [AddedIn(SageGame.Bfme)]
         public bool DoubleClick { get; private set; }
@@ -158,7 +158,7 @@ namespace OpenSage.Gui.ControlBar
         public string BuildUpgrades { get; private set; }
 
         [AddedIn(SageGame.Bfme)]
-        public bool Radial { get; private set; }
+        public bool Radial { get; set; }
 
         [AddedIn(SageGame.Bfme)]
         public bool IsClickable { get; private set; }

--- a/src/OpenSage.Game/Gui/UnitOverlay/RadialButton.cs
+++ b/src/OpenSage.Game/Gui/UnitOverlay/RadialButton.cs
@@ -14,7 +14,7 @@ namespace OpenSage.Gui.UnitOverlay
         private readonly Game _game;
         private readonly int _width;
 
-        private readonly MappedImage _background;
+        private MappedImage _background;
         private readonly MappedImage _border;
         private readonly MappedImage _hover;
         private readonly MappedImage _down;
@@ -67,12 +67,13 @@ namespace OpenSage.Gui.UnitOverlay
             //_scheme = game.AssetStore.ControlBarSchemes.FindBySide(game.Scene3D.LocalPlayer.Side);
         }
 
-        public void Update(float progress, int count, bool enabled)
+        public void Update(float progress, int count, bool enabled, MappedImage image = null)
         {
             _isPushed = false;
             _progress = progress;
             _count = count;
             _enabled = enabled;
+            _background = image ?? _background;
         }
 
         public void Render(DrawingContext2D drawingContext, Vector2 center)

--- a/src/OpenSage.Game/Gui/UnitOverlay/RadialButton.cs
+++ b/src/OpenSage.Game/Gui/UnitOverlay/RadialButton.cs
@@ -67,13 +67,12 @@ namespace OpenSage.Gui.UnitOverlay
             //_scheme = game.AssetStore.ControlBarSchemes.FindBySide(game.Scene3D.LocalPlayer.Side);
         }
 
-        public void Update(float progress, int count, bool enabled, MappedImage image = null)
+        public void Update(float progress, int count, bool enabled)
         {
             _isPushed = false;
             _progress = progress;
             _count = count;
             _enabled = enabled;
-            _background = image ?? _background;
         }
 
         public void Render(DrawingContext2D drawingContext, Vector2 center)

--- a/src/OpenSage.Game/Gui/UnitOverlay/RadialButton.cs
+++ b/src/OpenSage.Game/Gui/UnitOverlay/RadialButton.cs
@@ -14,7 +14,7 @@ namespace OpenSage.Gui.UnitOverlay
         private readonly Game _game;
         private readonly int _width;
 
-        private MappedImage _background;
+        private readonly MappedImage _background;
         private readonly MappedImage _border;
         private readonly MappedImage _hover;
         private readonly MappedImage _down;

--- a/src/OpenSage.Game/Logic/ExperienceLevel.cs
+++ b/src/OpenSage.Game/Logic/ExperienceLevel.cs
@@ -1,5 +1,6 @@
 ﻿using OpenSage.Content;
 using OpenSage.Data.Ini;
+using OpenSage.FX;
 using OpenSage.Gui.InGame;
 using OpenSage.Logic.Object;
 using OpenSage.Mathematics;
@@ -27,7 +28,7 @@ namespace OpenSage.Logic
             { "ShowLevelUpTint", (parser, x) => x.ShowLevelUpTint = parser.ParseBoolean() },
             { "AttributeModifiers", (parser, x) => x.AttributeModifiers = parser.ParseModifierListReferenceArray() },
             { "Rank", (parser, x) => x.Rank = parser.ParseInteger() },
-            { "LevelUpFx", (parser, x) => x.LevelUpFX = parser.ParseAssetReference().Replace("FX:", "") },
+            { "LevelUpFx", (parser, x) => x.LevelUpFX = parser.ParseFXListReference() },
             { "LevelUpTintColor", (parser, x) => x.LevelUpTintColor = parser.ParseColorRgb() },
             { "LevelUpTintPreColorTime", (parser, x) => x.LevelUpTintPreColorTime = parser.ParseInteger() },
             { "LevelUpTintPostColorTime", (parser, x) => x.LevelUpTintPostColorTime = parser.ParseInteger() },
@@ -46,7 +47,7 @@ namespace OpenSage.Logic
         public bool ShowLevelUpTint { get; private set; }
         public LazyAssetReference<ModifierList>[] AttributeModifiers { get; private set; }
         public int Rank { get; private set; }
-        public string LevelUpFX { get; private set; }
+        public LazyAssetReference<FXList> LevelUpFX { get; private set; }
         public ColorRgb LevelUpTintColor { get; private set; }
         public int LevelUpTintPreColorTime { get; private set; }
         public int LevelUpTintPostColorTime { get; private set; }

--- a/src/OpenSage.Game/Logic/ExperienceLevel.cs
+++ b/src/OpenSage.Game/Logic/ExperienceLevel.cs
@@ -1,5 +1,7 @@
-﻿using OpenSage.Data.Ini;
+﻿using OpenSage.Content;
+using OpenSage.Data.Ini;
 using OpenSage.Gui.InGame;
+using OpenSage.Logic.Object;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic
@@ -21,9 +23,9 @@ namespace OpenSage.Logic
             { "ExperienceAward", (parser, x) => x.ExperienceAward = parser.ParseInteger() },
             { "ExperienceAwardOwnGuysDie", (parser, x) => x.ExperienceAwardOwnGuysDie = parser.ParseInteger() },
             { "InformUpdateModule", (parser, x) => x.InformUpdateModule = parser.ParseBoolean() },
-            { "Upgrades", (parser, x) => x.Upgrades = parser.ParseAssetReferenceArray() },
+            { "Upgrades", (parser, x) => x.Upgrades = parser.ParseUpgradeReferenceArray() },
             { "ShowLevelUpTint", (parser, x) => x.ShowLevelUpTint = parser.ParseBoolean() },
-            { "AttributeModifiers", (parser, x) => x.AttributeModifiers = parser.ParseAssetReferenceArray() },
+            { "AttributeModifiers", (parser, x) => x.AttributeModifiers = parser.ParseModifierListReferenceArray() },
             { "Rank", (parser, x) => x.Rank = parser.ParseInteger() },
             { "LevelUpFx", (parser, x) => x.LevelUpFX = parser.ParseAssetReference().Replace("FX:", "") },
             { "LevelUpTintColor", (parser, x) => x.LevelUpTintColor = parser.ParseColorRgb() },
@@ -40,9 +42,9 @@ namespace OpenSage.Logic
         public int ExperienceAwardOwnGuysDie { get; private set; }
         // Inform BannerCarrierUpdate about level increase
         public bool InformUpdateModule { get; private set; }
-        public string[] Upgrades { get; private set; }
+        public LazyAssetReference<UpgradeTemplate>[] Upgrades { get; private set; }
         public bool ShowLevelUpTint { get; private set; }
-        public string[] AttributeModifiers { get; private set; }
+        public LazyAssetReference<ModifierList>[] AttributeModifiers { get; private set; }
         public int Rank { get; private set; }
         public string LevelUpFX { get; private set; }
         public ColorRgb LevelUpTintColor { get; private set; }

--- a/src/OpenSage.Game/Logic/ModifierList.cs
+++ b/src/OpenSage.Game/Logic/ModifierList.cs
@@ -1,4 +1,6 @@
-﻿using OpenSage.Data.Ini;
+﻿using OpenSage.Content;
+using OpenSage.Data.Ini;
+using OpenSage.FX;
 using OpenSage.Logic.Object;
 using OpenSage.Mathematics;
 using System;
@@ -41,6 +43,9 @@ namespace OpenSage.Logic
                 }
             }
 
+            TriggerFX(_modifierList.FX, gameObject);
+            TriggerFX(_modifierList.FX2, gameObject);
+            TriggerFX(_modifierList.FX3, gameObject);
 
             Applied = true;
         }
@@ -53,6 +58,31 @@ namespace OpenSage.Logic
             }
 
             return time.TotalTime > _activeUntil;
+        }
+
+        public void Remove(GameObject gameObject)
+        {
+            foreach (var modifier in _modifierList.Modifiers)
+            {
+                switch (modifier.ModifierType)
+                {
+                    case ModifierType.Production:
+                        gameObject.ProductionModifier /= modifier.Amount;
+                        break;
+                }
+            }
+
+            TriggerFX(_modifierList.EndFX, gameObject);
+            TriggerFX(_modifierList.EndFX2, gameObject);
+            TriggerFX(_modifierList.EndFX3, gameObject);
+        }
+
+        private void TriggerFX(LazyAssetReference<FXList> fx, GameObject gameObject)
+        {
+            fx?.Value?.Execute(new FXListExecutionContext(
+                    gameObject.Rotation,
+                    gameObject.Translation,
+                    gameObject.GameContext));
         }
     }
 
@@ -78,12 +108,12 @@ namespace OpenSage.Logic
             { "Duration", (parser, x) => x.Duration = parser.ParseLong() },
             { "ClearModelCondition", (parser, x) => x.ClearModelCondition = parser.ParseEnum<ModelConditionFlag>() },
             { "ModelCondition", (parser, x) => x.ModelCondition = parser.ParseEnum<ModelConditionFlag>() },
-            { "FX", (parser, x) => x.FX = parser.ParseAssetReference() },
-            { "FX2", (parser, x) => x.FX2 = parser.ParseAssetReference() },
-            { "FX3", (parser, x) => x.FX3 = parser.ParseAssetReference() },
-            { "EndFX", (parser, x) => x.EndFX = parser.ParseAssetReference() },
-            { "EndFX2", (parser, x) => x.EndFX2 = parser.ParseAssetReference() },
-            { "EndFX3", (parser, x) => x.EndFX3 = parser.ParseAssetReference() },
+            { "FX", (parser, x) => x.FX = parser.ParseFXListReference() },
+            { "FX2", (parser, x) => x.FX2 = parser.ParseFXListReference() },
+            { "FX3", (parser, x) => x.FX3 = parser.ParseFXListReference() },
+            { "EndFX", (parser, x) => x.EndFX = parser.ParseFXListReference() },
+            { "EndFX2", (parser, x) => x.EndFX2 = parser.ParseFXListReference() },
+            { "EndFX3", (parser, x) => x.EndFX3 = parser.ParseFXListReference() },
             { "MultiLevelFX", (parser, x) => x.MultiLevelFX = parser.ParseBoolean() },
             { "Upgrade", (parser, x) => x.Upgrade = ModifierUpgrade.Parse(parser) },
             { "ReplaceInCategoryIfLongest", (parser, x) => x.ReplaceInCategoryIfLongest = parser.ParseBoolean() },
@@ -97,12 +127,12 @@ namespace OpenSage.Logic
         public long Duration { get; private set; }
         public ModelConditionFlag ClearModelCondition { get; private set; }
         public ModelConditionFlag ModelCondition { get; private set; }
-        public string FX { get; private set; }
-        public string FX2 { get; private set; }
-        public string FX3 { get; private set; }
-        public string EndFX { get; private set; }
-        public string EndFX2 { get; private set; }
-        public string EndFX3 { get; private set; }
+        public LazyAssetReference<FXList> FX { get; private set; }
+        public LazyAssetReference<FXList> FX2 { get; private set; }
+        public LazyAssetReference<FXList> FX3 { get; private set; }
+        public LazyAssetReference<FXList> EndFX { get; private set; }
+        public LazyAssetReference<FXList> EndFX2 { get; private set; }
+        public LazyAssetReference<FXList> EndFX3 { get; private set; }
         public bool MultiLevelFX { get; private set; }
         public ModifierUpgrade? Upgrade { get; private set; }
 

--- a/src/OpenSage.Game/Logic/ModifierList.cs
+++ b/src/OpenSage.Game/Logic/ModifierList.cs
@@ -109,7 +109,7 @@ namespace OpenSage.Logic
                         break;
                     case ModifierType.Health:
                         gameObject.HealthModifier -= (Fix64) (int) (modifier.Amount * 100);
-                        // TODO: also reduce healt again by this amount?
+                        // TODO: also reduce health again by this amount?
                         break;
                 }
             }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using ImGuiNET;
 using OpenSage.Data.Ini;
 using OpenSage.Data.Map;
+using OpenSage.Gui;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
@@ -24,6 +25,12 @@ namespace OpenSage.Logic.Object
             _context = context;
 
             _nativePlayer = _gameObject.Owner;
+        }
+
+        public float GetUnpackCost(Player player)
+        {
+            var castleEntry = FindCastle(player.Side);
+            return castleEntry.UnpackCost;
         }
 
         public void Unpack(Player player, bool instant = false)
@@ -212,14 +219,14 @@ namespace OpenSage.Logic.Object
             {
                 FactionName = parser.ParseString(),
                 Camp = parser.ParseAssetReference(),
-                MaybeStartMoney = parser.GetFloatOptional()
+                UnpackCost = parser.GetFloatOptional()
             };
             return result;
         }
 
         public string FactionName { get; private set; }
         public string Camp { get; private set; }
-        public float MaybeStartMoney { get; private set; }
+        public float UnpackCost { get; private set; }
     }
 
     public sealed class Side

--- a/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
@@ -80,7 +80,8 @@ namespace OpenSage.Logic.Object
                     }
                 }
             }
-            _gameObject.Destroy();
+            _gameObject.Hidden = true;
+            _gameObject.IsSelectable = false;
             _unpacked = true;
         }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
@@ -4,12 +4,11 @@ using System.Numerics;
 using ImGuiNET;
 using OpenSage.Data.Ini;
 using OpenSage.Data.Map;
-using OpenSage.Gui;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class CastleBehavior : BehaviorModule
+    internal sealed class CastleBehavior : BehaviorModule
     {
         private GameObject _gameObject;
         private CastleBehaviorModuleData _moduleData;

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PassiveAreaEffectBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PassiveAreaEffectBehavior.cs
@@ -1,10 +1,54 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using OpenSage.Content;
 using OpenSage.Data.Ini;
+using OpenSage.FX;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
     [AddedIn(SageGame.Bfme)]
+    public class PassiveAreaEffectBehavior : UpdateModule
+    {
+        private readonly GameObject _gameObject;
+        private readonly PassiveAreaEffectBehaviorModuleData _moduleData;
+        private TimeSpan _nextPing;
+
+        public PassiveAreaEffectBehavior(GameObject gameObject, PassiveAreaEffectBehaviorModuleData moduleData)
+        {
+            _moduleData = moduleData;
+            _gameObject = gameObject;
+
+        }
+
+        internal override void Update(BehaviorUpdateContext context)
+        {
+            if (context.Time.TotalTime < _nextPing)
+            {
+                return;
+            }
+            _nextPing = context.Time.TotalTime + TimeSpan.FromMilliseconds(_moduleData.PingDelay);
+
+            var nearbyObjects = context.GameContext.Quadtree.FindNearby(_gameObject, _gameObject.Transform, _moduleData.EffectRadius);
+
+            foreach (var nearbyObject in nearbyObjects)
+            {
+                if (!_moduleData.AllowFilter.Matches(nearbyObject))
+                {
+                    continue;
+                }
+
+                // TODO: HealPercentPerSecond, UpgradeRequired, NonStackable, HealFX, AntiCategories
+
+                foreach (var modifier in _moduleData.Modifiers)
+                {
+                    nearbyObject.AddAttributeModifier(modifier.Value.Name, new AttributeModifier(modifier.Value));
+                }
+            }
+        }
+    }
+
+
     public sealed class PassiveAreaEffectBehaviorModuleData : UpdateModuleData
     {
         internal static PassiveAreaEffectBehaviorModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -15,10 +59,10 @@ namespace OpenSage.Logic.Object
             { "PingDelay", (parser, x) => x.PingDelay = parser.ParseInteger() },
             { "HealPercentPerSecond", (parser, x) => x.HealPercentPerSecond = parser.ParsePercentage() },
             { "AllowFilter", (parser, x) => x.AllowFilter = ObjectFilter.Parse(parser) },
-            { "ModifierName", (parser, x) => x.ModifierNames.Add(parser.ParseAssetReference()) },
-            { "UpgradeRequired", (parser, x) => x.UpgradeRequired = parser.ParseAssetReference() },
+            { "ModifierName", (parser, x) => x.Modifiers.Add(parser.ParseModifierListReference()) },
+            { "UpgradeRequired", (parser, x) => x.UpgradeRequired = parser.ParseUpgradeReference() },
             { "NonStackable", (parser, x) => x.NonStackable = parser.ParseBoolean() },
-            { "HealFX", (parser, x) => x.HealFX = parser.ParseAssetReference() },
+            { "HealFX", (parser, x) => x.HealFX = parser.ParseFXListReference() },
             { "AntiCategories", (parser, x) => x.AntiCategories = parser.ParseEnumBitArray<ModifierCategory>() }
         };
 
@@ -26,18 +70,23 @@ namespace OpenSage.Logic.Object
         public int PingDelay { get; private set; }
         public Percentage HealPercentPerSecond { get; private set; }
         public ObjectFilter AllowFilter { get; private set; }
-        public List<string> ModifierNames { get; } = new List<string>();
+        public List<LazyAssetReference<ModifierList>> Modifiers { get; } = new List<LazyAssetReference<ModifierList>>();
 
         [AddedIn(SageGame.Bfme2)]
-        public string UpgradeRequired { get; private set; }
+        public LazyAssetReference<UpgradeTemplate> UpgradeRequired { get; private set; }
 
         [AddedIn(SageGame.Bfme2)]
         public bool NonStackable { get; private set; }
 
         [AddedIn(SageGame.Bfme2)]
-        public string HealFX { get; private set; }
+        public LazyAssetReference<FXList> HealFX { get; private set; }
 
         [AddedIn(SageGame.Bfme2)]
         public BitArray<ModifierCategory> AntiCategories { get; private set; }
+
+        internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+        {
+            return new PassiveAreaEffectBehavior(gameObject, this);
+        }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
@@ -43,7 +43,7 @@ namespace OpenSage.Logic.Object
             if (_gameObject.Definition.KindOf.Get(ObjectKinds.Aircraft)
                 || _gameObject.Definition.KindOf.Get(ObjectKinds.Drone)
                 || _gameObject.Definition.KindOf.Get(ObjectKinds.GiantBird)
-                || _gameObject.AIUpdate?.CurrentLocomotor.LocomotorTemplate.Appearance == LocomotorAppearance.GiantBird)
+                || _gameObject.AIUpdate?.CurrentLocomotor?.LocomotorTemplate.Appearance == LocomotorAppearance.GiantBird)
             {
                 if (_gameObject.ModelConditionFlags.Get(ModelConditionFlag.Dying) == false) return;
             }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
@@ -29,7 +29,7 @@ namespace OpenSage.Logic.Object
             _moduleData = moduleData;
         }
 
-        internal bool IsApplicable(DeathType deathType) => _moduleData.DeathTypes?.Get(deathType) ?? false;
+        internal bool IsApplicable(DeathType deathType) => _moduleData.DeathTypes?.Get(deathType) ?? true;
 
         internal override void OnDie(BehaviorUpdateContext context, DeathType deathType)
         {

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
@@ -4,7 +4,7 @@ using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class SpawnBehavior : BehaviorModule
+    internal sealed class SpawnBehavior : BehaviorModule
     {
         GameObject _gameObject;
         SpawnBehaviorModuleData _moduleData;

--- a/src/OpenSage.Game/Logic/Object/Contain/HordeContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/HordeContain.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
@@ -103,7 +104,8 @@ namespace OpenSage.Logic.Object
                         continue;
                     }
 
-                    if (position.Definition.Name == obj.Definition.Name)
+                    if (position.Definition == obj.Definition
+                        || position.Definition.ObjectIsMemberOfBuildVariations(obj.Definition))
                     {
                         position.Object = obj;
                         _payload.Add(obj);

--- a/src/OpenSage.Game/Logic/Object/Contain/HordeContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/HordeContain.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Numerics;
 using OpenSage.Content;
 using OpenSage.Data.Ini;

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -929,7 +929,7 @@ namespace OpenSage.Logic.Object
             return true;
         }
 
-        public bool HasEnoughMoney(float cost) => true; // Owner.Money >= cost; 
+        public bool HasEnoughMoney(float cost) => Owner.Money >= cost; 
 
         public bool CanConstructUnit(ObjectDefinition objectDefinition)
         {

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -308,6 +308,11 @@ namespace OpenSage.Logic.Object
             Player owner,
             GameObjectCollection parent)
         {
+            if (objectDefinition.BuildVariations != null && objectDefinition.BuildVariations.Count() > 0)
+            {
+                objectDefinition = objectDefinition.BuildVariations[gameContext.Random.Next(0, objectDefinition.BuildVariations.Count())].Value;
+            }
+
             Definition = objectDefinition ?? throw new ArgumentNullException(nameof(objectDefinition));
 
             _tagToModuleLookup = new Dictionary<string, BehaviorModule>();

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -241,7 +241,7 @@ namespace OpenSage.Logic.Object
 
         public Team Team { get; set; }
 
-        public bool IsSelectable { get; private set; }
+        public bool IsSelectable { get; set; }
         public bool IsProjectile { get; private set; } = false;
         public bool CanAttack { get; private set; }
 
@@ -258,6 +258,8 @@ namespace OpenSage.Logic.Object
         public float BuildProgress { get; set; }
 
         public bool Destroyed { get; set; }
+
+        public bool Hidden { get; set; }
 
         public bool IsDamaged
         {
@@ -516,6 +518,11 @@ namespace OpenSage.Logic.Object
             {
                 CurrentWeapon?.LogicTick(time);
             }
+            if (ModelConditionFlags.Get(ModelConditionFlag.Sold))
+            {
+                Die(DeathType.Normal, time);
+                ModelConditionFlags.Set(ModelConditionFlag.Sold, false);
+            }
 
             AIUpdate?.Update(_behaviorUpdateContext);
 
@@ -738,7 +745,7 @@ namespace OpenSage.Logic.Object
 
         internal void BuildRenderList(RenderList renderList, Camera camera, in TimeInterval gameTime)
         {
-            if (Destroyed || ModelConditionFlags.Get(ModelConditionFlag.Sold))
+            if (Destroyed || ModelConditionFlags.Get(ModelConditionFlag.Sold) || Hidden)
             {
                 return;
             }

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -420,6 +420,7 @@ namespace OpenSage.Logic.Object
             _upgrades = new List<UpgradeTemplate>();
             _conflictingUpgrades = new List<UpgradeTemplate>();
 
+            Hidden = false;
             ExperienceMultiplier = 1.0f;
             ExperienceValue = 0;
             Rank = 0;

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -131,7 +131,7 @@ namespace OpenSage.Logic.Object
         private readonly Transform _transform;
         public readonly Transform ModelTransform;
 
-        private bool _objectMoved = false;
+        private bool _objectMoved = true;
 
         public Transform Transform => _transform;
         public float Yaw => _transform.Yaw;

--- a/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
@@ -446,7 +446,7 @@ namespace OpenSage.Logic.Object
         public bool IsPrerequisite { get; private set; }
         public Dictionary<BitArray<WeaponSetConditions>, WeaponTemplateSet> WeaponSets { get; internal set; } = new Dictionary<BitArray<WeaponSetConditions>, WeaponTemplateSet>();
         public Dictionary<BitArray<ArmorSetCondition>, ArmorTemplateSet> ArmorSets { get; internal set; } = new Dictionary<BitArray<ArmorSetCondition>, ArmorTemplateSet>();
-        public LazyAssetReference<CommandSet> CommandSet { get; private set; }
+        public LazyAssetReference<CommandSet> CommandSet { get; set; }
         public ObjectPrerequisites Prerequisites { get; private set; }
         public bool IsTrainable { get; private set; }
 

--- a/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Numerics;
+using FFmpeg.AutoGen;
 using OpenSage.Audio;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
@@ -51,6 +52,23 @@ namespace OpenSage.Logic.Object
             result.SetNameAndInstanceId("GameObject", name);
 
             return result;
+        }
+
+        internal bool ObjectIsMemberOfBuildVariations(ObjectDefinition definition)
+        {
+            if (BuildVariations == null)
+            {
+                return false;
+            }
+
+            foreach (var def in BuildVariations)
+            {
+                if (def.Value == definition)
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         internal static readonly IniParseTable<ObjectDefinition> FieldParseTable = new IniParseTable<ObjectDefinition>
@@ -242,7 +260,9 @@ namespace OpenSage.Logic.Object
                 (parser, x) =>
                 {
                     var behavior = BehaviorModuleData.ParseBehavior(parser);
-                    if (behavior is AIUpdateModuleData aiUpdate)
+                    var aiUpdate = behavior as AIUpdateModuleData;
+
+                    if (aiUpdate != null)
                     {
                         x.AIUpdate = aiUpdate;
                     }
@@ -299,7 +319,7 @@ namespace OpenSage.Logic.Object
             { "ShadowMaxHeight", (parser, x) => x.ShadowMaxHeight = parser.ParseInteger() },
             { "InstanceScaleFuzziness", (parser, x) => x.InstanceScaleFuzziness = parser.ParseFloat() },
             { "BuildCompletion", (parser, x) => x.BuildCompletion = parser.ParseAssetReference() },
-            { "BuildVariations", (parser, x) => x.BuildVariations = parser.ParseAssetReferenceArray() },
+            { "BuildVariations", (parser, x) => x.BuildVariations = parser.ParseObjectReferenceArray() },
 
             { "ExperienceScalarTable", (parser, x) => x.ExperienceScalarTable = parser.ParseAssetReference() },
 
@@ -869,7 +889,7 @@ namespace OpenSage.Logic.Object
         public int ShadowMaxHeight { get; private set; }
         public float InstanceScaleFuzziness { get; private set; }
         public string BuildCompletion { get; private set; }
-        public string[] BuildVariations { get; private set; }
+        public LazyAssetReference<ObjectDefinition>[] BuildVariations { get; private set; }
 
         [AddedIn(SageGame.Bfme)]
         public string ExperienceScalarTable { get; private set; }

--- a/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Numerics;
-using FFmpeg.AutoGen;
 using OpenSage.Audio;
 using OpenSage.Content;
 using OpenSage.Data.Ini;

--- a/src/OpenSage.Game/Logic/Object/StanceTemplate.cs
+++ b/src/OpenSage.Game/Logic/Object/StanceTemplate.cs
@@ -8,7 +8,7 @@ namespace OpenSage.Logic.Object
     {
         internal static StanceTemplate Parse(IniParser parser)
         {
-            AttributeModifier.AttributeModifiers.Clear();
+            StanceAttributeModifier.AttributeModifiers.Clear();
             return parser.ParseNamedBlock(
                 (x, name) => x.SetNameAndInstanceId("StanceTemplate", name),
                 FieldParseTable);
@@ -33,22 +33,22 @@ namespace OpenSage.Logic.Object
 
         private static readonly IniParseTable<Stance> FieldParseTable = new IniParseTable<Stance>
         {
-            { "AttributeModifier", (parser, x) => x.AttributeModifier = AttributeModifier.Parse(parser) },
+            { "AttributeModifier", (parser, x) => x.AttributeModifier = StanceAttributeModifier.Parse(parser) },
             { "MeleeBehavior", (parser, x) => x.MeleeBehavior = MeleeBehavior.Parse(parser) },
         };
 
         public string Name { get; private set; }
-        public AttributeModifier AttributeModifier { get; private set; }
+        public StanceAttributeModifier AttributeModifier { get; private set; }
 
         [AddedIn(SageGame.Bfme2Rotwk)]
         public MeleeBehavior MeleeBehavior { get; private set; }
     }
 
-    public sealed class AttributeModifier
+    public sealed class StanceAttributeModifier
     {
-        internal static Dictionary<string, AttributeModifier> AttributeModifiers { get; } = new Dictionary<string, AttributeModifier>();
+        internal static Dictionary<string, StanceAttributeModifier> AttributeModifiers { get; } = new Dictionary<string, StanceAttributeModifier>();
 
-        internal static AttributeModifier Parse(IniParser parser)
+        internal static StanceAttributeModifier Parse(IniParser parser)
         {
             var name = parser.ParseString();
             if (IsOnlyAReference(name))
@@ -67,7 +67,7 @@ namespace OpenSage.Logic.Object
             return AttributeModifiers.ContainsKey(name);
         }
 
-        private static readonly IniParseTable<AttributeModifier> FieldParseTable = new IniParseTable<AttributeModifier>
+        private static readonly IniParseTable<StanceAttributeModifier> FieldParseTable = new IniParseTable<StanceAttributeModifier>
         {
             { "MeleeBehavior", (parser, x) => x.MeleeBehavior = parser.ParseString() },
         };

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -68,7 +68,7 @@ namespace OpenSage.Logic.Object
             CurrentLocomotor = locomotor;
         }
 
-        public void AddTargetPoint(in Vector3 targetPoint)
+        internal void AddTargetPoint(in Vector3 targetPoint)
         {
             TargetPoints.Add(targetPoint);
 
@@ -136,7 +136,7 @@ namespace OpenSage.Logic.Object
             GameObject.Speed = 0;
         }
 
-        public void SetTargetDirection(Vector3 targetDirection)
+        internal void SetTargetDirection(Vector3 targetDirection)
         {
             _targetDirection = targetDirection;
             GameObject.ModelConditionFlags.Set(ModelConditionFlag.Moving, true);
@@ -285,7 +285,6 @@ namespace OpenSage.Logic.Object
             var unknown18 = reader.ReadBytes(36);
         }
     }
-
 
     public class AIUpdateModuleData : UpdateModuleData
     {

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -68,7 +68,7 @@ namespace OpenSage.Logic.Object
             CurrentLocomotor = locomotor;
         }
 
-        internal void AddTargetPoint(in Vector3 targetPoint)
+        public void AddTargetPoint(in Vector3 targetPoint)
         {
             TargetPoints.Add(targetPoint);
 
@@ -136,7 +136,7 @@ namespace OpenSage.Logic.Object
             GameObject.Speed = 0;
         }
 
-        internal void SetTargetDirection(Vector3 targetDirection)
+        public void SetTargetDirection(Vector3 targetDirection)
         {
             _targetDirection = targetDirection;
             GameObject.ModelConditionFlags.Set(ModelConditionFlag.Moving, true);
@@ -286,6 +286,7 @@ namespace OpenSage.Logic.Object
         }
     }
 
+
     public class AIUpdateModuleData : UpdateModuleData
     {
         internal static AIUpdateModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -382,10 +383,7 @@ namespace OpenSage.Logic.Object
             throw new InvalidOperationException();
         }
 
-        internal virtual AIUpdate CreateAIUpdate(GameObject gameObject)
-        {
-            return new AIUpdate(gameObject, this);
-        }
+        internal virtual AIUpdate CreateAIUpdate(GameObject gameObject) => new AIUpdate(gameObject, this);
     }
 
     public enum AutoAcquireEnemiesType

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AnimalAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AnimalAIUpdate.cs
@@ -4,6 +4,17 @@ using OpenSage.Mathematics;
 namespace OpenSage.Logic.Object
 {
     [AddedIn(SageGame.Bfme)]
+    public class AnimalAIUpdate : AIUpdate
+    {
+        private readonly AnimalAIUpdateModuleData _moduleData;
+
+        internal AnimalAIUpdate(GameObject gameObject, AnimalAIUpdateModuleData moduleData) : base(gameObject, moduleData)
+        {
+            _moduleData = moduleData;
+        }
+    }
+
+
     public sealed class AnimalAIUpdateModuleData : AIUpdateModuleData
     {
         internal new static AnimalAIUpdateModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -27,5 +38,7 @@ namespace OpenSage.Logic.Object
         public int MaxWanderRadius { get; private set; }
         public int UpdateTimer { get; private set; }
         public bool AfraidOfCastles { get; private set; }
+
+        internal override AIUpdate CreateAIUpdate(GameObject gameObject) => new AnimalAIUpdate(gameObject, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+﻿using System;
 using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
@@ -6,15 +6,25 @@ namespace OpenSage.Logic.Object
     [AddedIn(SageGame.Bfme)]
     public class FoundationAIUpdate : AIUpdate
     {
-        FoundationAIUpdateModuleData _moduleData;
+        private readonly FoundationAIUpdateModuleData _moduleData;
+        private TimeSpan _waitUntil;
+        private int _updateInterval;
 
         internal FoundationAIUpdate(GameObject gameObject, FoundationAIUpdateModuleData moduleData) : base(gameObject, moduleData)
         {
             _moduleData = moduleData;
+            _updateInterval = 500; // we do not have to check every frame
         }
 
         internal override void Update(BehaviorUpdateContext context)
         {
+            if (context.Time.TotalTime < _waitUntil)
+            {
+                return;
+            }
+
+            _waitUntil = context.Time.TotalTime + TimeSpan.FromMilliseconds(_updateInterval);
+
             var collidingObjects = context.GameContext.Quadtree.FindIntersecting(GameObject);
 
             foreach (var collidingObject in collidingObjects)

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
@@ -1,8 +1,38 @@
-﻿using OpenSage.Data.Ini;
+﻿using System.Linq;
+using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
     [AddedIn(SageGame.Bfme)]
+    public class FoundationAIUpdate : AIUpdate
+    {
+        FoundationAIUpdateModuleData _moduleData;
+
+        internal FoundationAIUpdate(GameObject gameObject, FoundationAIUpdateModuleData moduleData) : base(gameObject, moduleData)
+        {
+            _moduleData = moduleData;
+        }
+
+        internal override void Update(BehaviorUpdateContext context)
+        {
+            var collidingObjects = context.GameContext.Quadtree.FindIntersecting(GameObject);
+
+            foreach (var collidingObject in collidingObjects)
+            {
+                if (collidingObject.Definition.KindOf.Get(ObjectKinds.Structure))
+                {
+                    GameObject.IsSelectable = false;
+                    GameObject.Hidden = true;
+                    return;
+                }
+            }
+
+            GameObject.IsSelectable = true;
+            GameObject.Hidden = false;
+        }
+    }
+
+
     public sealed class FoundationAIUpdateModuleData : AIUpdateModuleData
     {
         internal new static FoundationAIUpdateModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
@@ -15,5 +45,10 @@ namespace OpenSage.Logic.Object
 
         [AddedIn(SageGame.Bfme2)]
         public int BuildVariation { get; private set; }
+
+        internal override AIUpdate CreateAIUpdate(GameObject gameObject)
+        {
+            return new FoundationAIUpdate(gameObject, this);
+        }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
@@ -26,10 +26,11 @@ namespace OpenSage.Logic.Object
             }
 
             _waitUntil = context.Time.TotalTime + TimeSpan.FromMilliseconds(_moduleData.DepositTiming);
-            _gameObject.Owner.ReceiveMoney((uint) _moduleData.DepositAmount);
+            var amount = (uint) (_moduleData.DepositAmount * _gameObject.ProductionModifier);
+            _gameObject.Owner.ReceiveMoney(amount);
             if (!_moduleData.GiveNoXP)
             {
-                _gameObject.GainExperience(_moduleData.DepositAmount);
+                _gameObject.GainExperience((int)amount);
             }
         }
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
@@ -4,7 +4,7 @@ using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class AutoDepositUpdate : BehaviorModule
+    internal sealed class AutoDepositUpdate : BehaviorModule
     {
         GameObject _gameObject;
         AutoDepositUpdateModuleData _moduleData;

--- a/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
@@ -67,7 +67,7 @@ namespace OpenSage.Logic.Object
                 {
                     foreach (var upgrade in _currentLevel.Upgrades)
                     {
-                        _gameObject.Upgrades.Remove(upgrade.Value);
+                        _gameObject.RemoveUpgrade(upgrade.Value);
                     }
                 }
 
@@ -85,7 +85,7 @@ namespace OpenSage.Logic.Object
             {
                 foreach (var upgrade in _nextLevel.Upgrades)
                 {
-                    _gameObject.Upgrades.Add(upgrade.Value);
+                    _gameObject.Upgrade(upgrade.Value);
                 }
             }
 

--- a/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
@@ -11,6 +11,7 @@ namespace OpenSage.Logic.Object
 
         private List<ExperienceLevel> _experienceLevels;
         private bool _initial;
+        private ExperienceLevel _currentLevel;
         private ExperienceLevel _nextLevel;
         private BannerCarrierUpdate _bannerCarrierUpdate;
 
@@ -59,11 +60,41 @@ namespace OpenSage.Logic.Object
             _gameObject.ExperienceValue -= _nextLevel.RequiredExperience;
             _gameObject.Rank = _nextLevel.Rank;
 
+            //remove stuff from current level
+            if (_currentLevel != null)
+            {
+                if (_currentLevel.Upgrades != null)
+                {
+                    foreach (var upgrade in _currentLevel.Upgrades)
+                    {
+                        _gameObject.Upgrades.Remove(upgrade.Value);
+                    }
+                }
+
+                if (_currentLevel.AttributeModifiers != null)
+                {
+                    foreach (var modifierList in _currentLevel.AttributeModifiers)
+                    {
+                        _gameObject.RemoveAttributeModifier(modifierList.Value.Name);
+                    }
+                }
+            }
+
+
             if (_nextLevel.Upgrades != null)
             {
-                foreach (var upgradeReference in _nextLevel.Upgrades)
+                foreach (var upgrade in _nextLevel.Upgrades)
                 {
-                    _gameObject.Upgrades.Add(context.GameContext.AssetLoadContext.AssetStore.Upgrades.GetByName(upgradeReference));
+                    _gameObject.Upgrades.Add(upgrade.Value);
+                }
+            }
+
+            if (_nextLevel.AttributeModifiers != null)
+            {
+                foreach (var modifierList in _nextLevel.AttributeModifiers)
+                {
+                    var attributeModifier = new AttributeModifier(modifierList.Value);
+                    _gameObject.AddAttributeModifier(modifierList.Value.Name, attributeModifier);
                 }
             }
 
@@ -89,12 +120,12 @@ namespace OpenSage.Logic.Object
 
             // TODO:
             // ExperienceAwardOwnGuysDie -> what is this?
-            // AttributeModifiers
             // EmotionType
 
             _experienceLevels.RemoveAt(0);
             if (_experienceLevels.Count > 0)
             {
+                _currentLevel = _nextLevel;
                 _nextLevel = _experienceLevels.First();
                 _gameObject.ExperienceRequiredForNextLevel = _nextLevel.RequiredExperience;
             }

--- a/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
@@ -100,9 +100,7 @@ namespace OpenSage.Logic.Object
 
             if (_nextLevel.LevelUpFX != null)
             {
-                var levelUpFx = context.GameContext.AssetLoadContext.AssetStore.FXLists.GetByName(_nextLevel.LevelUpFX);
-
-                levelUpFx?.Execute(new FXListExecutionContext(
+                _nextLevel.LevelUpFX.Value?.Execute(new FXListExecutionContext(
                     context.GameObject.Rotation,
                     context.GameObject.Translation,
                     context.GameContext));

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -411,7 +411,7 @@ namespace OpenSage.Logic.Object
 
         internal void QueueProduction(ObjectDefinition objectDefinition)
         {
-            var job = new ProductionJob(objectDefinition, objectDefinition.BuildTime);
+            var job = new ProductionJob(objectDefinition, objectDefinition.BuildTime / _gameObject.ProductionModifier);
             _productionQueue.Add(job);
         }
 
@@ -423,7 +423,7 @@ namespace OpenSage.Logic.Object
 
         internal void SpawnPayload(ObjectDefinition objectDefinition, float buildTime = 0.0f)
         {
-            var job = new ProductionJob(objectDefinition, buildTime);
+            var job = new ProductionJob(objectDefinition, buildTime / _gameObject.ProductionModifier);
             _productionQueue.Insert(1, job);
         }
 
@@ -446,10 +446,16 @@ namespace OpenSage.Logic.Object
             var index = -1;
             for (var i = 0; i < _productionQueue.Count; i++)
             {
-                if (_productionQueue[i].UpgradeDefinition == upgradeDefinition) index = i;
+                if (_productionQueue[i].UpgradeDefinition == upgradeDefinition)
+                {
+                    index = i;
+                }
             }
 
-            if (index < 0 || index > _productionQueue.Count) return;
+            if (index < 0 || index > _productionQueue.Count)
+            {
+                return;
+            }
 
             _productionQueue.RemoveAt(index);
         }

--- a/src/OpenSage.Game/Logic/Object/Update/SlavedUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SlavedUpdate.cs
@@ -38,7 +38,7 @@ namespace OpenSage.Logic.Object
         internal override void Update(BehaviorUpdateContext context)
         {
             var masterIsMoving = Master.ModelConditionFlags.Get(ModelConditionFlag.Moving);
-            var masterHealthPercent = Master.Body.Health / Master.Body.MaxHealth;
+            var masterHealthPercent = Master.HealthPercentage;
 
             var offsetToMaster = Master.Translation - _gameObject.Translation;
             var distanceToMaster = offsetToMaster.Vector2XY().Length();
@@ -111,10 +111,10 @@ namespace OpenSage.Logic.Object
                     case RepairStatus.ZIP_AROUND:
                     case RepairStatus.IN_TRANSITION:
                     case RepairStatus.WELDING:
-                        Master.Body.Health += (Fix64) (_moduleData.RepairRatePerSecond * context.Time.DeltaTime.TotalSeconds);
-                        if (Master.Body.Health > Master.Body.MaxHealth)
+                        Master.Health += (Fix64) (_moduleData.RepairRatePerSecond * context.Time.DeltaTime.TotalSeconds);
+                        if (Master.Health > Master.MaxHealth)
                         {
-                            Master.Body.Health = Master.Body.MaxHealth;
+                            Master.Health = Master.MaxHealth;
                             _repairStatus = RepairStatus.INITIAL;
                             _gameObject.AIUpdate.SetLocomotor(LocomotorSetType.Normal);
                         }

--- a/src/OpenSage.Game/Logic/Object/Update/SupplyCenterDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SupplyCenterDockUpdate.cs
@@ -29,7 +29,7 @@ namespace OpenSage.Logic.Object
                 }
             }
 
-            _gameObject.Owner.ReceiveMoney((uint)(numBoxes * amountPerBox));
+            _gameObject.Owner.ReceiveMoney((uint)(numBoxes * amountPerBox * _gameObject.ProductionModifier));
             numBoxes = 0;
         }
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/CommandSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/CommandSetUpgrade.cs
@@ -1,30 +1,70 @@
-﻿using OpenSage.Data.Ini;
+﻿using OpenSage.Content;
+using OpenSage.Data.Ini;
+using OpenSage.Gui.ControlBar;
 
 namespace OpenSage.Logic.Object
 {
+    public class CommandSetUpgrade : UpgradeModule
+    {
+        private readonly CommandSetUpgradeModuleData _moduleData;
+        private readonly LazyAssetReference<CommandSet> _defaultCommandSet;
+
+        public CommandSetUpgrade(GameObject gameObject, CommandSetUpgradeModuleData moduleData) : base(gameObject, moduleData)
+        {
+            _moduleData = moduleData;
+            _defaultCommandSet = gameObject.Definition.CommandSet;
+        }
+
+        internal override void OnTrigger(BehaviorUpdateContext context, bool triggered)
+        {
+            if (triggered)
+            {
+                _gameObject.Definition.CommandSet = _moduleData.CommandSet;
+            }
+            else
+            {
+                _gameObject.Definition.CommandSet = _defaultCommandSet;
+            }
+        }
+    }
+
     /// <summary>
-    /// Gives the object the ability to change commandsets back and forth when this module two times.
+    /// Gives the object the ability to change commandsets back and forth when this module exists multiple times.
     /// </summary>
     public sealed class CommandSetUpgradeModuleData : UpgradeModuleData
     {
-        internal static CommandSetUpgradeModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
+        internal static CommandSetUpgradeModuleData Parse(IniParser parser)
+        {
+            var result = parser.ParseBlock(FieldParseTable);
+            if (result.CommandSetAlt != null
+                || result.TriggerAlt != null)
+            {
+                var k = 0;
+            }
+            return result;
+        }
 
         private static new readonly IniParseTable<CommandSetUpgradeModuleData> FieldParseTable = UpgradeModuleData.FieldParseTable
             .Concat(new IniParseTable<CommandSetUpgradeModuleData>
             {
                 { "RemovesUpgrades", (parser, x) => x.RemovesUpgrades = parser.ParseAssetReferenceArray() },
-                { "CommandSet", (parser, x) => x.CommandSet = parser.ParseAssetReference() },
+                { "CommandSet", (parser, x) => x.CommandSet = parser.ParseCommandSetReference() },
                 { "CommandSetAlt", (parser, x) => x.CommandSetAlt = parser.ParseAssetReference() },
                 { "TriggerAlt", (parser, x) => x.TriggerAlt = parser.ParseAssetReference() }
             });
 
         public string[] RemovesUpgrades { get; private set; }
-        public string CommandSet { get; private set; }
+        public LazyAssetReference<CommandSet> CommandSet { get; private set; }
 
         [AddedIn(SageGame.CncGeneralsZeroHour)]
         public string CommandSetAlt { get; private set; }
 
         [AddedIn(SageGame.CncGeneralsZeroHour)]
         public string TriggerAlt { get; private set; }
+
+        internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+        {
+            return new CommandSetUpgrade(gameObject, this);
+        }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/CommandSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/CommandSetUpgrade.cs
@@ -4,7 +4,7 @@ using OpenSage.Gui.ControlBar;
 
 namespace OpenSage.Logic.Object
 {
-    public class CommandSetUpgrade : UpgradeModule
+    internal class CommandSetUpgrade : UpgradeModule
     {
         private readonly CommandSetUpgradeModuleData _moduleData;
         private readonly LazyAssetReference<CommandSet> _defaultCommandSet;
@@ -35,29 +35,23 @@ namespace OpenSage.Logic.Object
     {
         internal static CommandSetUpgradeModuleData Parse(IniParser parser)
         {
-            var result = parser.ParseBlock(FieldParseTable);
-            if (result.CommandSetAlt != null
-                || result.TriggerAlt != null)
-            {
-                var k = 0;
-            }
-            return result;
+            return parser.ParseBlock(FieldParseTable);
         }
 
         private static new readonly IniParseTable<CommandSetUpgradeModuleData> FieldParseTable = UpgradeModuleData.FieldParseTable
             .Concat(new IniParseTable<CommandSetUpgradeModuleData>
             {
-                { "RemovesUpgrades", (parser, x) => x.RemovesUpgrades = parser.ParseAssetReferenceArray() },
+                { "RemovesUpgrades", (parser, x) => x.RemovesUpgrades = parser.ParseUpgradeReferenceArray() },
                 { "CommandSet", (parser, x) => x.CommandSet = parser.ParseCommandSetReference() },
-                { "CommandSetAlt", (parser, x) => x.CommandSetAlt = parser.ParseAssetReference() },
+                { "CommandSetAlt", (parser, x) => x.CommandSetAlt = parser.ParseCommandSetReference() },
                 { "TriggerAlt", (parser, x) => x.TriggerAlt = parser.ParseAssetReference() }
             });
 
-        public string[] RemovesUpgrades { get; private set; }
+        public LazyAssetReference<UpgradeTemplate>[] RemovesUpgrades { get; private set; }
         public LazyAssetReference<CommandSet> CommandSet { get; private set; }
 
         [AddedIn(SageGame.CncGeneralsZeroHour)]
-        public string CommandSetAlt { get; private set; }
+        public LazyAssetReference<CommandSet> CommandSetAlt { get; private set; }
 
         [AddedIn(SageGame.CncGeneralsZeroHour)]
         public string TriggerAlt { get; private set; }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ExperienceScalarUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ExperienceScalarUpgrade.cs
@@ -4,7 +4,7 @@ using OpenSage.FileFormats;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class ExperienceScalarUpgrade : UpgradeModule
+    internal sealed class ExperienceScalarUpgrade : UpgradeModule
     {
         private readonly ExperienceScalarUpgradeModuleData _moduleData;
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/GeometryUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/GeometryUpgrade.cs
@@ -3,7 +3,7 @@
 namespace OpenSage.Logic.Object
 {
     [AddedIn(SageGame.Bfme)]
-    public class GeometryUpgrade : UpgradeModule
+    internal class GeometryUpgrade : UpgradeModule
     {
         private readonly GeometryUpgradeModuleData _moduleData;
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/MaxHealthUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/MaxHealthUpgrade.cs
@@ -20,18 +20,17 @@ namespace OpenSage.Logic.Object
                 switch (_moduleData.ChangeType)
                 {
                     case MaxHealthChangeType.PreserveRatio:
-                        var ratio = _gameObject.Body.Health / _gameObject.Body.MaxHealth;
-                        _gameObject.Body.Health += ratio * (Fix64) _moduleData.AddMaxHealth;
+                        _gameObject.Health += _gameObject.HealthPercentage * (Fix64) _moduleData.AddMaxHealth;
                         break;
                     case MaxHealthChangeType.AddCurrentHealthToo:
-                        _gameObject.Body.Health += (Fix64) _moduleData.AddMaxHealth;
+                        _gameObject.Health += (Fix64) _moduleData.AddMaxHealth;
                         break;
                     case MaxHealthChangeType.SameCurrentHealth:
                         // Don't add any new health
                         break;
                 }
 
-                _gameObject.Body.MaxHealth += (Fix64) _moduleData.AddMaxHealth;
+                _gameObject.MaxHealth += (Fix64) _moduleData.AddMaxHealth;
             }
         }
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/MaxHealthUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/MaxHealthUpgrade.cs
@@ -3,7 +3,7 @@ using OpenSage.Mathematics.FixedMath;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class MaxHealthUpgrade : UpgradeModule
+    internal sealed class MaxHealthUpgrade : UpgradeModule
     {
         private readonly MaxHealthUpgradeModuleData _moduleData;
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
@@ -6,7 +6,7 @@ using OpenSage.FileFormats;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class ObjectCreationUpgrade : UpgradeModule
+    internal sealed class ObjectCreationUpgrade : UpgradeModule
     {
         private readonly ObjectCreationUpgradeModuleData _moduleData;
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
@@ -40,6 +40,7 @@ namespace OpenSage.Logic.Object
                     {
                         continue;
                     }
+
                     _gameObject.AddConflictingUpgrade(upgrade.Value);
                 }
             }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
@@ -40,8 +40,7 @@ namespace OpenSage.Logic.Object
                     {
                         continue;
                     }
-
-                    _gameObject.ConflictingUpgrades.Add(upgrade.Value);
+                    _gameObject.AddConflictingUpgrade(upgrade.Value);
                 }
             }
         }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/PowerPlantUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/PowerPlantUpgrade.cs
@@ -4,7 +4,7 @@ using OpenSage.FileFormats;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class PowerPlantUpgrade : UpgradeModule
+    internal sealed class PowerPlantUpgrade : UpgradeModule
     {
         internal PowerPlantUpgrade(GameObject gameObject, PowerPlantUpgradeModuleData moduleData) : base(gameObject, moduleData)
         {

--- a/src/OpenSage.Game/Logic/Object/Upgrade/SubObjectsUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/SubObjectsUpgrade.cs
@@ -6,7 +6,7 @@ namespace OpenSage.Logic.Object
     /// <summary>
     /// Shows/hides sub-objects on this object's model via upgrading.
     /// </summary>
-    public class SubObjectsUpgrade : UpgradeModule
+    internal class SubObjectsUpgrade : UpgradeModule
     {
         private readonly SubObjectsUpgradeModuleData _moduleData;
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/UnpauseSpecialPowerUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/UnpauseSpecialPowerUpgrade.cs
@@ -4,7 +4,7 @@ using OpenSage.FileFormats;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class UnpauseSpecialPowerUpgrade : UpgradeModule
+    internal sealed class UnpauseSpecialPowerUpgrade : UpgradeModule
     {
         internal UnpauseSpecialPowerUpgrade(GameObject gameObject, UnpauseSpecialPowerUpgradeModuleData moduleData)
             : base(gameObject, moduleData)

--- a/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
@@ -6,7 +6,7 @@ using OpenSage.FileFormats;
 
 namespace OpenSage.Logic.Object
 {
-    public abstract class UpgradeModule : BehaviorModule
+    internal abstract class UpgradeModule : BehaviorModule
     {
         protected readonly GameObject _gameObject;
         private readonly UpgradeModuleData _moduleData;

--- a/src/OpenSage.Game/Logic/Object/Upgrade/WeaponBonusUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/WeaponBonusUpgrade.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class WeaponBonusUpgrade : UpgradeModule
+    internal sealed class WeaponBonusUpgrade : UpgradeModule
     {
         internal WeaponBonusUpgrade(GameObject gameObject, WeaponBonusUpgradeModuleData moduleData) : base(gameObject, moduleData)
         {

--- a/src/OpenSage.Game/Logic/Object/Upgrade/WeaponSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/WeaponSetUpgrade.cs
@@ -7,8 +7,11 @@ namespace OpenSage.Logic.Object
 {
     public sealed class WeaponSetUpgrade : UpgradeModule
     {
+        private readonly WeaponSetUpgradeModuleData _moduleData;
+
         internal WeaponSetUpgrade(GameObject gameObject, WeaponSetUpgradeModuleData moduleData) : base(gameObject, moduleData)
         {
+            _moduleData = moduleData;
         }
 
         internal override void OnTrigger(BehaviorUpdateContext context, bool triggered)

--- a/src/OpenSage.Game/Logic/Object/Upgrade/WeaponSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/WeaponSetUpgrade.cs
@@ -5,7 +5,7 @@ using OpenSage.FileFormats;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class WeaponSetUpgrade : UpgradeModule
+    internal sealed class WeaponSetUpgrade : UpgradeModule
     {
         private readonly WeaponSetUpgradeModuleData _moduleData;
 

--- a/src/OpenSage.Game/Logic/Object/Weapon/WeaponTarget.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/WeaponTarget.cs
@@ -31,7 +31,7 @@ namespace OpenSage.Logic.Object
         {
             if (TargetType == WeaponTargetType.Object)
             {
-                TargetObject.Body.DoDamage(damageType, amount, deathType, time);
+                TargetObject.DoDamage(damageType, amount, deathType, time);
             }
         }
     }

--- a/src/OpenSage.Game/Logic/Orders/Order.cs
+++ b/src/OpenSage.Game/Logic/Orders/Order.cs
@@ -146,7 +146,7 @@ namespace OpenSage.Logic.Orders
                     order.AddObjectIdArgument(objId);
                 }
             }
-            else
+            else if (objectIds.Count > 0)
             {
                 order.AddObjectIdArgument(objectIds.ElementAt(0));
                 order.AddPositionArgument(targetPosition);

--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -100,6 +100,14 @@ namespace OpenSage.Logic
             _allies = new HashSet<Player>();
             _enemies = new HashSet<Player>();
             Upgrades = new List<UpgradeTemplate>();
+
+            if (template?.InitialUpgrades != null)
+            {
+                foreach (var upgrade in template.InitialUpgrades)
+                {
+                    Upgrades.Add(upgrade.Value);
+                }
+            }
         }
 
         internal void SelectUnits(IEnumerable<GameObject> units, bool additive = false)

--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -35,6 +35,7 @@ namespace OpenSage.Logic
 
         public uint Money { get; private set; }
         public List<UpgradeTemplate> Upgrades { get; }
+        public List<UpgradeTemplate> ConflictingUpgrades { get; }
 
         public StringSet Sciences { get; } = new StringSet();
 
@@ -100,6 +101,7 @@ namespace OpenSage.Logic
             _allies = new HashSet<Player>();
             _enemies = new HashSet<Player>();
             Upgrades = new List<UpgradeTemplate>();
+            ConflictingUpgrades = new List<UpgradeTemplate>();
 
             if (template?.InitialUpgrades != null)
             {

--- a/src/OpenSage.Game/Logic/PlayerTemplate.cs
+++ b/src/OpenSage.Game/Logic/PlayerTemplate.cs
@@ -101,7 +101,7 @@ namespace OpenSage.Logic
             { "LightPointsUpSound", (parser, x) => x.LightPointsUpSound = parser.ParseAssetReference() },
             { "ObjectiveAddedSound", (parser, x) => x.ObjectiveAddedSound = parser.ParseAssetReference() },
             { "ObjectiveCompletedSound", (parser, x) => x.ObjectiveCompletedSound = parser.ParseAssetReference() },
-            { "InitialUpgrades", (parser, x) => x.InitialUpgrades = parser.ParseAssetReferenceArray() },
+            { "InitialUpgrades", (parser, x) => x.InitialUpgrades = parser.ParseUpgradeReferenceArray() },
             { "BuildableHeroesMP", (parser, x) => x.BuildableHeroesMP = parser.ParseObjectReferenceArray() },
             { "BuildableRingHeroesMP", (parser, x) => x.BuildableRingHeroesMP = parser.ParseAssetReferenceArray() },
             { "SpellStoreCurrentPowerLabel", (parser, x) => x.SpellStoreCurrentPowerLabel = parser.ParseAssetReference() },
@@ -202,7 +202,7 @@ namespace OpenSage.Logic
         public string ObjectiveCompletedSound { get; private set; }
 
         [AddedIn(SageGame.Bfme)]
-        public string[] InitialUpgrades { get; private set; }
+        public LazyAssetReference<UpgradeTemplate>[] InitialUpgrades { get; private set; }
 
         [AddedIn(SageGame.Bfme)]
         public LazyAssetReference<ObjectDefinition>[] BuildableHeroesMP { get; private set; }

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -511,12 +511,12 @@ namespace OpenSage
                 }
 
                 // TODO: Not sure what to draw for InactiveBody?
-                if (gameObject.Body is ActiveBody)
+                if (gameObject.HasActiveBody())
                 {
                     DrawBar(
                         healthBoxRect.Value,
                         new ColorRgbaF(0, 1, 0, 1),
-                        (float)gameObject.Body.HealthPercentage);
+                        (float)gameObject.HealthPercentage);
                 }
 
                 var yOffset = 0;

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -395,6 +395,9 @@ namespace OpenSage
 
         internal void LogicTick(ulong frame, in TimeInterval time)
         {
+            GameObjects.DeleteDestroyed();
+            GameObjects.InsertCreated();
+
             foreach (var gameObject in GameObjects.Items)
             {
                 gameObject.LogicTick(frame, time);
@@ -452,7 +455,11 @@ namespace OpenSage
             {
                 foreach (var gameObject in GameObjects.Items)
                 {
-                    gameObject.BuildRenderList(renderList, camera, gameTime);
+                    // TODO: fix boundingFrustum collision
+                    //if (gameObject.Collider.Intersects(Camera.BoundingFrustum))
+                    //{
+                     gameObject.BuildRenderList(renderList, camera, gameTime);
+                    //}
                 }
             }
 

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -399,24 +399,6 @@ namespace OpenSage
             {
                 gameObject.LogicTick(frame, time);
             }
-
-            GameObjects.DeleteDestroyed();
-            GameObjects.InsertCreated();
-            DetectCollisions(time);
-        }
-
-        private void DetectCollisions(in TimeInterval time)
-        {
-            foreach (var current in GameObjects.Items)
-            {
-                var intersecting = Quadtree.FindIntersecting(current.Collider);
-
-                foreach (var intersect in intersecting)
-                {
-                    current.DoCollide(intersect, time);
-                    intersect.DoCollide(current, time);
-                }
-            }
         }
 
         internal void LocalLogicTick(in TimeInterval gameTime, float tickT)

--- a/src/OpenSage.Game/Scripting/LuaScriptEngine.cs
+++ b/src/OpenSage.Game/Scripting/LuaScriptEngine.cs
@@ -355,7 +355,7 @@ namespace OpenSage.Scripting
 
         public int ObjectGetHealthFraction(string gameObject)
         {
-            return (int)(Game.Scene3D.GameObjects.GetObjectById(GetLuaObjectID(gameObject)).Body?.Health ?? (Mathematics.FixedMath.Fix64) 0);
+            return (int)(Game.Scene3D.GameObjects.GetObjectById(GetLuaObjectID(gameObject)).Health);
         }
 
         public string ObjectDescription(string gameObject)  //EXAMPLE C&C3: "Object 1187 (_jIWv4) [NODAvatar, owned by player 3 (MetaIdea)]"

--- a/src/OpenSage.Game/Subsystem.cs
+++ b/src/OpenSage.Game/Subsystem.cs
@@ -85,5 +85,15 @@
         /// Things that need to be loaded in order for the IngameUI to work.
         /// </summary>
         InGameUI,
+
+        /// <summary>
+        /// Definitions of the various levels of an object.
+        /// </summary>
+        ExperienceLevels,
+
+        /// <summary>
+        /// Defines modifications to object properties like health, armor etc.
+        /// </summary>
+        AttributeModifiers,
     }
 }

--- a/src/OpenSage.Mathematics/Percentage.cs
+++ b/src/OpenSage.Mathematics/Percentage.cs
@@ -14,19 +14,13 @@ namespace OpenSage.Mathematics
         }
 
         public static float operator *(float f, Percentage p) => f * p._value;
-        
         public static float operator *(Percentage p, float f) => p._value * f;
-
         public static float operator /(float f, Percentage p) => f / p._value;
-
         public static float operator /(Percentage p, float f) => p._value / f;
-
         public static Percentage operator *(Percentage p1, Percentage p2) => new Percentage(p1._value * p2._value);
-
+        public static Percentage operator /(Percentage p1, Percentage p2) => new Percentage(p1._value / p2._value);
         public static bool operator <(float f, Percentage p) => f < p._value;
-
         public static bool operator >(float f, Percentage p) => f > p._value;
-
         public static explicit operator float(Percentage p) => p._value;
 
         public override string ToString()

--- a/src/OpenSage.Mathematics/Percentage.cs
+++ b/src/OpenSage.Mathematics/Percentage.cs
@@ -1,10 +1,12 @@
-﻿namespace OpenSage.Mathematics
+﻿using System;
+
+namespace OpenSage.Mathematics
 {
     public readonly struct Percentage
     {
         private readonly float _value;
 
-        public bool IsZero => _value == 0;
+        public bool IsZero => MathF.Abs(_value) < 0.0001f;
 
         public Percentage(float value)
         {
@@ -12,7 +14,14 @@
         }
 
         public static float operator *(float f, Percentage p) => f * p._value;
+        
         public static float operator *(Percentage p, float f) => p._value * f;
+
+        public static float operator /(float f, Percentage p) => f / p._value;
+
+        public static float operator /(Percentage p, float f) => p._value / f;
+
+        public static Percentage operator *(Percentage p1, Percentage p2) => new Percentage(p1._value * p2._value);
 
         public static bool operator <(float f, Percentage p) => f < p._value;
 

--- a/src/OpenSage.Mods.Bfme/Gui/RadialUnitOverlay.cs
+++ b/src/OpenSage.Mods.Bfme/Gui/RadialUnitOverlay.cs
@@ -20,7 +20,7 @@ namespace OpenSage.Mods.Bfme.Gui
         private Point2D _center;
         private CommandSet _commandSet;
         List<RadialButton> _buttons;
-        private GameObject _selectedUnit;
+        private GameObject _selectedObject;
 
         public override HandlingPriority Priority => HandlingPriority.UIPriority;
 
@@ -36,28 +36,28 @@ namespace OpenSage.Mods.Bfme.Gui
             _visible = false;
             if (player.SelectedUnits.Count != 1)
             {
-                _selectedUnit = null;
+                _selectedObject = null;
                 return;
             }
 
-            var selectedUnit = player.SelectedUnits.First();
-            if (selectedUnit.Owner != player
-                || selectedUnit.IsBeingConstructed()
-                || !selectedUnit.Definition.KindOf.Get(ObjectKinds.Structure)
-                || selectedUnit.Definition.CommandSet == null)
+            var selectedObject = player.SelectedUnits.First();
+            if (selectedObject.Owner != player
+                || selectedObject.IsBeingConstructed()
+                || !selectedObject.Definition.KindOf.Get(ObjectKinds.Structure)
+                || selectedObject.Definition.CommandSet == null)
             {
-                _selectedUnit = null;
+                _selectedObject = null;
                 return;
             }
 
-            var playerTemplate = selectedUnit.Owner.Template;
+            var playerTemplate = selectedObject.Owner.Template;
             _visible = true;
 
-            var screenPosition = _game.Scene3D.Camera.WorldToScreenPoint(selectedUnit.Collider.WorldBounds.Center);
+            var screenPosition = _game.Scene3D.Camera.WorldToScreenPoint(selectedObject.Collider.WorldBounds.Center);
             _center = new Point2D((int)screenPosition.X, (int)screenPosition.Y);
-            _commandSet = selectedUnit.Definition.CommandSet.Value;
+            _commandSet = selectedObject.Definition.CommandSet.Value;
 
-            if (_selectedUnit != selectedUnit && _commandSet != null)
+            if (_selectedObject != selectedObject && _commandSet != null)
             {
                 //Update button list
                 var heroIndex = 0;
@@ -83,25 +83,25 @@ namespace OpenSage.Mods.Bfme.Gui
                 foreach (var commandButton in commandButtons)
                 {
                     var isHeroButton = commandButton.Object?.Value?.KindOf.Get(ObjectKinds.Hero) ?? false;
-                    var radialButton = new RadialButton(_game, selectedUnit, commandButton, isHeroButton);
+                    var radialButton = new RadialButton(_game, selectedObject, commandButton, isHeroButton);
                     _buttons.Add(radialButton);
                 }
 
-                _selectedUnit = selectedUnit;
+                _selectedObject = selectedObject;
             }
 
-            var isProducing = selectedUnit.ProductionUpdate?.IsProducing ?? false;
+            var isProducing = selectedObject.ProductionUpdate?.IsProducing ?? false;
             foreach (var radialButton in _buttons)
             {
                 radialButton.IsVisible = true;
                 if (radialButton.IsRecruitHeroButton)
                 {
                     var definition = radialButton.CommandButton.Object.Value;
-                    radialButton.IsVisible = selectedUnit.CanRecruitHero(definition);
+                    radialButton.IsVisible = selectedObject.CanRecruitHero(definition);
                 }
 
-                var (count, progress) = isProducing ? selectedUnit.ProductionUpdate.GetCountAndProgress(radialButton.CommandButton) : (0, 0.0f);
-                radialButton.Update(progress, count, selectedUnit.CanEnqueue(radialButton.CommandButton));
+                var (count, progress) = isProducing ? selectedObject.ProductionUpdate.GetCountAndProgress(radialButton.CommandButton) : (0, 0.0f);
+                radialButton.Update(progress, count, selectedObject.CanPurchase(radialButton.CommandButton));
             }
         }
 

--- a/src/OpenSage.Mods.Bfme2/Gui/AptControlBarSource.cs
+++ b/src/OpenSage.Mods.Bfme2/Gui/AptControlBarSource.cs
@@ -174,7 +174,7 @@ namespace OpenSage.Mods.Bfme2
                 var texture = button.ButtonImage.Value;
                 shape.RenderCallback = (AptRenderingContext renderContext, Geometry geom, Texture orig) =>
                 {
-                    var enabled = selectedUnit.CanEnqueue(button);
+                    var enabled = selectedUnit.CanPurchase(button);
                     var rect = new Rectangle(renderContext.GetBoundingBox(geom)).ToRectangleF();
                     renderContext.GetActiveDrawingContext().DrawMappedImage(texture, rect, grayscaled: !enabled);
 


### PR DESCRIPTION
- cancel unit build command
- attribute modifiers (production, health)
- PassiveAreaEffectBehavior
- fixed rohan peasant horde
- reduced gameObject collider updates and Quadtree access
- conflicting player upgrades
- hide build foundation plot as long as a structure is build on it
- CommandSetUpgrade
- initial player upgrades from playertemplate.ini
- check for collissions only on moved objects
- gettingBuildCommandset for buildings under construction