### PR TITLE
Add teams and configure allies/enemies

### DIFF
--- a/src/OpenSage.Game/Data/Sav/SaveFile.cs
+++ b/src/OpenSage.Game/Data/Sav/SaveFile.cs
@@ -108,7 +108,7 @@ namespace OpenSage.Data.Sav
                                         new PlayerSetting(
                                             null,
                                             game.AssetStore.PlayerTemplates.GetByName("FactionAmerica"), // TODO
-                                            new ColorRgb(0, 0, 255))
+                                            new ColorRgb(0, 0, 255), 0)
                                     },
                                     localPlayerIndex: 0, // TODO
                                     isMultiPlayer: false,

--- a/src/OpenSage.Game/Diagnostics/MainView.cs
+++ b/src/OpenSage.Game/Diagnostics/MainView.cs
@@ -179,8 +179,8 @@ namespace OpenSage.Diagnostics
                                 new EchoConnection(),
                                 new PlayerSetting?[]
                                 {
-                                    new PlayerSetting(null, _faction, new ColorRgb(255, 0, 0), PlayerOwner.Player),
-                                    new PlayerSetting(null, faction2, new ColorRgb(255, 255, 255), PlayerOwner.EasyAi),
+                                    new PlayerSetting(null, _faction, new ColorRgb(255, 0, 0), 0, PlayerOwner.Player),
+                                    new PlayerSetting(null, faction2, new ColorRgb(255, 255, 255), 0, PlayerOwner.EasyAi),
                                 },
                                 0,
                                 Environment.TickCount

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -227,7 +227,7 @@ namespace OpenSage
                     }
 
                 }
-                pSettings.Add(new PlayerSetting(slot.StartPosition, faction, color, owner, slot.HumanName));
+                pSettings.Add(new PlayerSetting(slot.StartPosition, faction, color, (byte)slot.Team, owner, slot.HumanName));
             }
 
             return pSettings;
@@ -719,6 +719,26 @@ namespace OpenSage
                     }
                 }
 
+                for (var i = 1; i < players.Length; i++)
+                {
+                    var outerPlayer = players[i];
+                    for (var j = 1; j < players.Length; j++)
+                    {
+                        if (i == j) continue;
+                        var innerPlayer = players[j];
+                        if (outerPlayer.Team == innerPlayer.Team && outerPlayer.Team != 0)
+                        {
+                            outerPlayer.AddAlly(innerPlayer);
+                            innerPlayer.AddAlly(outerPlayer);
+                        }
+                        else
+                        {
+                            outerPlayer.AddEnemy(innerPlayer);
+                            innerPlayer.AddEnemy(outerPlayer);
+                        }
+                    }
+                }
+
                 // TODO: Theoretically, there could be multiple civilian players
                 Scene3D.SetSkirmishPlayers(players, players[localPlayerIndex]);
                 Scripting.InitializeSkirmishGame();
@@ -771,6 +791,7 @@ namespace OpenSage
                                       s.Index,
                                       GetItem(s.FactionIndex, GetPlayableSides()),
                                       GetItem(s.ColorIndex, AssetStore.MultiplayerColors).RgbColor,
+                                      s.Team,
                                       s.State switch
                                       {
                                           SkirmishSlotState.EasyArmy => PlayerOwner.EasyAi,

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -227,7 +227,7 @@ namespace OpenSage
                     }
 
                 }
-                pSettings.Add(new PlayerSetting(slot.StartPosition, faction, color, (byte)slot.Team, owner, slot.HumanName));
+                pSettings.Add(new PlayerSetting(slot.StartPosition, faction, color, slot.Team, owner, slot.HumanName));
             }
 
             return pSettings;

--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -93,7 +93,7 @@ namespace OpenSage.Logic
 
         public GameObject HoveredUnit { get; set; }
 
-        public byte Team { get; init; }
+        public int Team { get; init; }
 
         public Player(PlayerTemplate template, in ColorRgb color)
         {

--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -93,6 +93,8 @@ namespace OpenSage.Logic
 
         public GameObject HoveredUnit { get; set; }
 
+        public byte Team { get; init; }
+
         public Player(PlayerTemplate template, in ColorRgb color)
         {
             Template = template;
@@ -452,8 +454,19 @@ namespace OpenSage.Logic
                 Name = setting == null ? template.Name : setting?.Name,
                 DisplayName = template.DisplayName.Translate(),
                 Money = (uint)(template.StartMoney + gameData.DefaultStartingCash),
-                IsHuman = setting?.Owner == PlayerOwner.Player
+                IsHuman = setting?.Owner == PlayerOwner.Player,
+                Team = setting?.Team ?? default,
             };
+        }
+
+        public void AddAlly(Player player)
+        {
+            _allies.Add(player);
+        }
+
+        public void AddEnemy(Player player)
+        {
+            _enemies.Add(player);
         }
     }
 

--- a/src/OpenSage.Game/Logic/PlayerSettings.cs
+++ b/src/OpenSage.Game/Logic/PlayerSettings.cs
@@ -21,9 +21,9 @@ namespace OpenSage.Logic
         public PlayerTemplate Template { get; set; }
         public PlayerOwner Owner { get; set; }
         public string Name { get; set; }
-        public byte Team { get; set; }
+        public int Team { get; set; }
 
-        public PlayerSetting(int? startPosition, PlayerTemplate template, ColorRgb color, byte team, PlayerOwner owner = PlayerOwner.None, string name = "")
+        public PlayerSetting(int? startPosition, PlayerTemplate template, ColorRgb color, int team, PlayerOwner owner = PlayerOwner.None, string name = "")
         {
             StartPosition = startPosition;
             Template = template;

--- a/src/OpenSage.Game/Logic/PlayerSettings.cs
+++ b/src/OpenSage.Game/Logic/PlayerSettings.cs
@@ -21,14 +21,16 @@ namespace OpenSage.Logic
         public PlayerTemplate Template { get; set; }
         public PlayerOwner Owner { get; set; }
         public string Name { get; set; }
+        public byte Team { get; set; }
 
-        public PlayerSetting(int? startPosition, PlayerTemplate template, ColorRgb color, PlayerOwner owner = PlayerOwner.None, string name = "")
+        public PlayerSetting(int? startPosition, PlayerTemplate template, ColorRgb color, byte team, PlayerOwner owner = PlayerOwner.None, string name = "")
         {
             StartPosition = startPosition;
             Template = template;
             Color = color;
             Owner = owner;
             Name = name;
+            Team = team;
         }
     }
 }

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -182,8 +182,8 @@ namespace OpenSage.Launcher
                         {
                             var pSettings = new PlayerSetting?[]
                             {
-                                new PlayerSetting(null, game.AssetStore.PlayerTemplates.GetByName("FactionAmerica"), new ColorRgb(255, 0, 0), PlayerOwner.Player),
-                                new PlayerSetting(null, game.AssetStore.PlayerTemplates.GetByName("FactionGLA"), new ColorRgb(0, 255, 0), PlayerOwner.EasyAi),
+                                new PlayerSetting(null, game.AssetStore.PlayerTemplates.GetByName("FactionAmerica"), new ColorRgb(255, 0, 0), 0, PlayerOwner.Player),
+                                new PlayerSetting(null, game.AssetStore.PlayerTemplates.GetByName("FactionGLA"), new ColorRgb(0, 255, 0), 0, PlayerOwner.EasyAi),
                             };
 
                             logger.Debug("Starting multiplayer game");

--- a/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
@@ -328,7 +328,7 @@ namespace OpenSage.Mods.Generals.Gui
                 // Get the selected player team
                 selected = GetSelectedComboBoxIndex(_optionsPath + ComboBoxTeamPrefix + i);
 
-                setting.Team = (byte)selected;
+                setting.Team = selected;
 
                 settingsList.Add(setting);
             }

--- a/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
@@ -324,6 +324,11 @@ namespace OpenSage.Mods.Generals.Gui
                     int r = rnd.Next(_playableSides.Count);
                     setting.Template = _playableSides[r];
                 }
+
+                // Get the selected player team
+                selected = GetSelectedComboBoxIndex(_optionsPath + ComboBoxTeamPrefix + i);
+
+                setting.Team = (byte)selected;
 
                 settingsList.Add(setting);
             }


### PR DESCRIPTION
This utilized the teams configured in a skirmish lobby and populates each player's allies/enemies.