### PR TITLE
Fix #532 add null check on CurrentWeapon in TurretAIUpdate

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TurretAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TurretAIUpdate.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using OpenSage.Data.Ini;
 using OpenSage.Mathematics;
@@ -39,13 +39,13 @@ namespace OpenSage.Logic.Object
         {
             var deltaTime = (float) context.Time.DeltaTime.TotalSeconds;
 
-            var target = _gameObject.CurrentWeapon.CurrentTarget;
+            var target = _gameObject.CurrentWeapon?.CurrentTarget;
             float targetYaw;
 
             if (_gameObject.ModelConditionFlags.Get(ModelConditionFlag.Moving))
             {
                 _turretAIstate = TurretAIStates.Recentering;
-                _gameObject.CurrentWeapon.SetTarget(null);
+                _gameObject.CurrentWeapon?.SetTarget(null);
             }
 
             switch (_turretAIstate)


### PR DESCRIPTION
Vehicles like the GLA Radar Van have no Weapon Set defined, and thus CurrentWeapon will never be anything but null for them.