### PR TITLE
Updated SharpAudio Version

### DIFF
--- a/src/OpenSage.Game/OpenSage.Game.csproj
+++ b/src/OpenSage.Game/OpenSage.Game.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="protobuf-net" Version="3.0.62" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0010" />
-    <PackageReference Include="SharpAudio" Version="1.0.22-beta" />
-    <PackageReference Include="SharpAudio.Codec" Version="1.0.22-beta" />
+    <PackageReference Include="SharpAudio" Version="1.0.27-beta" />
+    <PackageReference Include="SharpAudio.Codec" Version="1.0.27-beta" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Veldrid" Version="$(VeldridVersion)" />


### PR DESCRIPTION
Updates the SharpAudio version dependency that will allow systems that use OpenAL as their Audio SubSystem, such as Linux, to start. Previously it wouldn't start at all.