### PR TITLE
Idle animation state

### DIFF
--- a/src/OpenSage.Game/Content/SubsystemLoader.cs
+++ b/src/OpenSage.Game/Content/SubsystemLoader.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenSage.Data;
-using OpenSage.Data.Ini;
 using OpenSage.Data.StreamFS;
 using OpenSage.Utilities.Extensions;
 

--- a/src/OpenSage.Game/Logic/Object/AnimationState.cs
+++ b/src/OpenSage.Game/Logic/Object/AnimationState.cs
@@ -11,11 +11,8 @@ namespace OpenSage.Logic.Object
         internal static AnimationState Parse(IniParser parser)
         {
             var stateTypeFlags = parser.ParseEnumBitArray<ModelConditionFlag>();
-
             var result = parser.ParseBlock(FieldParseTable);
-
             result.ConditionFlags = stateTypeFlags;
-
             return result;
         }
 
@@ -35,7 +32,7 @@ namespace OpenSage.Logic.Object
             { "LuaEvent", (parser, x) => x.LuaEvents.Add(LuaEvent.Parse(parser)) }
         };
 
-        public BitArray<ModelConditionFlag> ConditionFlags { get; private set; }
+        public BitArray<ModelConditionFlag> ConditionFlags { get; protected set; }
 
         public List<AnimationStateAnimation> Animations { get; private set; } = new List<AnimationStateAnimation>();
         public List<ParticleSysBone> ParticleSysBones { get; private set; } = new List<ParticleSysBone>();

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -243,8 +243,6 @@ namespace OpenSage.Logic.Object
 
             var bestAnimationState = (AnimationState) FindBestFittingConditionState(_idleAnimationState, _animationStates, flags);
             SetActiveAnimationState(bestAnimationState, random);
-
-            flags.BitsChanged = false;
         }
 
         private W3dModelDrawConditionState CreateModelDrawConditionStateInstance(ModelConditionState conditionState, Random random)

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -995,6 +995,8 @@ namespace OpenSage.Logic.Object
                 // TODO: check if this should be drawn with transparency?
                 _rallyPointMarker.BuildRenderList(renderList, camera, gameTime);
             }
+
+            ModelConditionFlags.BitsChanged = false;
         }
 
         public void ClearModelConditionFlags()

--- a/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
@@ -69,7 +69,7 @@ namespace OpenSage.Logic.Object
                     context.GameContext));
             }
 
-            _gameObject.ExperienceValue -= _nextLevel.RequiredExperience; _gameObject.ExperienceValue -= _nextLevel.RequiredExperience;
+            _gameObject.ExperienceValue -= _nextLevel.RequiredExperience;
             _gameObject.Rank = _nextLevel.Rank; _gameObject.Rank = _nextLevel.Rank;
 
             levelUp();

--- a/src/OpenSage.Mathematics/BitArray`1.cs
+++ b/src/OpenSage.Mathematics/BitArray`1.cs
@@ -12,7 +12,7 @@ namespace OpenSage.Mathematics
         public bool AnyBitSet => _data.AnyBitSet;
         public int NumBitsSet => _data.NumBitsSet;
 
-        public bool BitsChanged { get; set; }
+        public bool BitsChanged { get; set; } = true;
 
         public BitArray()
         {

--- a/src/OpenSage.Mathematics/BitArray`1.cs
+++ b/src/OpenSage.Mathematics/BitArray`1.cs
@@ -12,6 +12,8 @@ namespace OpenSage.Mathematics
         public bool AnyBitSet => _data.AnyBitSet;
         public int NumBitsSet => _data.NumBitsSet;
 
+        public bool BitsChanged { get; set; }
+
         public BitArray()
         {
             var maxBits = GetNumValues();
@@ -61,6 +63,7 @@ namespace OpenSage.Mathematics
         public void Set(int bit, bool value)
         {
             _data.Set(bit, value);
+            BitsChanged = true;
         }
 
         public void Set(TEnum bit, bool value)
@@ -68,16 +71,19 @@ namespace OpenSage.Mathematics
             // This avoids an object allocation.
             var bitI = Unsafe.As<TEnum, int>(ref bit);
             _data.Set(bitI, value);
+            BitsChanged = true;
         }
 
         public void SetAll(bool value)
         {
             _data.SetAll(value);
+            BitsChanged = true;
         }
 
         public void CopyFrom(BitArray<TEnum> other)
         {
             _data.CopyFrom(other._data);
+            BitsChanged = true;
         }
 
         public int CountIntersectionBits(BitArray<TEnum> other)


### PR DESCRIPTION
- only update modelconditionstate and animationstate if any of the ModelConditionFlags has changed
- IdleAnimations are not "repeated" anymore, that means e.g. a door open animation only plays once, but we still shuffle through the various idle animations of a unit