### PR TITLE
Fix skirmish menu slots

### DIFF
--- a/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
@@ -358,7 +358,8 @@ namespace OpenSage.Mods.Generals.Gui
                 var playerCombo = (ComboBox) window.Controls.FindControl($"{_optionsPath}{ComboBoxPlayerPrefix}{slot.Index}");
 
                 var isLocalSlot = slot == _game.SkirmishManager.Settings.LocalSlot;
-                var editable = (isLocalSlot && !slot.Ready) || (_game.SkirmishManager.IsHosting && slot.State != SkirmishSlotState.Human);
+                // if there is no player or AI in the slot, the other boxes should be disabled
+                var editable = (isLocalSlot && !slot.Ready) || (_game.SkirmishManager.IsHosting && slot.State is not SkirmishSlotState.Human and not SkirmishSlotState.Open and not SkirmishSlotState.Closed);
 
                 // is null in singleplayer games for the local player
                 if (playerCombo != null)

--- a/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GameOptionsUtil.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -344,11 +344,11 @@ namespace OpenSage.Mods.Generals.Gui
 
                 var colorCombo = (ComboBox) window.Controls.FindControl($"{_optionsPath}{ComboBoxColorPrefix}{slot.Index}");
                 if ((sbyte) colorCombo.Items[colorCombo.SelectedIndex].DataItem != slot.ColorIndex)
-                    colorCombo.SelectedIndex = Array.FindIndex(colorCombo.Items, x => (sbyte) x.DataItem == slot.ColorIndex);
+                    colorCombo.SelectedIndex = Array.FindIndex(colorCombo.Items, x => (sbyte) x.DataItem == slot.ColorIndex - 1);
 
                 var teamCombo = (ComboBox) window.Controls.FindControl($"{_optionsPath}{ComboBoxTeamPrefix}{slot.Index}");
                 if ((sbyte) teamCombo.Items[teamCombo.SelectedIndex].DataItem != slot.Team)
-                    teamCombo.SelectedIndex = Array.FindIndex(teamCombo.Items, x => (sbyte) x.DataItem == slot.Team);
+                    teamCombo.SelectedIndex = Array.FindIndex(teamCombo.Items, x => (sbyte) x.DataItem == slot.Team - 1);
 
                 var playerTemplateCombo = (ComboBox) window.Controls.FindControl($"{_optionsPath}{ComboBoxPlayerTemplatePrefix}{slot.Index}");
                 if (playerTemplateCombo.SelectedIndex != slot.FactionIndex)


### PR DESCRIPTION
The color slot was defaulting to gold and the team slot was defaulting to 1. This also disables slot editing when a "player" (human or AI) is not present.