### PR TITLE
Removed samplerless to prevent black screen on OpenGL

### DIFF
--- a/src/OpenSage.Game/Assets/Shaders/Shadows.h
+++ b/src/OpenSage.Game/Assets/Shaders/Shadows.h
@@ -2,7 +2,6 @@
 
 #define SHADOWS_H
 
-#extension GL_EXT_samplerless_texture_functions : enable
 
 #define NUM_CASCADES 4
 
@@ -59,7 +58,7 @@ float SampleShadowMapOptimizedPCF(
     int cascadeIdx, 
     ShadowConstantsPSType constants)
 {
-    vec3 shadowMapSize = textureSize(shadowMap, 0);
+    vec3 shadowMapSize = textureSize(sampler2DArrayShadow(shadowMap, shadowSampler), 0);
 
     float lightDepth = shadowPos.z;
 
@@ -244,12 +243,13 @@ vec3 SampleShadowCascade(
 }
 
 vec3 GetShadowPosOffset(
-    texture2DArray shadowMap, 
+    texture2DArray shadowMap,
+    samplerShadow shadowSampler,
     float nDotL, 
     vec3 normal,
     ShadowConstantsPSType constants)
 {
-    vec3 shadowMapSize = textureSize(shadowMap, 0);
+    vec3 shadowMapSize = textureSize(sampler2DArrayShadow(shadowMap, shadowSampler), 0);
 
     float texelSize = 2.0f / shadowMapSize.x;
     float nmlOffsetScale = saturate(1.0f - nDotL);
@@ -282,7 +282,7 @@ vec3 ShadowVisibility(
     }
 
     // Apply offset
-    vec3 offset = GetShadowPosOffset(shadowMap, nDotL, normal, constants) / abs(constants.CascadeScales[cascadeIdx].z);
+    vec3 offset = GetShadowPosOffset(shadowMap, shadowSampler, nDotL, normal, constants) / abs(constants.CascadeScales[cascadeIdx].z);
 
     // Project into shadow space
     vec3 samplePos = positionWS + offset;

--- a/src/OpenSage.Game/Assets/Shaders/Terrain.frag
+++ b/src/OpenSage.Game/Assets/Shaders/Terrain.frag
@@ -1,6 +1,5 @@
 #version 450
 #extension GL_GOOGLE_include_directive : enable
-#extension GL_EXT_samplerless_texture_functions : enable
 
 #include "Common.h"
 #include "Lighting.h"
@@ -162,7 +161,7 @@ float CalculateBlendFactor(
 vec3 SampleBlendedTextures(vec2 uv)
 {
     uvec4 tileDatum = texelFetch(
-        TileData,
+        usampler2D(TileData, Sampler),
         ivec2(uv),
         0);
 


### PR DESCRIPTION
It seems that the samplerless has been the cause of the screen being black https://github.com/OpenSAGE/OpenSAGE/issues/389 when using OpenGL on some drivers that do not support the GL_EXT_samplerless_texture_functions extension.   