### PR TITLE
Fix issue with weird UI Rendering on OpenGL

### DIFF
--- a/src/OpenSage.Game/Assets/Shaders/Sprite.frag
+++ b/src/OpenSage.Game/Assets/Shaders/Sprite.frag
@@ -1,7 +1,5 @@
 #version 450
 
-#extension GL_EXT_samplerless_texture_functions : enable
-
 #define FILL_METHOD_NORMAL     0
 #define FILL_METHOD_RADIAL_360 1
 

--- a/src/OpenSage.Game/Assets/Shaders/Sprite.frag
+++ b/src/OpenSage.Game/Assets/Shaders/Sprite.frag
@@ -74,11 +74,11 @@ void main()
 
     // Currently we always sample from the alpha mask,
     // falling back to a default one if there isn't a real one.
-    ivec2 alphaMaskSize = textureSize(AlphaMask, 0);
+    ivec2 alphaMaskSize = textureSize(sampler2D(AlphaMask, Sampler), 0);
     vec4 fragCoord = gl_FragCoord;
     vec2 alphaMaskUV = vec2(
-        fragCoord.x / alphaMaskSize.x,
-        fragCoord.y / alphaMaskSize.y);
+        fragCoord.x / float(alphaMaskSize.x),
+        fragCoord.y / float(alphaMaskSize.y));
     vec4 alphaMaskColor = texture(sampler2D(AlphaMask, Sampler), alphaMaskUV);
     textureColor.a *= alphaMaskColor.a;
 


### PR DESCRIPTION
The OpenGL rendering of the UI didn't always rendering probably such as the main menu. It seems to to have been the cause by the sprite fragment shader. It would call textureSize(AlphaMask_1, 0) for getting the size for computing the UV for the getting the alphaMaskColor. The AlphaMask_1 sampler2D is just a dummy created by the glslangValidator and is never bounded texture object.