### PR TITLE
Disable RenderDoc menu item if renderdoc failed to load.

### DIFF
--- a/src/OpenSage.Game/Diagnostics/MainView.cs
+++ b/src/OpenSage.Game/Diagnostics/MainView.cs
@@ -224,12 +224,13 @@ namespace OpenSage.Diagnostics
                 if (_context.Game.Configuration.UseRenderDoc && ImGui.BeginMenu("RenderDoc"))
                 {
                     var renderDoc = Game.RenderDoc;
+                    var isRenderDocActive = renderDoc != null;
 
-                    if (ImGui.MenuItem("Trigger Capture"))
+                    if (ImGui.MenuItem("Trigger Capture", isRenderDocActive))
                     {
                         renderDoc.TriggerCapture();
                     }
-                    if (ImGui.BeginMenu("Options"))
+                    if (ImGui.BeginMenu("Options", isRenderDocActive))
                     {
                         bool allowVsync = renderDoc.AllowVSync;
                         if (ImGui.Checkbox("Allow VSync", ref allowVsync))
@@ -274,11 +275,10 @@ namespace OpenSage.Diagnostics
                         }
                         ImGui.EndMenu();
                     }
-                    if (ImGui.MenuItem("Launch Replay UI"))
+                    if (ImGui.MenuItem("Launch Replay UI", isRenderDocActive))
                     {
                         renderDoc.LaunchReplayUI();
                     }
-                  
                     ImGui.EndMenu();
                 }
 


### PR DESCRIPTION
If the renderdoc failed to load, the program will crash if pressing on any of the renderdoc menu items. By disabling the renderdoc menu item it will prevent the program to crash but still show that the option was enabled.