### PR TITLE
Use bitwise-and to compare module kind(s) for module inheritance

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
@@ -151,6 +151,8 @@ namespace OpenSage.Logic.Object
 
     public class SlowDeathBehaviorModuleData : UpdateModuleData
     {
+        public override ModuleKinds ModuleKinds => ModuleKinds.Update | ModuleKinds.Die;
+
         internal static SlowDeathBehaviorModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
 
         internal static readonly IniParseTable<SlowDeathBehaviorModuleData> FieldParseTable = new IniParseTable<SlowDeathBehaviorModuleData>

--- a/src/OpenSage.Game/Logic/Object/Body/BodyModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/BodyModule.cs
@@ -49,7 +49,7 @@ namespace OpenSage.Logic.Object
 
     public abstract class BodyModuleData : BehaviorModuleData
     {
-        public override ModuleKind ModuleKind => ModuleKind.Body;
+        public override ModuleKinds ModuleKinds => ModuleKinds.Body;
 
         internal static ModuleDataContainer ParseBody(IniParser parser, ModuleInheritanceMode inheritanceMode) => ParseModule(parser, BodyParseTable, inheritanceMode);
 

--- a/src/OpenSage.Game/Logic/Object/ClientUpdate/ClientUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/ClientUpdate/ClientUpdate.cs
@@ -23,7 +23,7 @@ namespace OpenSage.Logic.Object
 
     public abstract class ClientUpdateModuleData : ModuleData
     {
-        public override ModuleKind ModuleKind => ModuleKind.ClientUpdate;
+        public override ModuleKinds ModuleKinds => ModuleKinds.ClientUpdate;
 
         internal static ModuleDataContainer ParseClientUpdate(IniParser parser, ModuleInheritanceMode inheritanceMode) => ParseModule(parser, ClientUpdateParseTable, inheritanceMode);
 

--- a/src/OpenSage.Game/Logic/Object/Collide/CollideModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/CollideModule.cs
@@ -19,6 +19,6 @@ namespace OpenSage.Logic.Object
 
     public abstract class CollideModuleData : BehaviorModuleData
     {
-        public override ModuleKind ModuleKind => ModuleKind.Collide;
+        public override ModuleKinds ModuleKinds => ModuleKinds.Collide;
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Contain/ContainModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/ContainModule.cs
@@ -2,6 +2,6 @@
 {
     public abstract class ContainModuleData : BehaviorModuleData
     {
-        public override ModuleKind ModuleKind => ModuleKind.Contain;
+        public override ModuleKinds ModuleKinds => ModuleKinds.Contain;
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Create/CreateModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/CreateModule.cs
@@ -7,6 +7,6 @@
 
     public abstract class CreateModuleData : BehaviorModuleData
     {
-        public override ModuleKind ModuleKind => ModuleKind.Create;
+        public override ModuleKinds ModuleKinds => ModuleKinds.Create;
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Damage/DamageModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/DamageModule.cs
@@ -19,6 +19,6 @@ namespace OpenSage.Logic.Object
 
     public abstract class DamageModuleData : ContainModuleData
     {
-        public override ModuleKind ModuleKind => ModuleKind.Damage;
+        public override ModuleKinds ModuleKinds => ModuleKinds.Damage;
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/DieModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DieModule.cs
@@ -21,7 +21,7 @@ namespace OpenSage.Logic.Object
 
     public abstract class DieModuleData : BehaviorModuleData
     {
-        public override ModuleKind ModuleKind => ModuleKind.Die;
+        public override ModuleKinds ModuleKinds => ModuleKinds.Die;
 
         internal static readonly IniParseTable<DieModuleData> FieldParseTable = new IniParseTable<DieModuleData>
         {

--- a/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
@@ -67,7 +67,7 @@ namespace OpenSage.Logic.Object
 
     public abstract class DrawModuleData : ModuleData
     {
-        public override ModuleKind ModuleKind => ModuleKind.Draw;
+        public override ModuleKinds ModuleKinds => ModuleKinds.Draw;
 
         internal static ModuleDataContainer ParseDrawModule(IniParser parser, ModuleInheritanceMode inheritanceMode) => ParseModule(parser, DrawModuleParseTable, inheritanceMode);
 

--- a/src/OpenSage.Game/Logic/Object/Module.cs
+++ b/src/OpenSage.Game/Logic/Object/Module.cs
@@ -22,23 +22,24 @@ namespace OpenSage.Logic.Object
             return new ModuleDataContainer(tag.Text, result, inheritanceMode, false);
         }
 
-        public virtual ModuleKind ModuleKind => ModuleKind.None;
+        public virtual ModuleKinds ModuleKinds => ModuleKinds.None;
     }
 
-    public enum ModuleKind
+    [Flags]
+    public enum ModuleKinds
     {
-        None,
-        Body,
-        ClientUpdate,
-        Collide,
-        Contain,
-        Create,
-        Damage,
-        Die,
-        Draw,
-        SpecialPower,
-        Update,
-        Upgrade,
+        None         = 0x0,
+        Body         = 0x1,
+        ClientUpdate = 0x2,
+        Collide      = 0x4,
+        Contain      = 0x8,
+        Create       = 0x10,
+        Damage       = 0x20,
+        Die          = 0x40,
+        Draw         = 0x80,
+        SpecialPower = 0x100,
+        Update       = 0x200,
+        Upgrade      = 0x400,
     }
 
     public readonly struct ModuleDataContainer
@@ -66,7 +67,7 @@ namespace OpenSage.Logic.Object
     {
         /// <summary>
         /// This module is inherited, but if the inheriting object defines a module
-        /// with the same <see cref="ModuleKind"/>, then this module is removed.
+        /// with the same <see cref="ModuleKinds"/>, then this module is removed.
         /// </summary>
         Default,
 

--- a/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
@@ -1301,7 +1301,7 @@ namespace OpenSage.Logic.Object
                     switch (existingBehavior.InheritanceMode)
                     {
                         case ModuleInheritanceMode.Default:
-                            if (existingBehavior.Data.ModuleKind == module.Data.ModuleKind)
+                            if ((existingBehavior.Data.ModuleKinds & module.Data.ModuleKinds) != 0)
                             {
                                 behaviorsToRemove.Add(existingBehavior);
                             }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialPower.cs
@@ -28,7 +28,7 @@ namespace OpenSage.Logic.Object
 
     public class SpecialPowerModuleData : BehaviorModuleData
     {
-        public override ModuleKind ModuleKind => ModuleKind.SpecialPower;
+        public override ModuleKinds ModuleKinds => ModuleKinds.SpecialPower;
 
         internal static SpecialPowerModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
 

--- a/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
@@ -22,6 +22,6 @@ namespace OpenSage.Logic.Object
 
     public abstract class UpdateModuleData : ContainModuleData
     {
-        public override ModuleKind ModuleKind => ModuleKind.Update;
+        public override ModuleKinds ModuleKinds => ModuleKinds.Update;
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
@@ -96,7 +96,7 @@ namespace OpenSage.Logic.Object
 
     public abstract class UpgradeModuleData : BehaviorModuleData
     {
-        public override ModuleKind ModuleKind => ModuleKind.Upgrade;
+        public override ModuleKinds ModuleKinds => ModuleKinds.Upgrade;
 
         internal static readonly IniParseTable<UpgradeModuleData> FieldParseTable = new IniParseTable<UpgradeModuleData>
         {


### PR DESCRIPTION
This is a follow-up to #558. I've discovered that "default" module inheritance isn't just based on a single "module kind" for each module. For example, a `SlowDeathBehavior` will override both `Update` and `Die` modules from the `DefaultThingTemplate`. So we need to use a flags enum and bitwise-and to compare the module kinds.