### PR TITLE
Fix MapCache load error on Linux

### DIFF
--- a/src/OpenSage.Game/OpenSage.Game.csproj
+++ b/src/OpenSage.Game/OpenSage.Game.csproj
@@ -60,6 +60,18 @@
     <GlslangValidatorPath Condition="$([MSBuild]::IsOsPlatform('linux'))">linux-x64\glslangValidator</GlslangValidatorPath>
   </PropertyGroup>
 
+<PropertyGroup Condition="'$(GlslangValidatorPath)'=='win-x64\glslangValidator.exe'">
+  <DefineConstants>_WINDOWS_</DefineConstants>
+</PropertyGroup>
+
+<PropertyGroup Condition="'$(GlslangValidatorPath)'=='osx-x64\glslangValidator'">
+  <DefineConstants>_MACOSX_</DefineConstants>
+</PropertyGroup>
+ 
+<PropertyGroup Condition="'$(GlslangValidatorPath)'=='linux-x64\glslangValidator'">
+  <DefineConstants>_LINUX_</DefineConstants>
+</PropertyGroup>
+
   <ItemGroup>
     <None Update="Content\Fonts\FontFallbackSettings.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -308,10 +308,9 @@ namespace OpenSage
             if (mapPath != null)
             {
                 // Change filepath separator from / to \ when not on windows (GetByName() expects windows path)
-                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
+                #if !_WINDOWS_
                     mapPath = mapPath.Replace("/", "\\");
-                }
+                #endif
                 var mapCache = game.AssetStore.MapCaches.GetByName(mapPath.ToLower());
                 if (mapCache == null)
                 {

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using OpenSage.Audio;
 using OpenSage.Content;
 using OpenSage.Content.Loaders;
@@ -306,6 +307,11 @@ namespace OpenSage
 
             if (mapPath != null)
             {
+                // Change filepath separator from / to \ when not on windows (GetByName() expects windows path)
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    mapPath = mapPath.Replace("/", "\\");
+                }
                 var mapCache = game.AssetStore.MapCaches.GetByName(mapPath.ToLower());
                 if (mapCache == null)
                 {


### PR DESCRIPTION
Fixes #543. `GetByName()` expects a Windows filepath, so it changes `mapPath` to one before calling it.