### PR TITLE
Skirmish refactoring

### DIFF
--- a/src/OpenSage.Game.Tests/Mods/Generals/StartingPositionAssignmentTests.cs
+++ b/src/OpenSage.Game.Tests/Mods/Generals/StartingPositionAssignmentTests.cs
@@ -1,0 +1,421 @@
+﻿using OpenSage.Mods.Generals.Gui;
+using OpenSage.Network;
+using Xunit;
+
+namespace OpenSage.Tests.Mods.Generals
+{
+    public class StartingPositionAssignmentTests
+    {
+        [Fact]
+        public void JustHost_HostClickedEmpty_AssignsHost()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+
+            GameOptionsUtil.StartingPositionClicked(settings, 2);
+
+            Assert.Equal(2, settings.Slots[0].StartPosition);
+        }
+
+        [Fact]
+        public void JustHost_HostClickedHost_UnassignsHost()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[0].StartPosition = 2;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 2);
+
+            Assert.Equal(0, settings.Slots[0].StartPosition);
+        }
+
+        [Fact]
+        public void JustHost_HostClickedEmpty_UpdatesHost()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[0].StartPosition = 3;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 1);
+
+            Assert.Equal(1, settings.Slots[0].StartPosition);
+        }
+
+        [Fact]
+        public void HostAndAI_HostClickedEmptyTwice_AssignsAI()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[1].State = SkirmishSlotState.EasyArmy;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+
+            Assert.Equal(0, settings.Slots[0].StartPosition);
+            Assert.Equal(4, settings.Slots[1].StartPosition);
+        }
+
+        [Fact]
+        public void HostAndAI_HostClickedEmptyThreeTimes_DoesNothing()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[1].State = SkirmishSlotState.EasyArmy;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+
+            Assert.Equal(0, settings.Slots[0].StartPosition);
+            Assert.Equal(0, settings.Slots[1].StartPosition);
+        }
+
+        [Fact]
+        public void HostAndTwoAIs_HostClickedEmpty_AssignsHost()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[1].State = SkirmishSlotState.EasyArmy;
+            settings.Slots[2].State = SkirmishSlotState.HardArmy;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+
+            Assert.Equal(4, settings.Slots[0].StartPosition);
+            Assert.Equal(0, settings.Slots[1].StartPosition);
+            Assert.Equal(0, settings.Slots[2].StartPosition);
+        }
+
+        [Fact]
+        public void HostAndTwoAIs_HostClickedEmptyTwice_AssignsFirstAI()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[1].State = SkirmishSlotState.EasyArmy;
+            settings.Slots[2].State = SkirmishSlotState.HardArmy;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+
+            Assert.Equal(0, settings.Slots[0].StartPosition);
+            Assert.Equal(4, settings.Slots[1].StartPosition);
+            Assert.Equal(0, settings.Slots[2].StartPosition);
+        }
+
+        [Fact]
+        public void HostAndTwoAIs_HostClickedEmptyThreeTimes_AssignsSecondAI()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[1].State = SkirmishSlotState.EasyArmy;
+            settings.Slots[2].State = SkirmishSlotState.HardArmy;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+
+            Assert.Equal(0, settings.Slots[0].StartPosition);
+            Assert.Equal(0, settings.Slots[1].StartPosition);
+            Assert.Equal(4, settings.Slots[2].StartPosition);
+        }
+
+        [Fact]
+        public void HostAndAI_HostClickedHost_UnassignsHost()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[0].StartPosition = 1;
+            settings.Slots[1].State = SkirmishSlotState.EasyArmy;
+            settings.Slots[1].StartPosition = 2;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 1);
+            
+            Assert.Equal(0, settings.Slots[0].StartPosition);
+            Assert.Equal(2, settings.Slots[1].StartPosition);
+        }
+
+        [Fact]
+        public void HostAndAI_HostClickedAI_UnassignsAI()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[0].StartPosition = 1;
+            settings.Slots[1].State = SkirmishSlotState.MediumArmy;
+            settings.Slots[1].StartPosition = 2;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 2);
+
+            Assert.Equal(1, settings.Slots[0].StartPosition);
+            Assert.Equal(0, settings.Slots[1].StartPosition);
+        }
+
+        [Fact]
+        public void HostAndHuman_HostClickedEmptyTwice_DoesNothing()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[1].State = SkirmishSlotState.Human;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+
+            Assert.Equal(0, settings.Slots[0].StartPosition);
+            Assert.Equal(0, settings.Slots[1].StartPosition);
+        }
+
+        [Fact]
+        public void HostAndHuman_HostClickedEmptyThreeTimes_AssignsHost()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[1].State = SkirmishSlotState.Human;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+
+            Assert.Equal(4, settings.Slots[0].StartPosition);
+            Assert.Equal(0, settings.Slots[1].StartPosition);
+        }
+
+        [Fact]
+        public void HostAndHuman_HostClickedHost_UnassignsHost()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[0].StartPosition = 1;
+            settings.Slots[1].State = SkirmishSlotState.Human;
+            settings.Slots[1].StartPosition = 2;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 1);
+
+            Assert.Equal(0, settings.Slots[0].StartPosition);
+            Assert.Equal(2, settings.Slots[1].StartPosition);
+        }
+
+        [Fact]
+        public void HostAndHuman_HostClickedHuman_DoesNothing()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[0].StartPosition = 1;
+            settings.Slots[1].State = SkirmishSlotState.Human;
+            settings.Slots[1].StartPosition = 2;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 2);
+
+            Assert.Equal(1, settings.Slots[0].StartPosition);
+            Assert.Equal(2, settings.Slots[1].StartPosition);
+        }
+
+        [Fact]
+        public void HostAIAndHuman_HostClickedHost_UnassignsHost()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[0].StartPosition = 1;
+            settings.Slots[1].State = SkirmishSlotState.EasyArmy;
+            settings.Slots[1].StartPosition = 2;
+            settings.Slots[2].State = SkirmishSlotState.Human;
+            settings.Slots[2].StartPosition = 4;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 1);
+
+            Assert.Equal(0, settings.Slots[0].StartPosition);
+            Assert.Equal(2, settings.Slots[1].StartPosition);
+            Assert.Equal(4, settings.Slots[2].StartPosition);
+        }
+
+        [Fact]
+        public void HostAIAndHuman_HostClickedAI_UnassignsAI()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[0].StartPosition = 1;
+            settings.Slots[1].State = SkirmishSlotState.MediumArmy;
+            settings.Slots[1].StartPosition = 2;
+            settings.Slots[2].State = SkirmishSlotState.Human;
+            settings.Slots[2].StartPosition = 4;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 2);
+
+            Assert.Equal(1, settings.Slots[0].StartPosition);
+            Assert.Equal(0, settings.Slots[1].StartPosition);
+            Assert.Equal(4, settings.Slots[2].StartPosition);
+        }
+
+        [Fact]
+        public void HostAIAndHuman_HostClickedHuman_DoesNothing()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[0].StartPosition = 1;
+            settings.Slots[1].State = SkirmishSlotState.HardArmy;
+            settings.Slots[1].StartPosition = 2;
+            settings.Slots[2].State = SkirmishSlotState.Human;
+            settings.Slots[2].StartPosition = 4;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+
+            Assert.Equal(1, settings.Slots[0].StartPosition);
+            Assert.Equal(2, settings.Slots[1].StartPosition);
+            Assert.Equal(4, settings.Slots[2].StartPosition);
+        }
+
+        [Fact]
+        public void HostAIAndHuman_HostClickedEmpty_AssignsHost()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+            settings.Slots[0].StartPosition = 1;
+            settings.Slots[1].State = SkirmishSlotState.EasyArmy;
+            settings.Slots[1].StartPosition = 2;
+            settings.Slots[2].State = SkirmishSlotState.Human;
+            settings.Slots[2].StartPosition = 4;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 3);
+
+            Assert.Equal(3, settings.Slots[0].StartPosition);
+            Assert.Equal(2, settings.Slots[1].StartPosition);
+            Assert.Equal(4, settings.Slots[2].StartPosition);
+        }
+
+        [Fact]
+        public void HostHumanAndAI_HumanClickedHost_DoesNothing()
+        {
+            var settings = new SkirmishGameSettings(false) { LocalSlotIndex = 1 };
+            settings.Slots[0].StartPosition = 1;
+            settings.Slots[1].State = SkirmishSlotState.Human;
+            settings.Slots[1].StartPosition = 2;
+            settings.Slots[2].State = SkirmishSlotState.EasyArmy;
+            settings.Slots[2].StartPosition = 4;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 1);
+
+            Assert.Equal(1, settings.Slots[0].StartPosition);
+            Assert.Equal(2, settings.Slots[1].StartPosition);
+            Assert.Equal(4, settings.Slots[2].StartPosition);
+        }
+
+        [Fact]
+        public void HostHumanAndAI_HumanClickedHuman_UnassignsHuman()
+        {
+            var settings = new SkirmishGameSettings(false) { LocalSlotIndex = 1 };
+            settings.Slots[0].StartPosition = 1;
+            settings.Slots[1].State = SkirmishSlotState.Human;
+            settings.Slots[1].StartPosition = 2;
+            settings.Slots[2].State = SkirmishSlotState.EasyArmy;
+            settings.Slots[2].StartPosition = 4;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 2);
+
+            Assert.Equal(1, settings.Slots[0].StartPosition);
+            Assert.Equal(0, settings.Slots[1].StartPosition);
+            Assert.Equal(4, settings.Slots[2].StartPosition);
+        }
+
+        [Fact]
+        public void HostHumanAndAI_HumanClickedAI_DoesNothing()
+        {
+            var settings = new SkirmishGameSettings(false) { LocalSlotIndex = 1 };
+            settings.Slots[0].StartPosition = 1;
+            settings.Slots[1].State = SkirmishSlotState.Human;
+            settings.Slots[1].StartPosition = 2;
+            settings.Slots[2].State = SkirmishSlotState.EasyArmy;
+            settings.Slots[2].StartPosition = 4;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+
+            Assert.Equal(1, settings.Slots[0].StartPosition);
+            Assert.Equal(2, settings.Slots[1].StartPosition);
+            Assert.Equal(4, settings.Slots[2].StartPosition);
+        }
+
+        [Fact]
+        public void HostHumanAndAI_HumanClickedEmpty_AssignsHuman()
+        {
+            var settings = new SkirmishGameSettings(false) { LocalSlotIndex = 1 };
+            settings.Slots[0].StartPosition = 1;
+            settings.Slots[1].State = SkirmishSlotState.Human;
+            settings.Slots[1].StartPosition = 2;
+            settings.Slots[2].State = SkirmishSlotState.EasyArmy;
+            settings.Slots[2].StartPosition = 4;
+
+            GameOptionsUtil.StartingPositionClicked(settings, 3);
+
+            Assert.Equal(1, settings.Slots[0].StartPosition);
+            Assert.Equal(3, settings.Slots[1].StartPosition);
+            Assert.Equal(4, settings.Slots[2].StartPosition);
+        }
+
+        [Fact]
+        public void ComplexInteraction()
+        {
+            var settings = new SkirmishGameSettings(true) { LocalSlotIndex = 0 };
+
+            // host clicks on 1 and assigns host
+            GameOptionsUtil.StartingPositionClicked(settings, 1);
+            Assert.Equal(1, settings.Slots[0].StartPosition);
+
+            // host clicks on 2 and updates host
+            GameOptionsUtil.StartingPositionClicked(settings, 2);
+            Assert.Equal(2, settings.Slots[0].StartPosition);
+
+            // host clicks on 2 again and unassigns host
+            GameOptionsUtil.StartingPositionClicked(settings, 2);
+            Assert.Equal(0, settings.Slots[0].StartPosition);
+
+            // host adds AI
+            settings.Slots[1].State = SkirmishSlotState.EasyArmy;
+
+            // host clicks on 3 and assigns host
+            GameOptionsUtil.StartingPositionClicked(settings, 3);
+            Assert.Equal(3, settings.Slots[0].StartPosition);
+
+            // host clicks on 3 again and assigns AI
+            GameOptionsUtil.StartingPositionClicked(settings, 3);
+            Assert.Equal(0, settings.Slots[0].StartPosition);
+            Assert.Equal(3, settings.Slots[1].StartPosition);
+
+            // human joins
+            settings.Slots[2].State = SkirmishSlotState.Human;
+
+            // host clicks on 3 and unassigns AI
+            GameOptionsUtil.StartingPositionClicked(settings, 3);
+            Assert.Equal(0, settings.Slots[1].StartPosition);
+
+            // human selected position 4
+            settings.Slots[2].StartPosition = 4;
+
+            // host clicks on 4 and nothing happens
+            GameOptionsUtil.StartingPositionClicked(settings, 4);
+            Assert.Equal(0, settings.Slots[0].StartPosition);
+            Assert.Equal(4, settings.Slots[2].StartPosition);
+
+            // host closes slot 3
+            settings.Slots[3].State = SkirmishSlotState.Closed;
+
+            // host adds another AI
+            settings.Slots[4].State = SkirmishSlotState.HardArmy;
+
+            // host clicks on 2 and assigns host
+            GameOptionsUtil.StartingPositionClicked(settings, 2);
+            Assert.Equal(2, settings.Slots[0].StartPosition);
+
+            // host clicks on 2 again and assigns first AI
+            GameOptionsUtil.StartingPositionClicked(settings, 2);
+            Assert.Equal(0, settings.Slots[0].StartPosition);
+            Assert.Equal(2, settings.Slots[1].StartPosition);
+
+            // host clicks on 2 again and assigns second AI
+            GameOptionsUtil.StartingPositionClicked(settings, 2);
+            Assert.Equal(0, settings.Slots[1].StartPosition);
+            Assert.Equal(2, settings.Slots[4].StartPosition);
+
+            // host clicks on 2 again and unassigns second AI
+            GameOptionsUtil.StartingPositionClicked(settings, 2);
+            Assert.Equal(0, settings.Slots[4].StartPosition);
+
+            // host clicks on 2 and assigns host
+            GameOptionsUtil.StartingPositionClicked(settings, 2);
+            Assert.Equal(2, settings.Slots[0].StartPosition);
+
+            // host clicks on 1 and assigns first AI
+            GameOptionsUtil.StartingPositionClicked(settings, 1);
+            Assert.Equal(1, settings.Slots[1].StartPosition);
+
+            // host clicks on 3 and assigns second AI
+            GameOptionsUtil.StartingPositionClicked(settings, 3);
+            Assert.Equal(3, settings.Slots[4].StartPosition);
+
+            // host clicks on 6 and assigns host
+            GameOptionsUtil.StartingPositionClicked(settings, 6);
+            Assert.Equal(6, settings.Slots[0].StartPosition);
+
+            Assert.Equal(1, settings.Slots[1].StartPosition);
+            Assert.Equal(4, settings.Slots[2].StartPosition);
+            Assert.Equal(3, settings.Slots[4].StartPosition);
+        }
+    }
+}

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -776,16 +776,11 @@ namespace OpenSage
             StartSinglePlayerGame(firstMission.Map);
         }
 
-        public void HostSkirmishGame()
+        private void StartSkirmishGame()
         {
+            var random = new Random(SkirmishManager.Settings.Seed);
 
-        }
-
-        private void StartSkirmishGame(SkirmishGame skirmishGame)
-        {
-            var random = new Random(skirmishGame.Seed);
-
-            var playerSettings = (from s in skirmishGame.Slots
+            var playerSettings = (from s in SkirmishManager.Settings.Slots
                                   where s.State != SkirmishSlotState.Open && s.State != SkirmishSlotState.Closed
                                   select new PlayerSetting(
                                       s.StartPosition == 0 ? null : s.StartPosition,
@@ -802,11 +797,11 @@ namespace OpenSage
                                       })).OfType<PlayerSetting?>().ToArray();
 
             StartMultiPlayerGame(
-                skirmishGame.MapName,
+                SkirmishManager.Settings.MapName,
                 SkirmishManager.Connection,
                 playerSettings,
-                skirmishGame.LocalSlotIndex,
-                skirmishGame.Seed);
+                SkirmishManager.Settings.LocalSlotIndex,
+                SkirmishManager.Settings.Seed);
 
             T GetItem<T>(int index, IEnumerable<T> items) =>
                 items.ElementAt(index switch
@@ -957,10 +952,11 @@ namespace OpenSage
             Scene3D?.LocalLogicTick(MapTime, tickT);
 
             // TODO: do this properly (this is a hack to call StartMultiplayerGame on the correct thread)
-            if (SkirmishManager?.SkirmishGame?.Status == SkirmishGameStatus.ReadyToStart)
+            if (SkirmishManager?.Settings?.Status == SkirmishGameStatus.ReadyToStart)
             {
-                SkirmishManager.SkirmishGame.Status = SkirmishGameStatus.Started;
-                StartSkirmishGame(SkirmishManager.SkirmishGame);
+                SkirmishManager.Settings.Status = SkirmishGameStatus.Started;
+                Scene2D.WndWindowManager.PopWindow();
+                StartSkirmishGame();
             }
 
             Audio.Update(Scene3D?.Camera);

--- a/src/OpenSage.Game/Gui/Wnd/Controls/ComboBox.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Controls/ComboBox.cs
@@ -258,7 +258,7 @@ namespace OpenSage.Gui.Wnd.Controls
                 0,
                 ClientSize.Height,
                 ClientSize.Width,
-                itemsHeight);
+                itemsHeight + 2);
         }
 
         protected override void Dispose(bool disposeManagedResources)

--- a/src/OpenSage.Game/Gui/Wnd/Controls/ListBox.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Controls/ListBox.cs
@@ -400,15 +400,16 @@ namespace OpenSage.Gui.Wnd.Controls
         {
             var stillVisible = MaxDisplay == -1 ? Items.Length : MaxDisplay;
             var y = 0;
-            if (Controls.Any())
+            var firstChild = Controls.FirstOrDefault();
+            if (firstChild != null)
             {
-                y = _currentStartIndex * Controls.First().GetPreferredSize(ClientSize).Height * -1;
+                y = _currentStartIndex * firstChild.GetPreferredSize(ClientSize).Height * -1;
             }
 
             foreach (var child in Controls.AsList())
             {
                 var childHeight = child.GetPreferredSize(ClientSize).Height;
-                if (y >= 0 && stillVisible > 0)
+                if (y >= 0 && y + childHeight < Bounds.Height && stillVisible > 0)
                 {
                     child.Visible = true;
                     stillVisible--;
@@ -454,6 +455,7 @@ namespace OpenSage.Gui.Wnd.Controls
             }
 
             const int horizontalPadding = 3;
+            const int verticalPadding = 1;
             var availableWidth = proposedSize.Width - ((_parent.ColumnWidths.Length + 1) * horizontalPadding);
 
             int calculateColumnWidth(int column)
@@ -479,7 +481,7 @@ namespace OpenSage.Gui.Wnd.Controls
 
             var result = new ListBoxItemDimension
             {
-                Size = new Size(proposedSize.Width, itemHeight),
+                Size = new Size(proposedSize.Width, itemHeight + 2 * verticalPadding),
                 ColumnBounds = new Rectangle[_parent.ColumnWidths.Length]
             };
 
@@ -488,7 +490,7 @@ namespace OpenSage.Gui.Wnd.Controls
             {
                 var columnWidth = calculateColumnWidth(column);
 
-                result.ColumnBounds[column] = new Rectangle(x, 0, columnWidth, itemHeight);
+                result.ColumnBounds[column] = new Rectangle(x, verticalPadding, columnWidth, itemHeight);
 
                 x += columnWidth + horizontalPadding;
             }

--- a/src/OpenSage.Game/Network/NetworkConnection.cs
+++ b/src/OpenSage.Game/Network/NetworkConnection.cs
@@ -18,7 +18,7 @@ namespace OpenSage.Network
     {
         private IPAddress _hostAddress;
 
-        public ClientNetworkConnection(SkirmishGame game): base(game)
+        public ClientNetworkConnection(SkirmishGameSettings game): base(game)
         {
             _hostAddress = game.Slots[0].EndPoint.Address;
         }
@@ -47,7 +47,7 @@ namespace OpenSage.Network
 
     public sealed class HostNetworkConnection : NetworkConnection
     {
-        public HostNetworkConnection(SkirmishGame game) : base(game)
+        public HostNetworkConnection(SkirmishGameSettings game) : base(game)
         {
             _listener.ConnectionRequestEvent += request =>
             {
@@ -111,7 +111,7 @@ namespace OpenSage.Network
 
         protected static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
-        public NetworkConnection(SkirmishGame game)
+        public NetworkConnection(SkirmishGameSettings game)
         {
             _numberOfOtherPlayers = game.Slots.Count(s => s.State == SkirmishSlotState.Human) - 1;
             _listener = new EventBasedNetListener();

--- a/src/OpenSage.Game/Network/Packets/SkirmishClientUpdatePacket.cs
+++ b/src/OpenSage.Game/Network/Packets/SkirmishClientUpdatePacket.cs
@@ -6,6 +6,7 @@
         public byte ColorIndex { get; set; }
         public byte FactionIndex { get; set; }
         public byte Team { get; set; }
+        public byte StartPosition { get; set; }
         public bool Ready { get; set; }
     }
 }

--- a/src/OpenSage.Game/Network/SkirmishGameSettings.cs
+++ b/src/OpenSage.Game/Network/SkirmishGameSettings.cs
@@ -2,18 +2,20 @@
 
 namespace OpenSage.Network
 {
-    public class SkirmishGame
+    public class SkirmishGameSettings
     {
+        public const int MaxNumberOfPlayers = 8;
+
         private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
         private bool _isDirty;
         private string _mapName;
         private SkirmishGameStatus _status;
 
-        public SkirmishGame(bool isHost)
+        public SkirmishGameSettings(bool isHost)
         {
             IsHost = isHost;
-            Slots = Enumerable.Range(0, 8).Select(i => new SkirmishSlot(i)).ToArray();
+            Slots = Enumerable.Range(0, MaxNumberOfPlayers).Select(i => new SkirmishSlot(i)).ToArray();
             Status = SkirmishGameStatus.Configuring;
         }
 
@@ -60,7 +62,6 @@ namespace OpenSage.Network
         public SkirmishSlot[] Slots { get; internal set; }
         public int LocalSlotIndex { get; set; } = -1;
         public SkirmishSlot LocalSlot { get { return (LocalSlotIndex < 0 || LocalSlotIndex >= Slots.Length) ? null : Slots[LocalSlotIndex]; } }
-        public bool ReadyToStart { get; internal set; }
         public int Seed { get; internal set; }
     }
 }

--- a/src/OpenSage.Game/Network/SkirmishManager.cs
+++ b/src/OpenSage.Game/Network/SkirmishManager.cs
@@ -25,7 +25,7 @@ namespace OpenSage.Network
             Settings = new SkirmishGameSettings(isHosting);
         }
 
-        public bool IsHosting { get; private set; }
+        public bool IsHosting { get; protected set; }
         public SkirmishGameSettings Settings { get; protected set; }
         public IConnection Connection { get; protected set; }
 
@@ -99,15 +99,10 @@ namespace OpenSage.Network
             _processor.RegisterNestedType(SkirmishSlot.Serialize, SkirmishSlot.Deserialize);
         }
 
-        public async override void Stop()
+        public override void Stop()
         {
             _isRunning = false;
             _thread = null;
-
-            if (UPnP.Status == UPnPStatus.PortsForwarded)
-            {
-                await UPnP.RemovePortForwardingAsync();
-            }
         }
 
         protected void StartThread()
@@ -402,6 +397,12 @@ namespace OpenSage.Network
                     Stop();
                     break;
             }
+        }
+
+        public override void Stop()
+        {
+            this.IsHosting = false;
+            base.Stop();
         }
     }
 }

--- a/src/OpenSage.Game/Network/SkirmishManager.cs
+++ b/src/OpenSage.Game/Network/SkirmishManager.cs
@@ -136,6 +136,8 @@ namespace OpenSage.Network
             Settings.MapName = packet.MapName;
             Settings.Slots = packet.Slots;
 
+            // after joining a game, we don't know our slot index, but once
+            // we got the slot data from the host, we can figure it out
             if (Settings.LocalSlotIndex < 0)
             {
                 Settings.LocalSlotIndex = Array.FindIndex(packet.Slots, s => s.ClientId == ClientInstance.Id);

--- a/src/OpenSage.Game/Network/SkirmishManager.cs
+++ b/src/OpenSage.Game/Network/SkirmishManager.cs
@@ -226,6 +226,7 @@ namespace OpenSage.Network
                             ColorIndex = localSlot.ColorIndex,
                             FactionIndex = localSlot.FactionIndex,
                             Team = localSlot.Team,
+                            StartPosition = localSlot.StartPosition
                         });
 
                         _manager.SendToAll(_writer, DeliveryMethod.ReliableUnordered);
@@ -255,6 +256,11 @@ namespace OpenSage.Network
                 slot.Team = packet.Team;
                 slot.FactionIndex = packet.FactionIndex;
                 slot.ColorIndex = packet.ColorIndex;
+
+                if (packet.StartPosition == 0 || packet.StartPosition == slot.StartPosition || !Settings.Slots.Any(s => s.StartPosition == packet.StartPosition))
+                {
+                    slot.StartPosition = packet.StartPosition;
+                }
             }
         }
 

--- a/src/OpenSage.Game/Network/SkirmishManager.cs
+++ b/src/OpenSage.Game/Network/SkirmishManager.cs
@@ -42,6 +42,8 @@ namespace OpenSage.Network
         public LocalSkirmishManager(Game game)
             : base(game, isHosting: true)
         {
+            Settings.LocalSlotIndex = 0;
+            Settings.LocalSlot.State = SkirmishSlotState.Human;
         }
 
         public override bool IsStartButtonEnabled() => true;

--- a/src/OpenSage.Game/Network/SkirmishSlot.cs
+++ b/src/OpenSage.Game/Network/SkirmishSlot.cs
@@ -5,12 +5,12 @@ namespace OpenSage.Network
 {
     public enum SkirmishSlotState : byte
     {
-        Closed,
         Open,
-        Human,
+        Closed,
         EasyArmy,
         MediumArmy,
         HardArmy,
+        Human,
     }
 
     public class SkirmishSlot

--- a/src/OpenSage.Game/Network/SkirmishSlot.cs
+++ b/src/OpenSage.Game/Network/SkirmishSlot.cs
@@ -109,8 +109,8 @@ namespace OpenSage.Network
             }
         }
 
-        private int _startPosition;
-        public int StartPosition
+        private byte _startPosition;
+        public byte StartPosition
         {
             get
             {
@@ -157,7 +157,7 @@ namespace OpenSage.Network
                 FactionIndex = reader.GetByte(),
                 Team = reader.GetByte(),
                 Ready = reader.GetBool(),
-                StartPosition = reader.GetInt(),
+                StartPosition = reader.GetByte(),
             };
 
             if (slot.State == SkirmishSlotState.Human)

--- a/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
@@ -132,7 +132,15 @@ namespace OpenSage.Mods.Generals.Gui
                     break;
                 case ComboBoxPlayerPrefix:
                     Logger.Trace($"Changed the player type box to {value}");
-                        
+                    slot.State = value switch
+                    {
+                        0 => SkirmishSlotState.Open,
+                        1 => SkirmishSlotState.Closed,
+                        2 => SkirmishSlotState.EasyArmy,
+                        3 => SkirmishSlotState.MediumArmy,
+                        4 => SkirmishSlotState.HardArmy,
+                        _ => throw new ArgumentException("invalid player type: " + value)
+                    };
                     break;
                 case ComboBoxPlayerTemplatePrefix:
                     Logger.Trace($"Changed the faction box to {value}");
@@ -184,11 +192,6 @@ namespace OpenSage.Mods.Generals.Gui
                         if (!ValidateSettings(settings, context.WindowManager))
                         {
                             return true;
-                        }
-
-                        if (_optionsPath.StartsWith("LanGame"))
-                        {
-                            Debugger.Break(); // context.Game.HostSkirmishGame();
                         }
 
                         context.Game.SkirmishManager.HandleStartButtonClickAsync();

--- a/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
@@ -115,6 +115,8 @@ namespace OpenSage.Mods.Generals.Gui
                 var startPosition = (byte)(i + 1);
                 ((Button) mapWindow.Controls[i]).Click += (s, e) => StartingPositionClicked(_game.SkirmishManager.Settings, startPosition);
             }
+
+            _window.Controls.FindControl(_optionsPath + ":ButtonSelectMap").Enabled = _game.SkirmishManager.IsHosting;
         }
 
         public static void StartingPositionClicked(SkirmishGameSettings settings, byte clickedPosition)

--- a/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
@@ -112,12 +112,12 @@ namespace OpenSage.Mods.Generals.Gui
             var mapWindow = _window.Controls.FindControl(_optionsPath + ":MapWindow");
             for (int i = 0; i < SkirmishGameSettings.MaxNumberOfPlayers; i++)
             {
-                var startPosition = i + 1;
+                var startPosition = (byte)(i + 1);
                 ((Button) mapWindow.Controls[i]).Click += (s, e) => StartingPositionClicked(_game.SkirmishManager.Settings, startPosition);
             }
         }
 
-        public static void StartingPositionClicked(SkirmishGameSettings settings, int clickedPosition)
+        public static void StartingPositionClicked(SkirmishGameSettings settings, byte clickedPosition)
         {            
             var currentlyAssignedPlayer = settings.Slots.FirstOrDefault(s => s.StartPosition == clickedPosition)?.Index ?? -1;
 

--- a/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
@@ -26,6 +26,8 @@ namespace OpenSage.Mods.Generals.Gui
         public const string ComboBoxPlayerPrefix = ":ComboBoxPlayer";
         public const string ButtonAcceptPrefix = ":ButtonAccept";
         public const string ButtonStart = ":ButtonStart";
+        public const string ButtonSelectMap = ":ButtonSelectMap";
+        public const string MapWindow = ":MapWindow";
 
         private readonly string _optionsPath;
         private readonly string _mapSelectPath;
@@ -109,14 +111,14 @@ namespace OpenSage.Mods.Generals.Gui
                 }
             }
 
-            var mapWindow = _window.Controls.FindControl(_optionsPath + ":MapWindow");
+            var mapWindow = _window.Controls.FindControl(_optionsPath + MapWindow);
             for (int i = 0; i < SkirmishGameSettings.MaxNumberOfPlayers; i++)
             {
                 var startPosition = (byte)(i + 1);
                 ((Button) mapWindow.Controls[i]).Click += (s, e) => StartingPositionClicked(_game.SkirmishManager.Settings, startPosition);
             }
 
-            _window.Controls.FindControl(_optionsPath + ":ButtonSelectMap").Enabled = _game.SkirmishManager.IsHosting;
+            _window.Controls.FindControl(_optionsPath + ButtonSelectMap).Enabled = _game.SkirmishManager.IsHosting;
         }
 
         public static void StartingPositionClicked(SkirmishGameSettings settings, byte clickedPosition)
@@ -218,11 +220,11 @@ namespace OpenSage.Mods.Generals.Gui
             switch (message.MessageType)
             {
                 case WndWindowMessageType.SelectedButton:
-                    if (message.Element.Name == _optionsPath + ":ButtonSelectMap")
+                    if (message.Element.Name == _optionsPath + ButtonSelectMap)
                     {
                         OpenMapSelection(context);
                     }
-                    else if (message.Element.Name == _optionsPath + ":ButtonStart")
+                    else if (message.Element.Name == _optionsPath + ButtonStart)
                     {
                         if (_game.SkirmishManager.Settings.Slots.Count(s => s.State != SkirmishSlotState.Open && s.State != SkirmishSlotState.Closed) > CurrentMap.NumPlayers)
                         {
@@ -257,7 +259,7 @@ namespace OpenSage.Mods.Generals.Gui
                 }
             }
 
-            var mapWindow = _window.Controls.FindControl(_optionsPath + ":MapWindow");
+            var mapWindow = _window.Controls.FindControl(_optionsPath+ MapWindow);
             for (int i = 0; i < SkirmishGameSettings.MaxNumberOfPlayers; i++)
             {
                 ((Button) mapWindow.Controls[i]).Text = string.Empty;
@@ -407,7 +409,7 @@ namespace OpenSage.Mods.Generals.Gui
 
             CurrentMap = mapCache;
 
-            var mapWindow = _window.Controls.FindControl(_optionsPath + ":MapWindow");
+            var mapWindow = _window.Controls.FindControl(_optionsPath + MapWindow);
 
             MapUtils.SetMapPreview(mapCache, mapWindow, _game);
 

--- a/src/OpenSage.Mods.Generals/Gui/LanGameOptionsMenuCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/LanGameOptionsMenuCallbacks.cs
@@ -21,10 +21,10 @@ namespace OpenSage.Mods.Generals.Gui
             Logger.Trace($"Have message {message.MessageType} for control {message.Element.DisplayName}");
         }
 
-        public static void LanGameOptionsMenuSystem(Control control, WndWindowMessage message, ControlCallbackContext context)
+        public static async void LanGameOptionsMenuSystem(Control control, WndWindowMessage message, ControlCallbackContext context)
         {
             Logger.Trace($"Have message {message.MessageType} for control {control.Name}");
-            if (!GameOptions.HandleSystem(control, message, context))
+            if (!await GameOptions.HandleSystemAsync(control, message, context))
             {
                 switch (message.MessageType)
                 {
@@ -33,6 +33,12 @@ namespace OpenSage.Mods.Generals.Gui
                         {
                             case "LanGameOptionsMenu.wnd:ButtonBack":
                                 context.Game.SkirmishManager.Stop();
+
+                                if (UPnP.Status == UPnPStatus.PortsForwarded)
+                                {
+                                    await UPnP.RemovePortForwardingAsync();
+                                }
+
                                 context.WindowManager.SetWindow(@"Menus\LanLobbyMenu.wnd");
                                 break;
 

--- a/src/OpenSage.Mods.Generals/Gui/LanGameOptionsMenuCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/LanGameOptionsMenuCallbacks.cs
@@ -95,63 +95,7 @@ namespace OpenSage.Mods.Generals.Gui
 
         public static void LanGameOptionsMenuUpdate(Window window, Game game)
         {
-            var mapName = game.SkirmishManager.Settings.MapName;
-            if (mapName != GameOptions.CurrentMap.Name && mapName != null)
-            {
-                var mapCache = game.AssetStore.MapCaches.GetByName(mapName);
-                if (mapCache == null)
-                {
-                    Logger.Warn($"Map {mapName} not found");
-                }
-                else
-                {
-                    GameOptions.SetCurrentMap(mapCache);
-                }
-            }
-
-            foreach (var slot in game.SkirmishManager.Settings.Slots)
-            {
-                var colorCombo = (ComboBox)window.Controls.FindControl($"LanGameOptionsMenu.wnd:ComboBoxColor{slot.Index}");
-                if (colorCombo.SelectedIndex != slot.ColorIndex)
-                    colorCombo.SelectedIndex = slot.ColorIndex;
-
-                var teamCombo = (ComboBox)window.Controls.FindControl($"LanGameOptionsMenu.wnd:ComboBoxTeam{slot.Index}");
-                if (teamCombo.SelectedIndex != slot.Team)
-                    teamCombo.SelectedIndex = slot.Team;
-
-                var playerTemplateCombo = (ComboBox)window.Controls.FindControl($"LanGameOptionsMenu.wnd:ComboBoxPlayerTemplate{slot.Index}");
-                if (playerTemplateCombo.SelectedIndex != slot.FactionIndex)
-                    playerTemplateCombo.SelectedIndex = slot.FactionIndex;
-
-                var buttonAccepted = (Button) window.Controls.FindControl($"LanGameOptionsMenu.wnd:ButtonAccept{slot.Index}");
-                var playerCombo = (ComboBox) window.Controls.FindControl($"LanGameOptionsMenu.wnd:ComboBoxPlayer{slot.Index}");
-
-                var isLocalSlot = slot == game.SkirmishManager.Settings.LocalSlot;
-                var editable = isLocalSlot || (game.SkirmishManager.IsHosting && slot.State != SkirmishSlotState.Human);
-
-                playerCombo.Enabled = !isLocalSlot && game.SkirmishManager.IsHosting;
-
-                buttonAccepted.Visible = slot.State == SkirmishSlotState.Human;
-
-                if (slot.State == SkirmishSlotState.Human)
-                {
-                    if (buttonAccepted.Enabled != slot.Ready)
-                        buttonAccepted.Enabled = slot.Ready;
-
-                    playerCombo.Controls[0].Text = slot.PlayerName;
-                }
-                else
-                {
-                    playerCombo.Controls[0].Text = slot.State.ToString();
-                }
-
-                colorCombo.Enabled = editable;
-                teamCombo.Enabled = editable;
-                playerTemplateCombo.Enabled = editable;
-            };
-
-            var buttonStart = (Button) window.Controls.FindControl($"LanGameOptionsMenu.wnd:ButtonStart");
-            buttonStart.Enabled = game.SkirmishManager.IsStartButtonEnabled();
+            GameOptions.UpdateUI(window);
         }
     }
 }

--- a/src/OpenSage.Mods.Generals/Gui/LanGameOptionsMenuCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/LanGameOptionsMenuCallbacks.cs
@@ -148,8 +148,6 @@ namespace OpenSage.Mods.Generals.Gui
                 colorCombo.Enabled = editable;
                 teamCombo.Enabled = editable;
                 playerTemplateCombo.Enabled = editable;
-
-
             };
 
             var buttonStart = (Button) window.Controls.FindControl($"LanGameOptionsMenu.wnd:ButtonStart");

--- a/src/OpenSage.Mods.Generals/Gui/LanMapSelectMenuCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/LanMapSelectMenuCallbacks.cs
@@ -66,7 +66,7 @@ namespace OpenSage.Mods.Generals.Gui
 
             var mapCache = selectedItem.DataItem as MapCache;
 
-            _game.SkirmishManager.SkirmishGame.MapName = mapCache.Name;
+            _game.SkirmishManager.Settings.MapName = mapCache.Name;
             SetPreviewMap(mapCache);
         }
 

--- a/src/OpenSage.Mods.Generals/Gui/MainMenuCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/MainMenuCallbacks.cs
@@ -125,6 +125,7 @@ namespace OpenSage.Mods.Generals.Gui
                             break;
 
                         case "MainMenu.wnd:ButtonSkirmish":
+                            context.Game.SkirmishManager = new LocalSkirmishManager(context.Game);
                             context.WindowManager.SetWindow(@"Menus\SkirmishGameOptionsMenu.wnd");
                             break;
 

--- a/src/OpenSage.Mods.Generals/Gui/NetworkUtils.cs
+++ b/src/OpenSage.Mods.Generals/Gui/NetworkUtils.cs
@@ -10,13 +10,13 @@ namespace OpenSage.Mods.Generals.Gui
 
         public static void HostGame(ControlCallbackContext context, object windowTag = null)
         {
-            context.Game.SkirmishManager = new SkirmishManager.Host(context.Game);
+            context.Game.SkirmishManager = new HostSkirmishManager(context.Game);
             context.WindowManager.SetWindow(@"Menus\LanGameOptionsMenu.wnd", windowTag);
         }
 
         public static void JoinGame(ControlCallbackContext context, IPEndPoint endPoint)
         {
-            context.Game.SkirmishManager = new SkirmishManager.Client(context.Game, endPoint);
+            context.Game.SkirmishManager = new ClientSkirmishManager(context.Game, endPoint);
             context.WindowManager.SetWindow(@"Menus\LanGameOptionsMenu.wnd");
         }
     }

--- a/src/OpenSage.Mods.Generals/Gui/SkirmishGameOptionsMenuCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/SkirmishGameOptionsMenuCallbacks.cs
@@ -12,8 +12,6 @@ namespace OpenSage.Mods.Generals.Gui
     {
         public static GameOptionsUtil GameOptions { get; private set; }
 
-        private static Game _game;
-
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
         public static async void SkirmishGameOptionsMenuSystem(Control control, WndWindowMessage message, ControlCallbackContext context)
@@ -39,8 +37,6 @@ namespace OpenSage.Mods.Generals.Gui
         public static void SkirmishGameOptionsMenuInit(Window window, Game game)
         {
             GameOptions = new GameOptionsUtil(window, game, "Skirmish");
-
-            _game = game;
         }
 
         public static void SkirmishGameOptionsMenuUpdate(Window window, Game game)

--- a/src/OpenSage.Mods.Generals/Gui/SkirmishGameOptionsMenuCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/SkirmishGameOptionsMenuCallbacks.cs
@@ -45,8 +45,7 @@ namespace OpenSage.Mods.Generals.Gui
 
         public static void SkirmishGameOptionsMenuUpdate(Window window, Game game)
         {
-            var buttonStart = (Button) window.Controls.FindControl($"SkirmishGameOptionsMenu.wnd:ButtonStart");
-            buttonStart.Enabled = game.SkirmishManager.IsStartButtonEnabled();
+            GameOptions.UpdateUI(window);
         }
     }
 }

--- a/src/OpenSage.Mods.Generals/Gui/SkirmishGameOptionsMenuCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/SkirmishGameOptionsMenuCallbacks.cs
@@ -26,6 +26,7 @@ namespace OpenSage.Mods.Generals.Gui
                         switch (message.Element.Name)
                         {
                             case "SkirmishGameOptionsMenu.wnd:ButtonBack":
+                                context.Game.SkirmishManager.Stop();
                                 context.WindowManager.SetWindow(@"Menus\MainMenu.wnd");
                                 // TODO: Go back to Single Player sub-menu
                                 break;
@@ -37,12 +38,15 @@ namespace OpenSage.Mods.Generals.Gui
 
         public static void SkirmishGameOptionsMenuInit(Window window, Game game)
         {
-
-
-
             GameOptions = new GameOptionsUtil(window, game, "Skirmish");
 
             _game = game;
+        }
+
+        public static void SkirmishGameOptionsMenuUpdate(Window window, Game game)
+        {
+            var buttonStart = (Button) window.Controls.FindControl($"SkirmishGameOptionsMenu.wnd:ButtonStart");
+            buttonStart.Enabled = game.SkirmishManager.IsStartButtonEnabled();
         }
     }
 }

--- a/src/OpenSage.Mods.Generals/Gui/SkirmishGameOptionsMenuCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/SkirmishGameOptionsMenuCallbacks.cs
@@ -16,9 +16,9 @@ namespace OpenSage.Mods.Generals.Gui
 
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
-        public static void SkirmishGameOptionsMenuSystem(Control control, WndWindowMessage message, ControlCallbackContext context)
+        public static async void SkirmishGameOptionsMenuSystem(Control control, WndWindowMessage message, ControlCallbackContext context)
         {
-            if (!GameOptions.HandleSystem(control, message, context))
+            if (!await GameOptions.HandleSystemAsync(control, message, context))
             {
                 switch (message.MessageType)
                 {

--- a/src/OpenSage.Mods.Generals/Gui/SkirmishMapSelectMenuCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/SkirmishMapSelectMenuCallbacks.cs
@@ -69,6 +69,8 @@ namespace OpenSage.Mods.Generals.Gui
                 var mapCache = selectedItem.DataItem as MapCache;
 
                 SetPreviewMap(mapCache);
+
+                game.SkirmishManager.Settings.MapName = mapCache.Name;
             };
         }
 


### PR DESCRIPTION
Skirmish games are now handled in the same way as LAN games. Previously, they worked differently with the state (player positions, colors, teams, ...) being only implicitly stored in the UI controls. Now they use the same model (`SkirmishGameSettings`, formerly known as `SkirmishGame`) as LAN games, which makes the code cleaner and simpler.

Based on that, the starting position setup now also works for network games.