### PR TITLE
Revert Normalize FileSystem's root directory

### DIFF
--- a/src/OpenSage.Game/Data/FileSystem.cs
+++ b/src/OpenSage.Game/Data/FileSystem.cs
@@ -21,7 +21,7 @@ namespace OpenSage.Data
                           FileSystem nextFileSystem = null,
                           IEnumerable<KeyValuePair<string, string>> realPathsToVirtualPaths = null)
         {
-            RootDirectory = NormalizeFilePath(rootDirectory);
+            RootDirectory = rootDirectory;
             RootDirectoryWithSlash = RootDirectory.EndsWith(Path.DirectorySeparatorChar)
                 ? RootDirectory
                 : RootDirectory + Path.DirectorySeparatorChar;


### PR DESCRIPTION
Do not normalize path in FileSystem constructor.

NormalizeFilePath() lowercase paths, this break on linux ("/Command and Conquer Generals" become "/command and conquer generals") and crash calling OpenSage.Utilities.LanguageUtility.DetectFromFileSystem()