### PR TITLE
Miscellaneous changes and small fixes

### DIFF
--- a/src/OpenSage.Game/Content/AssetHash.cs
+++ b/src/OpenSage.Game/Content/AssetHash.cs
@@ -4,7 +4,9 @@ namespace OpenSage.Content
 {
     internal static class AssetHash
     {
-        public static uint GetHash(string input)
+        public static uint GetHash(string input) => GetHashCaseSensitive(input.ToLowerInvariant());
+
+        public static uint GetHashCaseSensitive(string input)
         {
             if (input.Length == 0)
             {
@@ -15,7 +17,7 @@ namespace OpenSage.Content
 
             static byte GetByte(ReadOnlySpan<char> span, int index)
             {
-                return (byte) char.ToLowerInvariant(span[index]);
+                return (byte) span[index];
             }
 
             var numBlocks = buffer.Length >> 2;

--- a/src/OpenSage.Game/Content/AssetStore.cs
+++ b/src/OpenSage.Game/Content/AssetStore.cs
@@ -1,7 +1,8 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using OpenSage.Audio;
 using OpenSage.Content.Loaders;
 using OpenSage.Data;
+using OpenSage.Data.StreamFS;
 using OpenSage.Eva;
 using OpenSage.FX;
 using OpenSage.Graphics;
@@ -174,6 +175,7 @@ namespace OpenSage.Content
         public ScopedAssetCollection<WindowTransition> WindowTransitions { get; }
 
         internal AssetStore(
+            SageGame sageGame,
             FileSystem fileSystem,
             string language,
             GraphicsDevice graphicsDevice,
@@ -197,7 +199,7 @@ namespace OpenSage.Content
             {
                 _scopedSingleAssetStorage.Add(assetStorage);
 
-                var typeId = AssetHash.GetHashCaseSensitive(typeof(TAsset).Name); // Type Id seems to be case sensitive
+                var typeId = AssetTypeUtility.GetAssetTypeId<TAsset>(sageGame);
                 _singleAssetStorageByTypeId.Add(typeId, assetStorage);
             }
 
@@ -244,7 +246,7 @@ namespace OpenSage.Content
             {
                 _scopedAssetCollections.Add(assetCollection);
 
-                var typeId = AssetHash.GetHashCaseSensitive(typeof(TAsset).Name);  // Type Id seems to be case sensitive
+                var typeId = AssetTypeUtility.GetAssetTypeId<TAsset>(sageGame);
                 _byTypeId.Add(typeId, assetCollection);
             }
 

--- a/src/OpenSage.Game/Content/AssetStore.cs
+++ b/src/OpenSage.Game/Content/AssetStore.cs
@@ -197,7 +197,7 @@ namespace OpenSage.Content
             {
                 _scopedSingleAssetStorage.Add(assetStorage);
 
-                var typeId = AssetHash.GetHash(typeof(TAsset).Name);
+                var typeId = AssetHash.GetHashCaseSensitive(typeof(TAsset).Name); // Type Id seems to be case sensitive
                 _singleAssetStorageByTypeId.Add(typeId, assetStorage);
             }
 
@@ -244,7 +244,7 @@ namespace OpenSage.Content
             {
                 _scopedAssetCollections.Add(assetCollection);
 
-                var typeId = AssetHash.GetHash(typeof(TAsset).Name);
+                var typeId = AssetHash.GetHashCaseSensitive(typeof(TAsset).Name);  // Type Id seems to be case sensitive
                 _byTypeId.Add(typeId, assetCollection);
             }
 

--- a/src/OpenSage.Game/Content/Translation/Providers/CsfTranslationProvider.cs
+++ b/src/OpenSage.Game/Content/Translation/Providers/CsfTranslationProvider.cs
@@ -155,7 +155,10 @@ namespace OpenSage.Content.Translation.Providers
                                 if (colonIdx == -1)
                                 {
                                     categoryLabel = string.Empty;
-                                    logger.Warn($"Empty category found for {label}.");
+                                    if (game != SageGame.Ra3) // RA3 has a lot of empty categories, so I guess it should be valid for RA3
+                                    {
+                                        logger.Warn($"Empty category found for {label}.");
+                                    }
                                 }
                                 else
                                 {

--- a/src/OpenSage.Game/Data/Dds/DdsFile.cs
+++ b/src/OpenSage.Game/Data/Dds/DdsFile.cs
@@ -39,8 +39,11 @@ namespace OpenSage.Data.Dds
                     case DdsImageFormat.Rgba8:
                         return PixelFormat.R8_G8_B8_A8_UNorm;
 
+                    case DdsImageFormat.Rgba16Float:
+                        return PixelFormat.R16_G16_B16_A16_Float;
+
                     default:
-                        throw new NotSupportedException();
+                        throw new NotSupportedException($"Unsupported DdsImageFormat: {ImageFormat}");
                 }
             }
         }
@@ -235,7 +238,7 @@ namespace OpenSage.Data.Dds
                     break;
 
                 case DdsImageFormat.Rgba16Float:
-                    rowBytes = width * 4;
+                    rowBytes = width * 8;
                     break;
             }
 

--- a/src/OpenSage.Game/Data/StreamFS/AssetType.cs
+++ b/src/OpenSage.Game/Data/StreamFS/AssetType.cs
@@ -1,4 +1,6 @@
-﻿namespace OpenSage.Data.StreamFS
+using System;
+
+namespace OpenSage.Data.StreamFS
 {
     public enum AssetType : uint
     {
@@ -11,15 +13,18 @@
         ArmorTemplate = 0x3A6C5E8E,
         ArmyDefinition = 0xD5D580F6,
         AttributeModifier = 0xC5E07887,
+        [SkipParsingIn(Game = SageGame.Ra3)] // inherited from BaseSingleSound
         AudioEvent = 0x844D7B9F,
         AudioFile = 0x166B084D,
         AudioLod = 0x11D8BAC7,
+        [SkipParsingIn(Game = SageGame.Ra3)] // BaseSingleSound's format is a bit different in RA3
         AudioSettings = 0x5608EE71,
         CampaignTemplate = 0x585E034E,
         ConnectionLineManager = 0x64B2184,
         CrowdResponse = 0x17E53184,
         DamageFX = 0xAD3568F5,
         DefaultHotKeys = 0xDEFCA2F6,
+        [SkipParsingIn(Game = SageGame.Ra3)] // inherited from BaseSingleSound
         DialogEvent = 0xD414D1C3,
         DynamicGameLod = 0xACEf31A4,
         Environment = 0x2893E309,
@@ -53,6 +58,7 @@
         MultiplayerColor = 0x8E28081D,
         MultiplayerSettings = 0xB63AEF0,
         Multisound = 0xA3A7AF37,
+        [SkipParsingIn(Game = SageGame.Ra3)] // inherited from BaseSingleSound
         MusicTrack = 0x7046D9F8,
         ObjectCreationList = 0xE86E4D61,
         OnDemandTexture = 0x9312B9AC,
@@ -85,5 +91,38 @@
         W3dMesh = 0xC2B1A262,
         WeaponTemplate = 0x94D4D96E,
         Weather = 0x90D951AD,
+    }
+
+    /// <summary>
+    /// Some assets binary assets (<see cref="Asset"/>)
+    /// have their format changed between different SAGE games,
+    /// and before we implement game-specific parsing of those assets,
+    /// OpenSage may run into issues when trying to parse them.
+    /// <br/>
+    /// This attribute is indeed used on those kind of assets where
+    /// currently we do not (yet) have game-specific parsing code,
+    /// so we skip parsing them for now, to avoid errors.
+    /// <br/>
+    /// This is a temporary workaround and should eventually be removed.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field)]
+    public sealed class SkipParsingInAttribute : Attribute
+    {
+        public SageGame Game { get; init; }
+
+        public static bool ShouldSkipFor(uint enumVal, SageGame game)
+        {
+            var type = typeof(AssetType);
+            var memInfo = type.GetMember(((AssetType) enumVal).ToString());
+            var attributes = memInfo[0].GetCustomAttributes(typeof(SkipParsingInAttribute), false);
+            foreach (var attribute in attributes)
+            {
+                if (((SkipParsingInAttribute) attribute).Game == game)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 }

--- a/src/OpenSage.Game/Data/StreamFS/GameStream.cs
+++ b/src/OpenSage.Game/Data/StreamFS/GameStream.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -56,7 +56,7 @@ namespace OpenSage.Data.StreamFS
 
                             if (Enum.IsDefined(typeof(AssetType), asset.Header.TypeId)) // TODO: Remove this.
                             {
-                                if (SkipParsingInAttribute.ShouldSkipFor(asset.Header.TypeId, game.SageGame))
+                                if (AssetTypeUtility.ShouldSkipFor(asset.Header.TypeId, game.SageGame))
                                 {
                                     Logger.Warn($"Skipped AssetType: {asset.Name.Split(':')[0]} = 0x{asset.Header.TypeId:X}");
                                     continue;

--- a/src/OpenSage.Game/Data/StreamFS/GameStream.cs
+++ b/src/OpenSage.Game/Data/StreamFS/GameStream.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using OpenSage.Diagnostics.Util;
 
 namespace OpenSage.Data.StreamFS
 {
@@ -55,6 +56,12 @@ namespace OpenSage.Data.StreamFS
 
                             if (Enum.IsDefined(typeof(AssetType), asset.Header.TypeId)) // TODO: Remove this.
                             {
+                                if (SkipParsingInAttribute.ShouldSkipFor(asset.Header.TypeId, game.SageGame))
+                                {
+                                    Logger.Warn($"Skipped AssetType: {asset.Name.Split(':')[0]} = 0x{asset.Header.TypeId:X}");
+                                    continue;
+                                }
+
                                 if (AssetReaderCatalog.TryGetAssetReader(asset.Header.TypeId, out var assetReader))
                                 {
                                     using (var instanceDataStream = new MemoryStream(instanceData, false))
@@ -91,7 +98,7 @@ namespace OpenSage.Data.StreamFS
                             else
                             {
                                 // TODO
-                                Logger.Info($"Missing AssetType: {asset.Name.Split(':')[0]} = 0x{asset.Header.TypeId.ToString("X")},");
+                                Logger.Info($"Missing AssetType: {asset.Name.Split(':')[0]} = 0x{asset.Header.TypeId:X}");
                             }
                         }
                     });
@@ -99,7 +106,7 @@ namespace OpenSage.Data.StreamFS
             });
         }
 
-        private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+        private static readonly DistinctLogger Logger = new(NLog.LogManager.GetCurrentClassLogger());
 
         private void ReadBinReloImpData(
             BinaryReader binReader,

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -438,6 +438,7 @@ namespace OpenSage
                 GraphicsLoadContext = new GraphicsLoadContext(GraphicsDevice, standardGraphicsResources, shaderResources);
 
                 AssetStore = new AssetStore(
+                    SageGame,
                     _fileSystem,
                     LanguageUtility.ReadCurrentLanguage(Definition, _fileSystem.RootDirectory),
                     GraphicsDevice,

--- a/src/OpenSage.Game/Logic/Object/GameObjectCollection.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObjectCollection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenSage.Diagnostics.Util;
 
 namespace OpenSage.Logic.Object
 {
@@ -18,7 +19,7 @@ namespace OpenSage.Logic.Object
 
         public IEnumerable<GameObject> Items => _items.Values;
 
-        private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+        private static readonly DistinctLogger Logger = new(NLog.LogManager.GetCurrentClassLogger());
 
         internal GameObjectCollection(
             GameContext gameContext,


### PR DESCRIPTION
- Added a simple version system for skudef, allowing OpenSage to load the lastest skudef (d37b854)
- Removed empty csf category warning for RA3 (1845c0f)
- Fixed case sensitive asset hash (it was incorrectly using case insensitive hash) (81fb8aa)
- Support `DdsImageFormat.Rgba16Float` (b7fb56a)
- Allows `OpenSage.Data.StreamFS.GameStream` to conditionally skip parsing binary assets based on current `SageGame` type (Mainly audio files, they don't work yet on RA3 right now) (1888aa9)
- Allow `AssetType` override based on `SageGame` (f1c6d79), because the same asset might have different names (so different asset id) in different games 
- Removed duplicate warnings in `GameObjectCollections` (e8335b2), now `[Warn] Skipping unknown GameObject {Type}` will be logged only once per each different type of `GameObject`.