### PR TITLE
Add GameLogic and GameClient

### DIFF
--- a/src/OpenSage.Game/Client/Drawable.cs
+++ b/src/OpenSage.Game/Client/Drawable.cs
@@ -1,0 +1,291 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using OpenSage.Data.Sav;
+using OpenSage.Graphics;
+using OpenSage.Graphics.Cameras;
+using OpenSage.Graphics.Rendering;
+using OpenSage.Graphics.Shaders;
+using OpenSage.Logic.Object;
+using OpenSage.Mathematics;
+
+namespace OpenSage.Client
+{
+    public sealed class Drawable : DisposableBase
+    {
+        private readonly ObjectDefinition _definition;
+        private readonly GameContext _gameContext;
+
+        private readonly List<string> _hiddenDrawModules;
+        private readonly Dictionary<string, bool> _hiddenSubObjects;
+        private readonly Dictionary<string, bool> _shownSubObjects;
+
+        public readonly GameObject GameObject;
+
+        public readonly IEnumerable<BitArray<ModelConditionFlag>> ModelConditionStates;
+
+        public readonly BitArray<ModelConditionFlag> ModelConditionFlags;
+
+        // Doing this with a field and a property instead of an auto-property allows us to have a read-only public interface,
+        // while simultaneously supporting fast (non-allocating) iteration when accessing the list within the class.
+        public IReadOnlyList<DrawModule> DrawModules => _drawModules;
+        private readonly List<DrawModule> _drawModules;
+
+        internal Drawable(ObjectDefinition objectDefinition, GameContext gameContext, GameObject gameObject)
+        {
+            _definition = objectDefinition;
+            _gameContext = gameContext;
+            GameObject = gameObject;
+
+            ModelConditionFlags = new BitArray<ModelConditionFlag>();
+
+            var drawModules = new List<DrawModule>();
+            foreach (var drawData in objectDefinition.Draws.Values)
+            {
+                var drawModule = AddDisposable(drawData.CreateDrawModule(this, gameContext));
+                if (drawModule != null)
+                {
+                    // TODO: This will never be null once we've implemented all the draw modules.
+                    drawModules.Add(drawModule);
+                }
+            }
+            _drawModules = drawModules;
+
+            ModelConditionStates = drawModules
+                .SelectMany(x => x.ModelConditionStates)
+                .Distinct()
+                .OrderBy(x => x.NumBitsSet)
+                .ToList();
+
+            _hiddenDrawModules = new List<string>();
+            _hiddenSubObjects = new Dictionary<string, bool>();
+            _shownSubObjects = new Dictionary<string, bool>();
+        }
+
+        internal void CopyModelConditionFlags(BitArray<ModelConditionFlag> newFlags)
+        {
+            ModelConditionFlags.CopyFrom(newFlags);
+        }
+
+        // TODO: This probably shouldn't be here.
+        public Matrix4x4? GetWeaponFireFXBoneTransform(WeaponSlot slot, int index)
+        {
+            foreach (var drawModule in _drawModules)
+            {
+                var fireFXBone = drawModule.GetWeaponFireFXBone(slot);
+                if (fireFXBone != null)
+                {
+                    var (modelInstance, bone) = drawModule.FindBone(fireFXBone + (index + 1).ToString("D2"));
+                    if (bone != null)
+                    {
+                        return modelInstance.AbsoluteBoneTransforms[bone.Index];
+                    }
+                    break;
+                }
+            }
+
+            return null;
+        }
+
+        // TODO: This probably shouldn't be here.
+        public Matrix4x4? GetWeaponLaunchBoneTransform(WeaponSlot slot, int index)
+        {
+            foreach (var drawModule in _drawModules)
+            {
+                var fireFXBone = drawModule.GetWeaponLaunchBone(slot);
+                if (fireFXBone != null)
+                {
+                    var (modelInstance, bone) = drawModule.FindBone(fireFXBone + (index + 1).ToString("D2"));
+                    if (bone != null)
+                    {
+                        return modelInstance.AbsoluteBoneTransforms[bone.Index];
+                    }
+                    break;
+                }
+            }
+
+            return null;
+        }
+
+        public (ModelInstance modelInstance, ModelBone bone) FindBone(string boneName)
+        {
+            foreach (var drawModule in _drawModules)
+            {
+                var (modelInstance, bone) = drawModule.FindBone(boneName);
+                if (bone != null)
+                {
+                    return (modelInstance, bone);
+                }
+            }
+
+            return (null, null);
+        }
+
+        internal void BuildRenderList(RenderList renderList, Camera camera, in TimeInterval gameTime, in Matrix4x4 worldMatrix, in MeshShaderResources.RenderItemConstantsPS renderItemConstantsPS)
+        {
+            var castsShadow = false;
+            switch (_definition.Shadow)
+            {
+                case ObjectShadowType.ShadowVolume:
+                case ObjectShadowType.ShadowVolumeNew:
+                    castsShadow = true;
+                    break;
+            }
+
+            // Update all draw modules
+            foreach (var drawModule in _drawModules)
+            {
+                if (_hiddenDrawModules.Contains(drawModule.Tag))
+                {
+                    continue;
+                }
+
+                drawModule.UpdateConditionState(ModelConditionFlags, _gameContext.Random);
+                drawModule.Update(gameTime);
+                drawModule.SetWorldMatrix(worldMatrix);
+                drawModule.BuildRenderList(
+                    renderList,
+                    camera,
+                    castsShadow,
+                    renderItemConstantsPS,
+                    _shownSubObjects,
+                    _hiddenSubObjects);
+            }
+        }
+
+        public void HideDrawModule(string module)
+        {
+            if (!_hiddenDrawModules.Contains(module))
+            {
+                _hiddenDrawModules.Add(module);
+            }
+        }
+
+        public void ShowDrawModule(string module)
+        {
+            _hiddenDrawModules.Remove(module);
+        }
+
+        public void HideSubObject(string subObject)
+        {
+            if (subObject == null) return;
+
+            if (!_hiddenSubObjects.ContainsKey(subObject))
+            {
+                _hiddenSubObjects.Add(subObject, false);
+            }
+            _shownSubObjects.Remove(subObject);
+        }
+
+        public void HideSubObjectPermanently(string subObject)
+        {
+            if (subObject == null) return;
+
+            if (!_hiddenSubObjects.ContainsKey(subObject))
+            {
+                _hiddenSubObjects.Add(subObject, true);
+            }
+            else
+            {
+                _hiddenSubObjects[subObject] = true;
+            }
+            _shownSubObjects.Remove(subObject);
+        }
+
+
+        public void ShowSubObject(string subObject)
+        {
+            if (subObject == null) return;
+
+            if (!_shownSubObjects.ContainsKey(subObject))
+            {
+                _shownSubObjects.Add(subObject, false);
+            }
+            _hiddenSubObjects.Remove(subObject);
+        }
+
+        public void ShowSubObjectPermanently(string subObject)
+        {
+            if (subObject == null) return;
+
+            if (!_shownSubObjects.ContainsKey(subObject))
+            {
+                _shownSubObjects.Add(subObject, true);
+            }
+            else
+            {
+                _shownSubObjects[subObject] = true;
+            }
+            _hiddenSubObjects.Remove(subObject);
+        }
+
+        internal void Destroy()
+        {
+            foreach (var drawModule in _drawModules)
+            {
+                drawModule.Dispose();
+            }
+        }
+
+        internal void Load(SaveFileReader reader)
+        {
+            reader.ReadVersion(1);
+
+            var drawableID = reader.ReadUInt32();
+
+            reader.ReadByte();
+
+            var numModelConditionFlags = reader.ReadUInt32();
+            for (var j = 0; j < numModelConditionFlags; j++)
+            {
+                var modelConditionFlag = reader.ReadAsciiString();
+            }
+
+            var transform = reader.ReadMatrix4x3();
+
+            var unknownBool = reader.ReadBoolean();
+            var unknownBool2 = reader.ReadBoolean();
+            if (unknownBool)
+            {
+                for (var j = 0; j < 9; j++)
+                {
+                    reader.ReadSingle();
+                }
+                reader.__Skip(19);
+            }
+
+            reader.__Skip(56);
+
+            var unknownBool3 = reader.ReadBoolean();
+            if (unknownBool3)
+            {
+                for (var j = 0; j < 19; j++)
+                {
+                    reader.ReadSingle();
+                }
+            }
+
+            reader.__Skip(3);
+
+            var numModules = reader.ReadUInt16();
+            for (var moduleIndex = 0; moduleIndex < numModules; moduleIndex++)
+            {
+                var moduleTag = reader.ReadAsciiString();
+                reader.BeginSegment();
+                // TODO
+                reader.EndSegment();
+            }
+
+            var numClientUpdates = reader.ReadUInt16();
+            for (var moduleIndex = 0; moduleIndex < numClientUpdates; moduleIndex++)
+            {
+                var moduleTag = reader.ReadAsciiString();
+                reader.BeginSegment();
+                // TODO
+                reader.EndSegment();
+            }
+
+            reader.__Skip(81);
+        }
+    }
+}

--- a/src/OpenSage.Game/Client/GameClient.cs
+++ b/src/OpenSage.Game/Client/GameClient.cs
@@ -1,0 +1,100 @@
+﻿using OpenSage.Data.Sav;
+using OpenSage.Logic;
+
+namespace OpenSage.Client
+{
+    internal sealed class GameClient
+    {
+        private readonly GameLogic _gameLogic;
+        private readonly ObjectDefinitionLookupTable _objectDefinitionLookupTable;
+
+        private uint _currentFrame;
+
+        public GameClient(Scene3D scene3D, GameLogic gameLogic)
+        {
+            _gameLogic = gameLogic;
+            _objectDefinitionLookupTable = new ObjectDefinitionLookupTable(scene3D.AssetLoadContext.AssetStore.ObjectDefinitions);
+        }
+
+        internal void Load(SaveFileReader reader)
+        {
+            reader.ReadVersion(3);
+
+            _currentFrame = reader.ReadUInt32();
+
+            _objectDefinitionLookupTable.Load(reader);
+
+            var drawablesCount = reader.ReadUInt16();
+            for (var i = 0; i < drawablesCount; i++)
+            {
+                var objectDefinitionId = reader.ReadUInt16();
+                var objectDefinition = _objectDefinitionLookupTable.GetById(objectDefinitionId);
+
+                reader.BeginSegment();
+
+                var objectID = reader.ReadUInt32();
+                var gameObject = _gameLogic.GetObjectById(objectID);
+
+                reader.ReadByte();
+
+                var drawableID = reader.ReadUInt32();
+
+                reader.ReadByte();
+
+                var numModelConditionFlags = reader.ReadUInt32();
+                for (var j = 0; j < numModelConditionFlags; j++)
+                {
+                    var modelConditionFlag = reader.ReadAsciiString();
+                }
+
+                var transform = reader.ReadMatrix4x3();
+
+                var unknownBool = reader.ReadBoolean();
+                var unknownBool2 = reader.ReadBoolean();
+                if (unknownBool)
+                {
+                    for (var j = 0; j < 9; j++)
+                    {
+                        reader.ReadSingle();
+                    }
+                    reader.__Skip(19);
+                }
+
+                reader.__Skip(56);
+
+                var unknownBool3 = reader.ReadBoolean();
+                if (unknownBool3)
+                {
+                    for (var j = 0; j < 19; j++)
+                    {
+                        reader.ReadSingle();
+                    }
+                }
+
+                reader.__Skip(3);
+
+                var numModules = reader.ReadUInt16();
+                for (var moduleIndex = 0; moduleIndex < numModules; moduleIndex++)
+                {
+                    var moduleTag = reader.ReadAsciiString();
+                    reader.BeginSegment();
+                    // TODO
+                    reader.EndSegment();
+                }
+
+                var numClientUpdates = reader.ReadUInt16();
+                for (var moduleIndex = 0; moduleIndex < numClientUpdates; moduleIndex++)
+                {
+                    var moduleTag = reader.ReadAsciiString();
+                    reader.BeginSegment();
+                    // TODO
+                    reader.EndSegment();
+                }
+
+                reader.__Skip(81);
+            }
+
+            reader.ReadUInt32();
+        }
+    }
+}

--- a/src/OpenSage.Game/Client/GameClient.cs
+++ b/src/OpenSage.Game/Client/GameClient.cs
@@ -35,63 +35,9 @@ namespace OpenSage.Client
                 var objectID = reader.ReadUInt32();
                 var gameObject = _gameLogic.GetObjectById(objectID);
 
-                reader.ReadByte();
+                gameObject.Drawable.Load(reader);
 
-                var drawableID = reader.ReadUInt32();
-
-                reader.ReadByte();
-
-                var numModelConditionFlags = reader.ReadUInt32();
-                for (var j = 0; j < numModelConditionFlags; j++)
-                {
-                    var modelConditionFlag = reader.ReadAsciiString();
-                }
-
-                var transform = reader.ReadMatrix4x3();
-
-                var unknownBool = reader.ReadBoolean();
-                var unknownBool2 = reader.ReadBoolean();
-                if (unknownBool)
-                {
-                    for (var j = 0; j < 9; j++)
-                    {
-                        reader.ReadSingle();
-                    }
-                    reader.__Skip(19);
-                }
-
-                reader.__Skip(56);
-
-                var unknownBool3 = reader.ReadBoolean();
-                if (unknownBool3)
-                {
-                    for (var j = 0; j < 19; j++)
-                    {
-                        reader.ReadSingle();
-                    }
-                }
-
-                reader.__Skip(3);
-
-                var numModules = reader.ReadUInt16();
-                for (var moduleIndex = 0; moduleIndex < numModules; moduleIndex++)
-                {
-                    var moduleTag = reader.ReadAsciiString();
-                    reader.BeginSegment();
-                    // TODO
-                    reader.EndSegment();
-                }
-
-                var numClientUpdates = reader.ReadUInt16();
-                for (var moduleIndex = 0; moduleIndex < numClientUpdates; moduleIndex++)
-                {
-                    var moduleTag = reader.ReadAsciiString();
-                    reader.BeginSegment();
-                    // TODO
-                    reader.EndSegment();
-                }
-
-                reader.__Skip(81);
+                reader.EndSegment();
             }
 
             reader.ReadUInt32();

--- a/src/OpenSage.Game/Data/Sav/SaveFile.cs
+++ b/src/OpenSage.Game/Data/Sav/SaveFile.cs
@@ -2,13 +2,12 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using OpenSage.Data.Ini;
+using OpenSage.Client;
 using OpenSage.Data.Map;
 using OpenSage.Data.Rep;
 using OpenSage.FileFormats;
 using OpenSage.Graphics.ParticleSystems;
 using OpenSage.Logic;
-using OpenSage.Logic.Object;
 using OpenSage.Mathematics;
 using OpenSage.Network;
 
@@ -55,6 +54,8 @@ namespace OpenSage.Data.Sav
 
                 GameState gameState = null;
                 MapFile map = null;
+                GameLogic gameLogic = null;
+                GameClient gameClient = null;
 
                 while (!chunkHeader.IsEof)
                 {
@@ -210,11 +211,9 @@ namespace OpenSage.Data.Sav
                             }
 
                         case "CHUNK_GameLogic":
-                            {
-                                var gameLogic = new GameLogic(game.Scene3D);
-                                gameLogic.Load(new SaveFileReader(reader));
-                                break;
-                            }
+                            gameLogic = new GameLogic(game.Scene3D);
+                            gameLogic.Load(new SaveFileReader(reader));
+                            break;
 
                         case "CHUNK_ParticleSystem":
                             {
@@ -426,85 +425,9 @@ namespace OpenSage.Data.Sav
                             }
 
                         case "CHUNK_GameClient":
-                            {
-                                var version = reader.ReadByte();
-                                var unknown1 = reader.ReadUInt32(); // Maybe some kind of frame counter
-                                var unknown2 = reader.ReadByte();
-                                var numGameObjects = reader.ReadUInt32();
-                                var gameObjects = new List<GameObjectState>();
-                                for (var i = 0; i < numGameObjects; i++)
-                                {
-                                    gameObjects.Add(new GameObjectState
-                                    {
-                                        Name = reader.ReadBytePrefixedAsciiString(),
-                                        Id = reader.ReadUInt16()
-                                    });
-                                }
-
-                                var numGameObjects2 = reader.ReadUInt16(); // 5
-                                for (var i = 0; i < numGameObjects2; i++)
-                                {
-                                    var objectID = reader.ReadUInt16();
-                                    reader.ReadBytes(14);
-
-                                    var numModelConditionFlags = reader.ReadUInt32();
-
-                                    for (var j = 0; j < numModelConditionFlags; j++)
-                                    {
-                                        var modelConditionFlag = reader.ReadBytePrefixedAsciiString();
-                                    }
-
-                                    reader.ReadByte();
-
-                                    var transform = reader.ReadMatrix4x3Transposed();
-
-                                    var unknownBool = reader.ReadBooleanChecked();
-                                    var unknownBool2 = reader.ReadBooleanChecked();
-                                    if (unknownBool)
-                                    {
-                                        for (var j = 0; j < 9; j++)
-                                        {
-                                            reader.ReadSingle();
-                                        }
-                                        reader.ReadBytes(19);
-                                    }
-
-                                    reader.ReadBytes(56);
-
-                                    var unknownBool3 = reader.ReadBooleanChecked();
-                                    if (unknownBool3)
-                                    {
-                                        for (var j = 0; j < 19; j++)
-                                        {
-                                            reader.ReadSingle();
-                                        }
-                                    }
-
-                                    reader.ReadBytes(3);
-
-                                    var numModules = reader.ReadUInt16();
-                                    for (var moduleIndex = 0; moduleIndex < numModules; moduleIndex++)
-                                    {
-                                        var moduleTag = reader.ReadBytePrefixedAsciiString();
-                                        var moduleLengthInBytes = reader.ReadUInt32();
-                                        reader.ReadBytes((int) moduleLengthInBytes);
-                                    }
-
-                                    var numClientUpdates = reader.ReadUInt16();
-                                    for (var moduleIndex = 0; moduleIndex < numClientUpdates; moduleIndex++)
-                                    {
-                                        var moduleTag = reader.ReadBytePrefixedAsciiString();
-                                        var moduleLengthInBytes = reader.ReadUInt32();
-                                        reader.ReadBytes((int) moduleLengthInBytes);
-                                    }
-
-                                    reader.ReadBytes(81);
-                                }
-
-                                reader.ReadUInt32();
-
-                                break;
-                            }
+                            gameClient = new GameClient(game.Scene3D, gameLogic);
+                            gameClient.Load(new SaveFileReader(reader));
+                            break;
 
                         case "CHUNK_InGameUI":
                             {

--- a/src/OpenSage.Game/Data/Sav/SaveFileReader.cs
+++ b/src/OpenSage.Game/Data/Sav/SaveFileReader.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Numerics;
+using OpenSage.FileFormats;
+using OpenSage.Mathematics;
+
+namespace OpenSage.Data.Sav
+{
+    public sealed class SaveFileReader
+    {
+        private readonly BinaryReader _binaryReader;
+        private readonly Stack<Segment> _segments;
+
+        public BinaryReader Inner => _binaryReader;
+
+        internal SaveFileReader(BinaryReader binaryReader)
+        {
+            _binaryReader = binaryReader;
+            _segments = new Stack<Segment>();
+        }
+
+        public byte ReadVersion(byte maximumVersion)
+        {
+            var result = _binaryReader.ReadByte();
+            if (result > maximumVersion)
+            {
+                throw new InvalidDataException();
+            }
+            return result;
+        }
+
+        public byte ReadByte() => _binaryReader.ReadByte();
+
+        public ushort ReadUInt16() => _binaryReader.ReadUInt16();
+
+        public uint ReadUInt32() => _binaryReader.ReadUInt32();
+
+        public bool ReadBoolean() => _binaryReader.ReadBooleanChecked();
+
+        public uint ReadObjectID() => ReadUInt32();
+
+        public string ReadAsciiString() => _binaryReader.ReadBytePrefixedAsciiString();
+
+        public float ReadSingle() => _binaryReader.ReadSingle();
+
+        public Vector3 ReadVector3() => _binaryReader.ReadVector3();
+
+        public TEnum ReadEnum<TEnum>()
+            where TEnum : struct
+        {
+            return _binaryReader.ReadUInt32AsEnum<TEnum>();
+        }
+
+        public Matrix4x3 ReadMatrix4x3()
+        {
+            ReadVersion(1);
+
+            var m11 = _binaryReader.ReadSingle();
+            var m21 = _binaryReader.ReadSingle();
+            var m31 = _binaryReader.ReadSingle();
+            var m41 = _binaryReader.ReadSingle();
+
+            var m12 = _binaryReader.ReadSingle();
+            var m22 = _binaryReader.ReadSingle();
+            var m32 = _binaryReader.ReadSingle();
+            var m42 = _binaryReader.ReadSingle();
+
+            var m13 = _binaryReader.ReadSingle();
+            var m23 = _binaryReader.ReadSingle();
+            var m33 = _binaryReader.ReadSingle();
+            var m43 = _binaryReader.ReadSingle();
+
+            return new Matrix4x3(
+                m11, m12, m13,
+                m21, m22, m23,
+                m31, m32, m33,
+                m41, m42, m43);
+        }
+
+        public void BeginSegment()
+        {
+            var segmentLength = _binaryReader.ReadUInt32();
+
+            var currentPosition = _binaryReader.BaseStream.Position;
+
+            _segments.Push(new Segment(currentPosition, currentPosition + segmentLength));
+        }
+
+        public void EndSegment()
+        {
+            var segment = _segments.Pop();
+
+            if (_binaryReader.BaseStream.Position != segment.End)
+            {
+                Console.WriteLine("Skipped segment in .sav file");
+
+                _binaryReader.BaseStream.Position = segment.End;
+
+                //throw new InvalidDataException();
+            }
+        }
+
+        private readonly struct Segment
+        {
+            public readonly long Start;
+            public readonly long End;
+
+            public Segment(long start, long end)
+            {
+                Start = start;
+                End = end;
+            }
+        }
+
+        public void __Skip(int numBytes)
+        {
+            _binaryReader.BaseStream.Position += numBytes;
+        }
+    }
+}

--- a/src/OpenSage.Game/Diagnostics/AssetViews/GameObjectView.cs
+++ b/src/OpenSage.Game/Diagnostics/AssetViews/GameObjectView.cs
@@ -26,7 +26,7 @@ namespace OpenSage.Diagnostics.AssetViews
                     gameObjects.InsertCreated();
                 }));
 
-            _modelConditionStates = _gameObject.ModelConditionStates.ToList();
+            _modelConditionStates = _gameObject.Drawable.ModelConditionStates.ToList();
             _selectedIndex = 0;
         }
 
@@ -40,7 +40,7 @@ namespace OpenSage.Diagnostics.AssetViews
 
                 if (ImGui.Selectable(modelConditionState.DisplayName, i == _selectedIndex))
                 {
-                    _gameObject.CopyModelConditionFlags(modelConditionState);
+                    _gameObject.Drawable.CopyModelConditionFlags(modelConditionState);
                     _selectedIndex = i;
                 }
             }

--- a/src/OpenSage.Game/Logic/GameLogic.cs
+++ b/src/OpenSage.Game/Logic/GameLogic.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using OpenSage.Content;
+using OpenSage.Data.Sav;
+using OpenSage.Logic.Object;
+
+namespace OpenSage.Logic
+{
+    internal sealed class GameLogic
+    {
+        private readonly Scene3D _scene3D;
+        private readonly ObjectDefinitionLookupTable _objectDefinitionLookupTable;
+        private readonly List<GameObject> _objects;
+
+        private uint _currentFrame;
+
+        public GameLogic(Scene3D scene3D)
+        {
+            _scene3D = scene3D;
+            _objectDefinitionLookupTable = new ObjectDefinitionLookupTable(scene3D.AssetLoadContext.AssetStore.ObjectDefinitions);
+            _objects = new List<GameObject>();
+        }
+
+        public void Load(SaveFileReader reader)
+        {
+            reader.ReadVersion(9);
+
+            _currentFrame = reader.ReadUInt32();
+
+            _objectDefinitionLookupTable.Load(reader);
+
+            var gameObjectsCount = reader.ReadUInt32();
+            for (var i = 0; i < gameObjectsCount; i++)
+            {
+                var objectDefinitionId = reader.ReadUInt16();
+                var objectDefinition = _objectDefinitionLookupTable.GetById(objectDefinitionId);
+
+                var gameObject = _scene3D.GameObjects.Add(objectDefinition, _scene3D.LocalPlayer);
+
+                reader.BeginSegment();
+
+                gameObject.Load(reader);
+
+                reader.EndSegment();
+            }
+
+            reader.ReadByte(); // 3
+
+            var sideName = reader.ReadAsciiString();
+            var missionName = reader.ReadAsciiString();
+
+            reader.__Skip(12);
+
+            var someCount4 = reader.ReadUInt32();
+            for (var i = 0; i < someCount4; i++)
+            {
+                var maybeIndex = reader.ReadUInt32();
+                reader.ReadBoolean(); // 1
+                var someCount5 = reader.ReadUInt32();
+                for (var j = 0; j < someCount5; j++)
+                {
+                    reader.ReadUInt32();
+                    reader.ReadUInt32();
+                    reader.ReadUInt32();
+                }
+                reader.ReadUInt32();
+                reader.ReadUInt32();
+                reader.ReadUInt32();
+                reader.ReadUInt32();
+                reader.ReadSingle();
+                reader.ReadBoolean();
+            }
+
+            reader.ReadUInt32(); // 1000
+            reader.ReadUInt32(); // 0
+            reader.ReadBoolean(); // 0
+            reader.ReadBoolean(); // 1
+            reader.ReadBoolean(); // 1
+            reader.ReadBoolean(); // 1
+            reader.ReadUInt32(); // 0xFFFFFFFF
+
+
+
+            reader.ReadUInt32(); // 0
+            reader.ReadBoolean(); // 0
+        }
+    }
+
+    internal sealed class ObjectDefinitionLookupTable
+    {
+        private readonly ScopedAssetCollection<ObjectDefinition> _objectDefinitions;
+        private readonly Dictionary<ushort, string> _nameLookup;
+
+        public ObjectDefinitionLookupTable(ScopedAssetCollection<ObjectDefinition> objectDefinitions)
+        {
+            _objectDefinitions = objectDefinitions;
+            _nameLookup = new Dictionary<ushort, string>();
+        }
+
+        public ObjectDefinition GetById(ushort id)
+        {
+            if (_nameLookup.TryGetValue(id, out var objectDefinitionName))
+            {
+                return _objectDefinitions.GetByName(objectDefinitionName);
+            }
+
+            throw new InvalidOperationException();
+        }
+
+        public void Load(SaveFileReader reader)
+        {
+            reader.ReadVersion(1);
+
+            _nameLookup.Clear();
+
+            var count = reader.ReadUInt32();
+            for (var i = 0; i < count; i++)
+            {
+                var name = reader.ReadAsciiString();
+                var id = reader.ReadUInt16();
+
+                _nameLookup.Add(id, name);
+            }
+        }
+
+        private void LoadObjectLookupTable(SaveFileReader reader)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/OpenSage.Game/Logic/GameLogic.cs
+++ b/src/OpenSage.Game/Logic/GameLogic.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using OpenSage.Content;
 using OpenSage.Data.Sav;
 using OpenSage.Logic.Object;
@@ -22,6 +21,11 @@ namespace OpenSage.Logic
             _objects = new List<GameObject>();
         }
 
+        public GameObject GetObjectById(uint id)
+        {
+            return _objects[(int)id];
+        }
+
         public void Load(SaveFileReader reader)
         {
             reader.ReadVersion(9);
@@ -41,6 +45,12 @@ namespace OpenSage.Logic
                 reader.BeginSegment();
 
                 gameObject.Load(reader);
+
+                while (_objects.Count <= gameObject.ID)
+                {
+                    _objects.Add(null);
+                }
+                _objects[(int)gameObject.ID] = gameObject;
 
                 reader.EndSegment();
             }
@@ -122,11 +132,6 @@ namespace OpenSage.Logic
 
                 _nameLookup.Add(id, name);
             }
-        }
-
-        private void LoadObjectLookupTable(SaveFileReader reader)
-        {
-            throw new System.NotImplementedException();
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BuildingBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BuildingBehavior.cs
@@ -39,11 +39,11 @@ namespace OpenSage.Logic.Object
                 var nightWindow = _moduleData.NightWindowName;
                 if (night)
                 {
-                    _gameObject.ShowSubObject(nightWindow);
+                    _gameObject.Drawable.ShowSubObject(nightWindow);
                 }
                 else
                 {
-                    _gameObject.HideSubObject(nightWindow);
+                    _gameObject.Drawable.HideSubObject(nightWindow);
                 }
 
                 _isNight = night;
@@ -54,19 +54,19 @@ namespace OpenSage.Logic.Object
                 var fireWindow = _moduleData.FireWindowName;
                 if (fire)
                 {
-                    _gameObject.ShowSubObject(fireWindow);
+                    _gameObject.Drawable.ShowSubObject(fireWindow);
                     foreach (var fireName in _moduleData.FireNames)
                     {
-                        _gameObject.ShowSubObject(fireName);
+                        _gameObject.Drawable.ShowSubObject(fireName);
                     }
                 }
                 else
                 {
-                    _gameObject.HideSubObject(fireWindow);
+                    _gameObject.Drawable.HideSubObject(fireWindow);
 
                     foreach (var fireName in _moduleData.FireNames)
                     {
-                        _gameObject.HideSubObject(fireName);
+                        _gameObject.Drawable.HideSubObject(fireName);
                     }
                 }
 
@@ -78,11 +78,11 @@ namespace OpenSage.Logic.Object
                 var glowWindow = _moduleData.GlowWindowName;
                 if (glowing)
                 {
-                    _gameObject.ShowSubObject(glowWindow);
+                    _gameObject.Drawable.ShowSubObject(glowWindow);
                 }
                 else
                 {
-                    _gameObject.HideSubObject(glowWindow);
+                    _gameObject.Drawable.HideSubObject(glowWindow);
                 }
 
                 _isGlowing = glowing;

--- a/src/OpenSage.Game/Logic/Object/Behaviors/ParkingPlaceBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/ParkingPlaceBehavior.cs
@@ -210,7 +210,7 @@ namespace OpenSage.Logic.Object
 
         public Transform GetBoneTransform(string name)
         {
-            var (_, bone) = _gameObject.FindBone(name);
+            var (_, bone) = _gameObject.Drawable.FindBone(name);
             if (bone == null)
             {
                 throw new InvalidOperationException("Could not find runway start point bone");

--- a/src/OpenSage.Game/Logic/Object/Body/HighlanderBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/HighlanderBody.cs
@@ -1,4 +1,6 @@
-﻿using OpenSage.Data.Ini;
+﻿using System.IO;
+using OpenSage.Data.Ini;
+using OpenSage.FileFormats;
 using OpenSage.Mathematics.FixedMath;
 
 namespace OpenSage.Logic.Object
@@ -29,6 +31,17 @@ namespace OpenSage.Logic.Object
                     GameObject.Die(deathType, time);
                 }
             }
+        }
+
+        internal override void Load(BinaryReader reader)
+        {
+            var version = reader.ReadVersion();
+            if (version != 1)
+            {
+                throw new InvalidDataException();
+            }
+
+            base.Load(reader);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Collide/FireWeaponCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/FireWeaponCollide.cs
@@ -1,11 +1,43 @@
-﻿using OpenSage.Content;
+﻿using System.IO;
+using OpenSage.Content;
 using OpenSage.Data.Ini;
+using OpenSage.FileFormats;
 
 namespace OpenSage.Logic.Object
 {
     public sealed class FireWeaponCollide : CollideModule
     {
-        // TODO
+        private readonly FireWeaponCollideModuleData _moduleData;
+        private readonly Weapon _collideWeapon;
+
+        internal FireWeaponCollide(GameObject gameObject, FireWeaponCollideModuleData moduleData)
+        {
+            _moduleData = moduleData;
+
+            _collideWeapon = new Weapon(
+                gameObject,
+                moduleData.CollideWeapon.Value,
+                0,
+                WeaponSlot.Primary,
+                gameObject.GameContext);
+        }
+
+        internal override void Load(BinaryReader reader)
+        {
+            var version = reader.ReadVersion();
+            if (version != 1)
+            {
+                throw new InvalidDataException();
+            }
+
+            base.Load(reader);
+
+            var unknown1 = reader.ReadBooleanChecked();
+
+            _collideWeapon.Load(reader);
+
+            var unknown2 = reader.ReadBooleanChecked();
+        }
     }
 
     public sealed class FireWeaponCollideModuleData : CollideModuleData
@@ -23,7 +55,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new FireWeaponCollide();
+            return new FireWeaponCollide(gameObject, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Colliders.cs
+++ b/src/OpenSage.Game/Logic/Object/Colliders.cs
@@ -45,9 +45,6 @@ namespace OpenSage.Logic.Object
                 case ObjectGeometry.Cylinder:
                     return new CylinderCollider(geometry, transform);
 
-                case ObjectGeometry.None:
-                    return null;
-
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Numerics;
+using OpenSage.Client;
 using OpenSage.Data.Ini;
 using OpenSage.Graphics;
 using OpenSage.Graphics.Cameras;
@@ -13,7 +14,8 @@ namespace OpenSage.Logic.Object
     public abstract class DrawModule : DisposableBase
     {
         public abstract string Tag { get; }
-        public GameObject GameObject { get; protected set; }
+        public Drawable Drawable { get; protected set; }
+        public GameObject GameObject => Drawable.GameObject;
         public abstract IEnumerable<BitArray<ModelConditionFlag>> ModelConditionStates { get; }
 
         // TODO: Probably shouldn't have this here.
@@ -78,6 +80,6 @@ namespace OpenSage.Logic.Object
             { "W3DTruckDraw", W3dTruckDrawModuleData.Parse },
         };
 
-        internal virtual DrawModule CreateDrawModule(GameObject gameObject, GameContext context) => null; // TODO: Make this abstract.
+        internal virtual DrawModule CreateDrawModule(Drawable drawable, GameContext context) => null; // TODO: Make this abstract.
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dDebrisDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dDebrisDraw.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Numerics;
+using OpenSage.Client;
 using OpenSage.Data.Ini;
 using OpenSage.Graphics;
 using OpenSage.Graphics.Cameras;
@@ -87,7 +88,7 @@ namespace OpenSage.Logic.Object
 
         internal static readonly IniParseTable<W3dDebrisDrawModuleData> FieldParseTable = new IniParseTable<W3dDebrisDrawModuleData>();
 
-        internal override DrawModule CreateDrawModule(GameObject gameObject, GameContext context)
+        internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
         {
             return new W3dDebrisDraw(this, context);
         }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dFloorDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dFloorDraw.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Numerics;
+using OpenSage.Client;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.Data.Map;
@@ -17,16 +18,16 @@ namespace OpenSage.Logic.Object
     {
         public override string Tag => _moduleData.Tag;
 
-        private readonly GameObject _gameObject;
+        private readonly Drawable _drawable;
         private readonly GameContext _gameContext;
         private readonly ModelInstance _modelInstance;
         private readonly W3dFloorDrawModuleData _moduleData;
 
         public override IEnumerable<BitArray<ModelConditionFlag>> ModelConditionStates { get; } = Array.Empty<BitArray<ModelConditionFlag>>();
 
-        internal W3dFloorDraw(W3dFloorDrawModuleData moduleData, GameContext context, GameObject gameObject)
+        internal W3dFloorDraw(W3dFloorDrawModuleData moduleData, GameContext context, Drawable drawable)
         {
-            _gameObject = gameObject;
+            _drawable = drawable;
             _gameContext = context;
             _moduleData = moduleData;
             _modelInstance = AddDisposable(_moduleData.Model.Value.CreateInstance(_gameContext.AssetLoadContext));
@@ -42,7 +43,7 @@ namespace OpenSage.Logic.Object
         {
             foreach (var hideFlag in _moduleData.HideIfModelConditions)
             {
-                if (_gameObject.ModelConditionFlags.Get(hideFlag))
+                if (_drawable.ModelConditionFlags.Get(hideFlag))
                 {
                     return;
                 }
@@ -111,9 +112,9 @@ namespace OpenSage.Logic.Object
         [AddedIn(SageGame.Bfme2)]
         public WeatherTexture WeatherTexture { get; private set; }
 
-        internal override DrawModule CreateDrawModule(GameObject gameObject, GameContext context)
+        internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
         {
-            return Model.Value == null ? null : (DrawModule) new W3dFloorDraw(this, context, gameObject);
+            return Model.Value == null ? null : (DrawModule) new W3dFloorDraw(this, context, drawable);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dHordeModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dHordeModelDraw.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using OpenSage.Client;
 using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
@@ -10,8 +11,8 @@ namespace OpenSage.Logic.Object
     {
         internal W3dHordeModelDraw(
             W3dHordeModelDrawModuleData data,
-            GameObject gameObject,
-            GameContext context) : base(data, gameObject, context)
+            Drawable drawable,
+            GameContext context) : base(data, drawable, context)
         {
         }
 
@@ -33,9 +34,9 @@ namespace OpenSage.Logic.Object
 
         public List<LodOption> LodOptions { get; private set; } = new List<LodOption>();
 
-        internal override DrawModule CreateDrawModule(GameObject gameObject, GameContext context)
+        internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
         {
-            return new W3dHordeModelDraw(this, gameObject, context);
+            return new W3dHordeModelDraw(this, drawable, context);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using ImGuiNET;
+using OpenSage.Client;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.Graphics;
@@ -66,11 +67,11 @@ namespace OpenSage.Logic.Object
 
         internal W3dModelDraw(
             W3dModelDrawModuleData data,
-            GameObject gameObject,
+            Drawable drawable,
             GameContext context)
         {
             _data = data;
-            GameObject = gameObject;
+            Drawable = drawable;
             _context = context;
 
             _conditionStates = new List<IConditionState>();
@@ -588,9 +589,9 @@ namespace OpenSage.Logic.Object
         }
 
 
-        internal override DrawModule CreateDrawModule(GameObject gameObject, GameContext context)
+        internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
         {
-            return new W3dModelDraw(this, gameObject, context);
+            return new W3dModelDraw(this, drawable, context);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dScriptedModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dScriptedModelDraw.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenSage.Client;
 using OpenSage.Data.Ini;
 using OpenSage.Mathematics;
 
@@ -14,8 +15,9 @@ namespace OpenSage.Logic.Object
 
         internal W3dScriptedModelDraw(
             W3dScriptedModelDrawModuleData data,
-            GameObject gameObject,
-            GameContext context) : base(data, gameObject, context)
+            Drawable drawable,
+            GameContext context)
+            : base(data, drawable, context)
         {
             _context = context;
         }
@@ -104,9 +106,9 @@ namespace OpenSage.Logic.Object
         [AddedIn(SageGame.Bfme2)]
         public bool RandomTextureFixedRandomIndex { get; private set; }
 
-        internal override DrawModule CreateDrawModule(GameObject gameObject, GameContext context)
+        internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
         {
-            return new W3dScriptedModelDraw(this, gameObject, context);
+            return new W3dScriptedModelDraw(this, drawable, context);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTankDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTankDraw.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using OpenSage.Client;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.Graphics;
@@ -22,8 +23,8 @@ namespace OpenSage.Logic.Object
             "TREADSR01",
         };
 
-        internal W3dTankDraw(W3dTankDrawModuleData data, GameObject gameObject, GameContext context)
-            : base(data, gameObject, context)
+        internal W3dTankDraw(W3dTankDrawModuleData data, Drawable drawable, GameContext context)
+            : base(data, drawable, context)
         {
             _data = data;
             _treadDebrisLeft = data.TreadDebrisLeft?.Value ?? context.AssetLoadContext.AssetStore.FXParticleSystemTemplates.GetByName("TrackDebrisDirtLeft");
@@ -94,9 +95,9 @@ namespace OpenSage.Logic.Object
         public float TreadDriveSpeedFraction { get; private set; }
         public float TreadPivotSpeedFraction { get; private set; }
 
-        internal override DrawModule CreateDrawModule(GameObject gameObject, GameContext context)
+        internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
         {
-            return new W3dTankDraw(this, gameObject, context);
+            return new W3dTankDraw(this, drawable, context);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTreeDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTreeDraw.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Numerics;
+using OpenSage.Client;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.FX;
@@ -144,7 +145,7 @@ namespace OpenSage.Logic.Object
         [AddedIn(SageGame.Bfme)]
         public string MorphTree { get; private set; }
 
-        internal override DrawModule CreateDrawModule(GameObject gameObject, GameContext context)
+        internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
         {
             return new W3dTreeDraw(this, context);
         }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Numerics;
+﻿using System.Numerics;
+using OpenSage.Client;
 using OpenSage.Data.Ini;
-using OpenSage.Graphics;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
@@ -12,8 +11,8 @@ namespace OpenSage.Logic.Object
 
         private readonly (string name, bool affectedBySteering)[] _boneList;
 
-        internal W3dTruckDraw(W3dTruckDrawModuleData data, GameObject gameObject, GameContext context)
-            : base(data, gameObject, context)
+        internal W3dTruckDraw(W3dTruckDrawModuleData data, Drawable drawable, GameContext context)
+            : base(data, drawable, context)
         {
             _data = data;
             _boneList = new[] {
@@ -159,9 +158,9 @@ namespace OpenSage.Logic.Object
         [AddedIn(SageGame.Bfme2Rotwk)]
         public RandomTexture RandomTexture { get; private set; }
 
-        internal override DrawModule CreateDrawModule(GameObject gameObject, GameContext context)
+        internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
         {
-            return new W3dTruckDraw(this, gameObject, context);
+            return new W3dTruckDraw(this, drawable, context);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -109,6 +109,8 @@ namespace OpenSage.Logic.Object
         private readonly Dictionary<string, BehaviorModule> _tagToModuleLookup;
         private readonly Dictionary<string, AttributeModifier> _attributeModifiers;
 
+        public uint ID { get; private set; }
+
         public Percentage ProductionModifier { get; set; } = new Percentage(1);
         public Fix64 HealthModifier { get; set; }
 
@@ -1294,12 +1296,14 @@ namespace OpenSage.Logic.Object
         {
             reader.ReadVersion(7);
 
-            var objectID = reader.ReadObjectID();
+            ID = reader.ReadObjectID();
 
             var transform = reader.ReadMatrix4x3();
             SetTransformMatrix(transform.ToMatrix4x4());
 
-            reader.__Skip(16);
+            reader.__Skip(12);
+
+            var drawableID = reader.ReadUInt32();
 
             _name = reader.ReadAsciiString();
 

--- a/src/OpenSage.Game/Logic/Object/Geometry.cs
+++ b/src/OpenSage.Game/Logic/Object/Geometry.cs
@@ -1,0 +1,55 @@
+﻿using System.Numerics;
+using OpenSage.Data.Ini;
+using OpenSage.Data.Sav;
+
+namespace OpenSage.Logic.Object
+{
+    [AddedIn(SageGame.Bfme)]
+    public sealed class Geometry
+    {
+        public Geometry() { }
+
+        public Geometry(ObjectGeometry type)
+        {
+            Type = type;
+        }
+
+        internal static Geometry Parse(IniParser parser)
+        {
+            return new Geometry()
+            {
+                Type = parser.ParseAttributeEnum<ObjectGeometry>("GeomType"),
+                IsSmall = parser.ParseAttributeBoolean("IsSmall"),
+                Height = parser.ParseAttributeInteger("Height"),
+                MajorRadius = parser.ParseAttributeInteger("MajorRadius"),
+                MinorRadius = parser.ParseAttributeInteger("MinorRadius"),
+                OffsetX = parser.ParseAttributeInteger("OffsetX")
+            };
+        }
+
+        public string Name { get; set; }
+        public ObjectGeometry Type { get; set; }
+        public bool IsSmall { get; set; }
+        public float Height { get; set; }
+        public float MajorRadius { get; set; }
+        public float MinorRadius { get; set; }
+        public int OffsetX { get; set; }
+        public Vector3 Offset { get; set; }
+        public bool IsActive { get; set; }
+        public float FrontAngle { get; set; }
+
+        public void Load(SaveFileReader reader)
+        {
+            reader.ReadVersion(1);
+            Type = reader.ReadEnum<ObjectGeometry>();
+            IsSmall = reader.ReadBoolean();
+            Height = reader.ReadSingle();
+            MajorRadius = reader.ReadSingle();
+            MinorRadius = reader.ReadSingle();
+            var unknown1 = reader.ReadSingle();
+            var unknown2 = reader.ReadSingle();
+        }
+
+        public Geometry Clone() => (Geometry) MemberwiseClone();
+    }
+}

--- a/src/OpenSage.Game/Logic/Object/ObjectCreationList.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectCreationList.cs
@@ -132,7 +132,7 @@ namespace OpenSage.Logic.Object
             debrisObject.UpdateTransform(context.GameObject.Translation + Offset, context.GameObject.Rotation);
 
             // Model
-            var w3dDebrisDraw = (W3dDebrisDraw) debrisObject.DrawModules[0];
+            var w3dDebrisDraw = (W3dDebrisDraw) debrisObject.Drawable.DrawModules[0];
             // TODO
             //var modelName = ModelNames[context.GameContext.Random.Next(ModelNames.Length)];
             var modelName = ModelNames[0];

--- a/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
@@ -1375,43 +1375,6 @@ namespace OpenSage.Logic.Object
     }
 
     [AddedIn(SageGame.Bfme)]
-    public sealed class Geometry
-    {
-        public Geometry() { }
-
-        public Geometry(ObjectGeometry type)
-        {
-            Type = type;
-        }
-
-        internal static Geometry Parse(IniParser parser)
-        {
-            return new Geometry()
-            {
-                Type = parser.ParseAttributeEnum<ObjectGeometry>("GeomType"),
-                IsSmall = parser.ParseAttributeBoolean("IsSmall"),
-                Height = parser.ParseAttributeInteger("Height"),
-                MajorRadius = parser.ParseAttributeInteger("MajorRadius"),
-                MinorRadius = parser.ParseAttributeInteger("MinorRadius"),
-                OffsetX = parser.ParseAttributeInteger("OffsetX")
-            };
-        }
-
-        public string Name { get; set; }
-        public ObjectGeometry Type { get; set; }
-        public bool IsSmall { get; set; }
-        public float Height { get; set; }
-        public float MajorRadius { get; set; }
-        public float MinorRadius { get; set; }
-        public int OffsetX { get; set; }
-        public Vector3 Offset { get; set; }
-        public bool IsActive { get; set; }
-        public float FrontAngle { get; set; }
-
-        public Geometry Clone() => (Geometry) MemberwiseClone();
-    }
-
-    [AddedIn(SageGame.Bfme)]
     public enum CollideSize
     {
         [IniEnum("LARGE")]

--- a/src/OpenSage.Game/Logic/Object/ObjectGeometry.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectGeometry.cs
@@ -4,15 +4,13 @@ namespace OpenSage.Logic.Object
 {
     public enum ObjectGeometry
     {
-        None,
-
-        [IniEnum("BOX")]
-        Box,
-
         [IniEnum("SPHERE")]
-        Sphere,
+        Sphere = 0,
 
         [IniEnum("CYLINDER")]
-        Cylinder
+        Cylinder = 1,
+
+        [IniEnum("BOX")]
+        Box = 2,
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TransportAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TransportAIUpdate.cs
@@ -20,8 +20,6 @@ namespace OpenSage.Logic.Object
             }
 
             base.Load(reader);
-
-            var unknown = reader.ReadBytes(33);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/DockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DockUpdate.cs
@@ -24,7 +24,7 @@ namespace OpenSage.Logic.Object
         private Vector3 GetActionBone()
         {
             // TODO: might also be DOCKSTART or DOCKEND
-            var (actionModelInstance, actionBone) = _gameObject.FindBone($"DOCKACTION");
+            var (actionModelInstance, actionBone) = _gameObject.Drawable.FindBone($"DOCKACTION");
 
             if (actionModelInstance != null && actionBone != null)
             {
@@ -36,7 +36,7 @@ namespace OpenSage.Logic.Object
         private Vector3 GetDockWaitingBone(int id)
         {
             var identifier = id.ToString("D2");
-            var (modelInstance, bone) = _gameObject.FindBone($"DOCKWAITING{identifier}");
+            var (modelInstance, bone) = _gameObject.Drawable.FindBone($"DOCKWAITING{identifier}");
             return modelInstance.AbsoluteBoneTransforms[bone.Index].Translation;
         }
 

--- a/src/OpenSage.Game/Logic/Object/Update/FireSpreadUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FireSpreadUpdate.cs
@@ -1,12 +1,25 @@
 ﻿using System;
+using System.IO;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
+using OpenSage.FileFormats;
 
 namespace OpenSage.Logic.Object
 {
     public sealed class FireSpreadUpdate : UpdateModule
     {
         // TODO
+
+        internal override void Load(BinaryReader reader)
+        {
+            var version = reader.ReadVersion();
+            if (version != 1)
+            {
+                throw new InvalidDataException();
+            }
+
+            base.Load(reader);
+        }
     }
 
     public sealed class FireSpreadUpdateModuleData : UpdateModuleData

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SpawnPointProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SpawnPointProductionExitUpdate.cs
@@ -40,7 +40,7 @@ namespace OpenSage.Logic.Object
         }
 
         private (ModelInstance, ModelBone) FindBone(int index)
-            => _gameObject.FindBone(_moduleData.SpawnPointBoneName + index.ToString("D2"));
+            => _gameObject.Drawable.FindBone(_moduleData.SpawnPointBoneName + index.ToString("D2"));
 
         Vector3? IProductionExit.GetNaturalRallyPoint() => null;
     }

--- a/src/OpenSage.Game/Logic/Object/Update/SlavedUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SlavedUpdate.cs
@@ -83,7 +83,7 @@ namespace OpenSage.Logic.Object
                     case RepairStatus.IN_TRANSITION:
                         if (!isMoving)
                         {
-                            var (modelInstance, bone) = _gameObject.FindBone(_moduleData.RepairWeldingFXBone);
+                            var (modelInstance, bone) = _gameObject.Drawable.FindBone(_moduleData.RepairWeldingFXBone);
                             var transform = modelInstance.AbsoluteBoneTransforms[bone.Index];
                             _particleTemplate ??= context.GameContext.AssetLoadContext.AssetStore.FXParticleSystemTemplates.GetByName(_moduleData.RepairWeldingSys);
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/SubObjectsUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/SubObjectsUpgrade.cs
@@ -21,7 +21,7 @@ namespace OpenSage.Logic.Object
             {
                 foreach (var subObject in _moduleData.ShowSubObjects)
                 {
-                    _gameObject.ShowSubObject(subObject);
+                    _gameObject.Drawable.ShowSubObject(subObject);
                 }
             }
 
@@ -29,7 +29,7 @@ namespace OpenSage.Logic.Object
             {
                 foreach (var subObject in _moduleData.HideSubObjects)
                 {
-                    _gameObject.HideSubObject(subObject);
+                    _gameObject.Drawable.HideSubObject(subObject);
                 }
             }
         }

--- a/src/OpenSage.Game/Logic/Object/Weapon/Weapon.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/Weapon.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.IO;
 using System.Numerics;
 using ImGuiNET;
+using OpenSage.FileFormats;
 
 namespace OpenSage.Logic.Object
 {
@@ -114,6 +116,25 @@ namespace OpenSage.Logic.Object
         public void Fire(TimeInterval time)
         {
             _stateMachine.Fire(time);
+        }
+
+        internal void Load(BinaryReader reader)
+        {
+            var version = reader.ReadVersion();
+
+            var templateName = reader.ReadBytePrefixedAsciiString();
+
+            reader.ReadBytes(13 * 4);
+
+            var count = reader.ReadUInt16();
+
+            if (count > 0)
+            {
+                throw new NotImplementedException();
+            }
+
+            var unknown1 = reader.ReadBooleanChecked();
+            var unknown2 = reader.ReadBooleanChecked();
         }
 
         internal void DrawInspector()

--- a/src/OpenSage.Game/Logic/Object/Weapon/WeaponEffects/ProjectileNugget.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/WeaponEffects/ProjectileNugget.cs
@@ -61,7 +61,7 @@ namespace OpenSage.Logic.Object
                 projectileTemplate,
                 context.Weapon.ParentGameObject.Owner);
 
-            var launchBoneTransform = context.Weapon.ParentGameObject.GetWeaponLaunchBoneTransform(
+            var launchBoneTransform = context.Weapon.ParentGameObject.Drawable.GetWeaponLaunchBoneTransform(
                 context.Weapon.Slot, context.Weapon.WeaponIndex);
 
             projectileObject.SetTransformMatrix(launchBoneTransform.Value);

--- a/src/OpenSage.Game/Logic/Object/Weapon/WeaponStates/FiringWeaponState.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/WeaponStates/FiringWeaponState.cs
@@ -44,7 +44,7 @@ namespace OpenSage.Logic.Object
 
         private void TriggerWeaponFireFX()
         {
-            var fireFXTransform = Context.GameObject.GetWeaponFireFXBoneTransform(
+            var fireFXTransform = Context.GameObject.Drawable.GetWeaponFireFXBoneTransform(
                 Context.Weapon.Slot,
                 Context.Weapon.WeaponIndex);
             if (fireFXTransform == null)

--- a/src/OpenSage.Game/Scripting/LuaScriptEngine.cs
+++ b/src/OpenSage.Game/Scripting/LuaScriptEngine.cs
@@ -277,13 +277,13 @@ namespace OpenSage.Scripting
 
         public void ObjectSetModelCondition(string gameObject, string modelCondition)
         {
-            Game.Scene3D.GameObjects.GetObjectById(GetLuaObjectID(gameObject)).CopyModelConditionFlags(IniParser.ParseEnumBitArray<ModelConditionFlag>(modelCondition, IniTokenPosition.None));
+            Game.Scene3D.GameObjects.GetObjectById(GetLuaObjectID(gameObject)).Drawable.CopyModelConditionFlags(IniParser.ParseEnumBitArray<ModelConditionFlag>(modelCondition, IniTokenPosition.None));
         }
 
         public bool ObjectTestModelCondition(string gameObject, string modelCondition)
         {
             var modelConditionBitArray = IniParser.ParseEnumBitArray<ModelConditionFlag>(modelCondition, IniTokenPosition.None);
-            var modelconditionBitArrayEnum = Game.Scene3D.GameObjects.GetObjectById(GetLuaObjectID(gameObject)).ModelConditionStates;
+            var modelconditionBitArrayEnum = Game.Scene3D.GameObjects.GetObjectById(GetLuaObjectID(gameObject)).Drawable.ModelConditionStates;
             foreach (var i in modelconditionBitArrayEnum)
             {
                 if (i == modelConditionBitArray)
@@ -297,7 +297,7 @@ namespace OpenSage.Scripting
         public void ObjectClearModelCondition(string gameObject, string modelCondition)
         {
             var modelConditionBitArray = IniParser.ParseEnumBitArray<ModelConditionFlag>(modelCondition, IniTokenPosition.None);
-            var modelconditionBitArrayEnum = Game.Scene3D.GameObjects.GetObjectById(GetLuaObjectID(gameObject)).ModelConditionStates;
+            var modelconditionBitArrayEnum = Game.Scene3D.GameObjects.GetObjectById(GetLuaObjectID(gameObject)).Drawable.ModelConditionStates;
             foreach (var i in modelconditionBitArrayEnum)
             {
                 if (i == modelConditionBitArray)
@@ -333,12 +333,12 @@ namespace OpenSage.Scripting
 
         public void ObjectHideSubObject(string gameObject, string subObject, string state)
         {
-            Game.Scene3D.GameObjects.GetObjectById(GetLuaObjectID(gameObject)).HideSubObject(subObject);
+            Game.Scene3D.GameObjects.GetObjectById(GetLuaObjectID(gameObject)).Drawable.HideSubObject(subObject);
         }
 
         public void ObjectHideSubObjectPermanently(string gameObject, string subObject, string state)
         {
-            Game.Scene3D.GameObjects.GetObjectById(GetLuaObjectID(gameObject)).HideSubObjectPermanently(subObject);
+            Game.Scene3D.GameObjects.GetObjectById(GetLuaObjectID(gameObject)).Drawable.HideSubObjectPermanently(subObject);
         }
 
         public int ObjectCountNearbyEnemies(string gameObject, string radius)
@@ -448,12 +448,12 @@ namespace OpenSage.Scripting
 
         public string CurDrawableGetPrevAnimationState() => _currentDrawModule.PreviousAnimationState?.StateName ?? "";
         public void CurDrawablePlaySound(string sound) => Game.Audio.PlayAudioEvent(sound);
-        public void CurDrawableShowSubObject(string subObject) => _currentDrawModule.GameObject.ShowSubObject(subObject);
-        public void CurDrawableHideSubObject(string subObject) => _currentDrawModule.GameObject.HideSubObject(subObject);
-        public void CurDrawableShowSubObjectPermanently(string subObject) => _currentDrawModule.GameObject.ShowSubObjectPermanently(subObject);
-        public void CurDrawableHideSubObjectPermanently(string subObject) => _currentDrawModule.GameObject.HideSubObjectPermanently(subObject);
-        public void CurDrawableShowModule(string module) => _currentDrawModule.GameObject.ShowDrawModule(module);
-        public void CurDrawableHideModule(string module) => _currentDrawModule.GameObject.HideDrawModule(module);
+        public void CurDrawableShowSubObject(string subObject) => _currentDrawModule.Drawable.ShowSubObject(subObject);
+        public void CurDrawableHideSubObject(string subObject) => _currentDrawModule.Drawable.HideSubObject(subObject);
+        public void CurDrawableShowSubObjectPermanently(string subObject) => _currentDrawModule.Drawable.ShowSubObjectPermanently(subObject);
+        public void CurDrawableHideSubObjectPermanently(string subObject) => _currentDrawModule.Drawable.HideSubObjectPermanently(subObject);
+        public void CurDrawableShowModule(string module) => _currentDrawModule.Drawable.ShowDrawModule(module);
+        public void CurDrawableHideModule(string module) => _currentDrawModule.Drawable.HideDrawModule(module);
         public void CurDrawableSetTransitionAnimState(string state) => _currentDrawModule.SetTransitionState(state);
         public bool CurDrawableModelcondition(string conditionString)
         {


### PR DESCRIPTION
This PR adds `GameLogic` and `GameClient`, and moves drawing-related code from `GameObject` into a new `Drawable` class. Eventually we'll move more from `Scene3D` into `GameLogic` and `GameClient`.

The names `GameLogic` and `GameClient` come from the `CHUNK_GameLogic` and `CHUNK_GameClient` chunks in .sav files. The `Drawable` name comes from many mentions to "objects and drawables", where objects contain logic and drawables contain drawing stuff, in .ini files. Also in .sav files, objects contain behaviours, while drawables contain draw modules and client updates.