### PR TITLE
Fix crash in lobby

### DIFF
--- a/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
@@ -411,6 +411,8 @@ namespace OpenSage.Mods.Generals.Gui
 
         public void SetCurrentMap(MapCache mapCache)
         {
+            _game.SkirmishManager.Settings.MapName = mapCache.Name;
+
             Logger.Info("Set current map to " + mapCache.Name);
 
             CurrentMap = mapCache;

--- a/src/OpenSage.Mods.Generals/Gui/LanMapSelectMenuCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/LanMapSelectMenuCallbacks.cs
@@ -27,7 +27,6 @@ namespace OpenSage.Mods.Generals.Gui
                             LanGameOptionsMenuCallbacks.GameOptions.CloseMapSelection(context);
                             break;
                         case "LanMapSelectMenu.wnd:ButtonOK":
-                            _game.SkirmishManager.Settings.MapName = _previewMap.Name;
                             LanGameOptionsMenuCallbacks.GameOptions.SetCurrentMap(_previewMap);
                             LanGameOptionsMenuCallbacks.GameOptions.CloseMapSelection(context);
                             break;

--- a/src/OpenSage.Mods.Generals/Gui/SkirmishMapSelectMenuCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/SkirmishMapSelectMenuCallbacks.cs
@@ -27,7 +27,6 @@ namespace OpenSage.Mods.Generals.Gui
                             SkirmishGameOptionsMenuCallbacks.GameOptions.CloseMapSelection(context);
                             break;
                         case "SkirmishMapSelectMenu.wnd:ButtonOK":
-                            _game.SkirmishManager.Settings.MapName = _previewMap.Name;
                             SkirmishGameOptionsMenuCallbacks.GameOptions.SetCurrentMap(_previewMap);
                             SkirmishGameOptionsMenuCallbacks.GameOptions.CloseMapSelection(context);
                             break;


### PR DESCRIPTION
Without actively selecting a map the mapname was not set