### PR TITLE
Generals & ZH command bar button limit = ButtonCommand children in ControlBar.wnd (max 99)

### DIFF
--- a/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
@@ -236,9 +236,13 @@ namespace OpenSage.Mods.Generals.Gui
 
             protected void ApplyCommandSet(GameObject selectedUnit, GeneralsControlBar controlBar, CommandSet commandSet)
             {
-                for (var i = 1; i <= 12; i++)
+                for (var i = 1; i < 100; i++) // Generals has 12 buttons and Zero Hour has 14, but there's no need to set those values as the limit in the code
                 {
                     var buttonControl = controlBar._commandWindow.Controls.FindControl($"ControlBar.wnd:ButtonCommand{i:D2}") as Button;
+
+                    // the amount of ButtonCommand children in ControlBar.wnd defines how many buttons the game will have in-game
+                    if ( controlBar._commandWindow.Controls.FindControl($"ControlBar.wnd:ButtonCommand{i:D2}") == null )
+                        break;
 
                     if (commandSet != null && commandSet.Buttons.TryGetValue(i, out var commandButtonReference))
                     {


### PR DESCRIPTION
With this, all the buttons in Zero Hour show up as they should.
I think a maximum of 99 buttons should suffice. :) I chose that number simply because of the naming scheme of ButtonCommandXX with it starting at 01.

Refs #462 