### PR TITLE
Add memory mapped spans and streams

### DIFF
--- a/src/OpenSage.Core/Endianness.cs
+++ b/src/OpenSage.Core/Endianness.cs
@@ -1,0 +1,29 @@
+﻿#region License
+/*
+ * Copyright (C) 2019 Stefano Moioli <smxdev4@gmail.com>
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#endregion
+using System;
+
+namespace OpenSage.Core
+{
+	/* http://stackoverflow.com/a/2624377 */
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Struct, Inherited = true)]
+	public class EndianAttribute : Attribute
+	{
+		public Endianness Endianness { get; private set; }
+
+		public EndianAttribute(Endianness endianness) {
+			this.Endianness = endianness;
+		}
+	}
+
+	public enum Endianness
+	{
+		BigEndian,
+		LittleEndian
+	}
+}

--- a/src/OpenSage.Core/MFile.cs
+++ b/src/OpenSage.Core/MFile.cs
@@ -1,0 +1,41 @@
+﻿#region License
+/*
+ * Copyright (C) 2019 Stefano Moioli <smxdev4@gmail.com>
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#endregion
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenSage.Core
+{
+	public class MFile : IDisposable
+	{
+		public readonly MemoryMappedSpan<byte> Span;
+
+		public MFile(MemoryMappedSpan<byte> span) {
+			this.Span = span;
+		}
+
+		public static MFile Open(string filePath) {
+			FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Read);
+			MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(
+				fs, null, 0,
+				MemoryMappedFileAccess.Read, HandleInheritability.Inheritable, false
+			);
+			MemoryMappedSpan<byte> span = new MemoryMappedSpan<byte>(mmf, (int)fs.Length);
+			return new MFile(span);
+		}
+
+		public void Dispose() {
+			Span.Dispose();
+		}
+	}
+}

--- a/src/OpenSage.Core/MemoryMappedSpan.cs
+++ b/src/OpenSage.Core/MemoryMappedSpan.cs
@@ -1,0 +1,52 @@
+﻿#region License
+/*
+ * Copyright (C) 2019 Stefano Moioli <smxdev4@gmail.com>
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#endregion
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO.MemoryMappedFiles;
+using System.Text;
+
+namespace OpenSage.Core
+{
+	public unsafe class MemoryMappedSpan<T> : MemoryManager<T>, IDisposable where T : unmanaged
+	{
+		public readonly int Length;
+
+		private readonly MemoryMappedViewAccessor acc;
+		private readonly byte* dptr = null;
+
+		public MemoryMappedSpan(MemoryMappedFile mf, int length) {
+			this.Length = length;
+			this.acc = mf.CreateViewAccessor(0, length, MemoryMappedFileAccess.Read);
+			this.acc.SafeMemoryMappedViewHandle.AcquirePointer(ref dptr);
+		}
+
+		public override Span<T> GetSpan() {
+			return new Span<T>((void*)dptr, Length);
+		}
+
+		public override MemoryHandle Pin(int elementIndex = 0) {
+			if (elementIndex < 0 || elementIndex >= Length) {
+				throw new ArgumentOutOfRangeException(nameof(elementIndex));
+			}
+
+			return new MemoryHandle(dptr + elementIndex);
+		}
+
+		public override void Unpin() { }
+
+		public void Dispose() {
+			Dispose(true);
+		}
+
+		protected override void Dispose(bool disposing) {
+			acc.Dispose();
+		}
+	}
+}

--- a/src/OpenSage.Core/MemoryMappedSpan.cs
+++ b/src/OpenSage.Core/MemoryMappedSpan.cs
@@ -21,9 +21,9 @@ namespace OpenSage.Core
 		private readonly MemoryMappedViewAccessor acc;
 		private readonly byte* dptr = null;
 
-		public MemoryMappedSpan(MemoryMappedFile mf, int length) {
+		public MemoryMappedSpan(MemoryMappedFile mf, int length, MemoryMappedFileAccess mmapFlags) {
 			this.Length = length;
-			this.acc = mf.CreateViewAccessor(0, length, MemoryMappedFileAccess.Read);
+			this.acc = mf.CreateViewAccessor(0, length, mmapFlags);
 			this.acc.SafeMemoryMappedViewHandle.AcquirePointer(ref dptr);
 		}
 

--- a/src/OpenSage.Core/OpenSage.Core.csproj
+++ b/src/OpenSage.Core/OpenSage.Core.csproj
@@ -4,6 +4,14 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Veldrid.SDL2" Version="$(VeldridVersion)" />
     <PackageReference Include="NLog.Config" Version="4.7.10" />

--- a/src/OpenSage.Core/SpanExtensions.cs
+++ b/src/OpenSage.Core/SpanExtensions.cs
@@ -1,0 +1,63 @@
+﻿#region License
+/*
+ * Copyright (C) 2019 Stefano Moioli <smxdev4@gmail.com>
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#endregion
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace OpenSage.Core
+{
+	public static class SpanExtensions
+	{
+		public unsafe static T Read<T>(this ReadOnlySpan<byte> data, int offset) where T : unmanaged {
+			int length = sizeof(T);
+			return Cast<T>(data.Slice(offset, length))[0];
+		}
+
+		public unsafe static T Read<T>(this Span<byte> data, int offset) where T : unmanaged {
+			int length = sizeof(T);
+			return Cast<T>(data.Slice(offset, length))[0];
+		}
+
+		public unsafe static void Write<T>(this Span<byte> data, int offset, T value) where T : unmanaged {
+			int length = sizeof(T);
+			Cast<T>(data.Slice(offset, length))[0] = value;
+		}
+
+		public unsafe static void CopyTo<TFrom, TTo>(this Span<TFrom> data, Span<TTo> dest, int dstOffset)
+			where TFrom : unmanaged
+			where TTo : unmanaged
+		{
+			var srcBytes = MemoryMarshal.Cast<TFrom, byte>(data);
+			var dstBytes = MemoryMarshal.Cast<TTo, byte>(dest).Slice(dstOffset);
+			srcBytes.CopyTo(dstBytes);
+		}
+
+		public unsafe static void CopyTo<TFrom, TTo>(this Memory<TFrom> data, Memory<TTo> dest, int dstOffset)
+			where TFrom : unmanaged
+			where TTo : unmanaged
+		{
+			data.Span.CopyTo(dest.Span, dstOffset);
+		}
+
+		public unsafe static void WriteBytes(this Span<byte> data, int offset, byte[] bytes) {
+			var start = data.Slice(offset, bytes.Length);
+			var dspan = new Span<byte>(bytes);
+			dspan.CopyTo(start);
+		}
+
+		public static ReadOnlySpan<T> Cast<T>(this ReadOnlySpan<byte> data) where T : struct {
+			return MemoryMarshal.Cast<byte, T>(data);
+		}
+
+		public static Span<T> Cast<T>(this Span<byte> data) where T : struct {
+			return MemoryMarshal.Cast<byte, T>(data);
+		}
+	}
+}

--- a/src/OpenSage.Core/SpanStream.cs
+++ b/src/OpenSage.Core/SpanStream.cs
@@ -1,0 +1,492 @@
+﻿#region License
+/*
+ * Copyright (C) 2019 Stefano Moioli <smxdev4@gmail.com>
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#endregion
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace OpenSage.Core
+{
+	public partial class SpanStream
+	{
+
+		delegate T ReaderDelegate<T>() where T : unmanaged;
+		delegate void WriterDelegate<T>(T value) where T : unmanaged;
+
+		private ReaderDelegate<ushort> u16Reader;
+		private ReaderDelegate<uint> u32Reader;
+		private ReaderDelegate<ulong> u64Reader;
+
+		private WriterDelegate<ushort> u16Writer;
+		private WriterDelegate<uint> u32Writer;
+		private WriterDelegate<ulong> u64Writer;
+
+		private int pos;
+
+        public long Position {
+			get => pos;
+			set => pos = (int)value;
+		}
+		public long Remaining => Length - Position;
+		public long Length => Memory.Length;
+
+		public Memory<byte> Memory { get; private set; }
+		public Span<byte> Span => Memory.Span;
+
+        private Endianness endianness = Endianness.LittleEndian;
+		public Endianness Endianness {
+			get => endianness;
+			set {
+				endianness = value;
+				SetDelegates();
+			}
+		}
+
+        public bool CanRead { get; set; } = true;
+        public bool CanSeek { get; set; } = true;
+
+        private void SetDelegates() {
+			if (
+				BitConverter.IsLittleEndian && Endianness == Endianness.LittleEndian ||
+				!BitConverter.IsLittleEndian && Endianness == Endianness.BigEndian
+			) {
+				u16Reader = new ReaderDelegate<ushort>(Read<ushort>);
+				u16Writer = new WriterDelegate<ushort>(Write<ushort>);
+				u32Reader = new ReaderDelegate<uint>(Read<uint>);
+				u32Writer = new WriterDelegate<uint>(Write<uint>);
+				u64Reader = new ReaderDelegate<ulong>(Read<ulong>);
+				u64Writer = new WriterDelegate<ulong>(Write<ulong>);
+			} else {
+				u16Reader = new ReaderDelegate<ushort>(ReadUInt16Swapped);
+				u16Writer = new WriterDelegate<ushort>(WriteUInt16Swapped);
+				u32Reader = new ReaderDelegate<uint>(ReadUInt32Swapped);
+				u32Writer = new WriterDelegate<uint>(WriteUInt32Swapped);
+				u64Reader = new ReaderDelegate<ulong>(ReadUInt64Swapped);
+				u64Writer = new WriterDelegate<ulong>(WriteUInt64Swapped);
+			}
+		}
+
+		public byte[] ReadBytes(int count) {
+			byte[] ret = Memory.Slice(pos, count).ToArray();
+			pos += count;
+			return ret;
+		}
+
+		private ushort ReadUInt16Swapped() {
+			return ByteSwap16(Read<ushort>());
+		}
+
+		private void WriteUInt16Swapped(ushort value) {
+			Write<ushort>(ByteSwap16(value));
+		}
+
+		private void WriteUInt32Swapped(uint value) {
+			Write<uint>(ByteSwap32(value));
+		}
+
+		private void WriteUInt64Swapped(ulong value) {
+			Write<ulong>(ByteSwap64(value));
+		}
+
+		private uint ReadUInt32Swapped() {
+			return ByteSwap32(Read<uint>());
+		}
+
+		private ulong ReadUInt64Swapped() {
+			return ByteSwap64(Read<ulong>());
+		}
+
+		private static ushort ByteSwap16(ushort num) {
+			return (ushort)(
+				((num & 0xFF00) >> 8) |
+				((num & 0x00FF) << 8)
+			);
+		}
+
+		private static uint ByteSwap32(uint num) {
+			return (
+				((num & 0xFF000000) >> 24) |
+				((num & 0x00FF0000) >> 8) |
+				((num & 0x0000FF00) << 8) |
+				((num & 0x000000FF) << 24)
+			);
+		}
+
+		private static ulong ByteSwap64(ulong num) {
+			return (
+				((num & 0xFF00000000000000) >> 56) |
+				((num & 0x00FF000000000000) >> 40) |
+				((num & 0x0000FF0000000000) >> 24) |
+				((num & 0x000000FF00000000) >>  8) | 
+				((num & 0x00000000FF000000) <<  8) |
+				((num & 0x0000000000FF0000) << 24) |
+				((num & 0x000000000000FF00) << 40) |
+				((num & 0x00000000000000FF) << 56)
+			);
+		}
+
+
+        private int FieldSize(FieldInfo field)
+        {
+            if (field.FieldType.IsArray)
+            {
+                MarshalAsAttribute attr = (MarshalAsAttribute) field.GetCustomAttribute(typeof(MarshalAsAttribute), false);
+                return Marshal.SizeOf(field.FieldType.GetElementType()) * attr.SizeConst;
+            }
+            else
+            {
+                if (field.FieldType.IsEnum)
+                {
+                    return Marshal.SizeOf(Enum.GetUnderlyingType(field.FieldType));
+                }
+                return Marshal.SizeOf(field.FieldType);
+            }
+        }
+
+        private void SwapEndian<T>(byte[] data, FieldInfo field)
+        {
+            var type = typeof(T);
+            int offset = Marshal.OffsetOf(type, field.Name).ToInt32();
+            if (field.FieldType.IsArray)
+            {
+                MarshalAsAttribute attr = (MarshalAsAttribute) field.GetCustomAttribute(typeof(MarshalAsAttribute), false);
+                int subSize = Marshal.SizeOf(field.FieldType.GetElementType());
+                for (int i = 0; i < attr.SizeConst; i++)
+                {
+                    Array.Reverse(data, offset + (i * subSize), subSize);
+                }
+            }
+            else
+            {
+                Array.Reverse(data, offset, FieldSize(field));
+            }
+        }
+
+        private Endianness defaultEndianess = Endianness.LittleEndian;
+
+        /* Adapted from http://stackoverflow.com/a/2624377 */
+        private T RespectEndianness<T>(T data)
+        {
+            var structEndianness = this.defaultEndianess;
+            var type = typeof(T);
+            if (type.IsDefined(typeof(EndianAttribute), false))
+            {
+                EndianAttribute attr = (EndianAttribute)type
+                    .GetCustomAttribute(typeof(EndianAttribute), false);
+                structEndianness = attr.Endianness;
+            }
+
+            var sz = Marshal.SizeOf(data);
+            var mem = Marshal.AllocHGlobal(sz);
+            try
+            {
+                Marshal.StructureToPtr(data, mem, false);
+                var bytes = new byte[sz];
+                Marshal.Copy(mem, bytes, 0, sz);
+                foreach (var field in type.GetFields())
+                {
+                    if (field.IsDefined(typeof(EndianAttribute), false))
+                    {
+                        Endianness fieldEndianess = ((EndianAttribute) field.GetCustomAttributes(typeof(EndianAttribute), false)[0]).Endianness;
+                        if (
+                            (fieldEndianess == Endianness.BigEndian && BitConverter.IsLittleEndian) ||
+                            (fieldEndianess == Endianness.LittleEndian && !BitConverter.IsLittleEndian)
+                        )
+                        {
+                            SwapEndian<T>(bytes, field);
+                        }
+                    }
+                    else if (
+                      (structEndianness == Endianness.BigEndian && BitConverter.IsLittleEndian) ||
+                      (structEndianness == Endianness.LittleEndian && !BitConverter.IsLittleEndian)
+                  )
+                    {
+                        SwapEndian<T>(bytes, field);
+                    }
+                }
+                Marshal.Copy(bytes, 0, mem, sz);
+                data = Marshal.PtrToStructure<T>(mem);
+            } finally
+            {
+                Marshal.FreeHGlobal(mem);
+            }
+
+            return data;
+        }
+
+        private T AdjustFieldEndianness<T>(T value) where T : unmanaged {
+			switch (value) {
+				case sbyte num:
+					return (T)(object)num;
+				case byte num:
+					return (T)(object)num;
+			}
+
+			if (BitConverter.IsLittleEndian && Endianness == Endianness.LittleEndian)
+				return value;
+
+			switch (value) {
+				case short num:
+					return (T)(object)ByteSwap16((ushort)num);
+				case ushort num:
+					return (T)(object)ByteSwap16(num);
+				case int num:
+					return (T)(object)ByteSwap32((uint)num);
+				case uint num:
+					return (T)(object)ByteSwap32(num);
+				case long num:
+					return (T)(object)ByteSwap64((ulong)num);
+				case ulong num:
+					return (T)(object)ByteSwap64(num);
+				default:
+					throw new NotImplementedException(typeof(T).Name);
+			}
+		}
+
+		public unsafe T Read<T>() where T : unmanaged {
+			var start = Memory.Span.Slice(pos, sizeof(T));
+			T ret = MemoryMarshal.Cast<byte, T>(start)[0];
+			pos += sizeof(T);
+			return ret;
+		}
+
+        public int Read(byte[] buffer, int offset, int count)
+        {
+            Memory.Span
+                .Slice((int)Position, count)
+                .ToArray()
+                .CopyTo(buffer, offset);
+            Seek(count, SeekOrigin.Current);
+            return count;
+        }
+
+        public unsafe void Write<T>(T value) where T : unmanaged {
+			var start = Memory.Span.Slice(pos, sizeof(T));
+			MemoryMarshal.Cast<byte, T>(start)[0] = value;
+			pos += sizeof(T);
+		}
+
+		public unsafe void WriteAt<T>(long offset, T value) where T : unmanaged {
+			Memory.Span.Write<T>((int)offset, value);
+		}
+
+		public void WriteMemory<T>(Memory<T> data) where T : unmanaged {
+			data.CopyTo(Memory, pos);
+			pos += data.Length;
+		}
+
+		public void WriteSpan<T>(Span<T> data) where T : unmanaged {
+			data.CopyTo(Span, pos);
+			pos += data.Length;
+		}
+
+		public string ReadString16NoTerm() {
+			int length = ReadByte();
+			string str = Encoding.ASCII.GetString(ReadBytes(length));
+			return str;
+		}
+
+		public string ReadString16() {
+			int length = ReadByte();
+			string str = Encoding.ASCII.GetString(ReadBytes(length));
+			ReadByte(); //null terminator
+			return str;
+		}
+
+		public string ReadString32() {
+			int length = ReadInt32();
+			string str = Encoding.ASCII.GetString(ReadBytes(length));
+			ReadByte(); //null terminator
+			return str;
+		}
+
+		public void WriteString(string str) {
+			WriteUInt32((uint)str.Length);
+			WriteBytes(Encoding.ASCII.GetBytes(str));
+			WriteByte(0x00);
+		}
+
+		public void WriteCString(string str) {
+			WriteBytes(Encoding.ASCII.GetBytes(str));
+			WriteByte(0x00);
+		}
+
+
+		public unsafe T ReadStruct<T>() where T : unmanaged {
+			int length = sizeof(T);
+			var start = Memory.Span.Slice(pos, length);
+
+            T ret;
+            ret = MemoryMarshal.Cast<byte, T>(start)[0];
+            ret = RespectEndianness(ret);
+
+			pos += length;
+			return ret;
+		}
+
+		public SpanStream(SpanStream other) : this() {
+			this.Memory = other.Memory.Slice(other.pos);
+		}
+
+		public SpanStream(Memory<byte> data) : this() {
+			this.Memory = data;
+		}
+
+		private SpanStream() {
+			SetDelegates();
+		}
+
+		public void Replace(byte[] newData) {
+			this.Memory = new Memory<byte>(newData);
+		}
+
+		public void Extend(int newSize) {
+			if(newSize <= Memory.Length) {
+				throw new ArgumentOutOfRangeException($"New size {newSize} is shorter than current {Memory.Length}");
+			}
+			byte[] data = new byte[newSize];
+			var newMem = new Memory<byte>(data);
+			Memory.CopyTo(newMem);
+
+			this.Memory = newMem;
+		}
+
+		public unsafe T ReadEnum<T>() where T : unmanaged {
+			T value = ReadFlagsEnum<T>();
+
+			Type enumType = typeof(T);
+			if (!Enum.IsDefined(enumType, value)) {
+				throw new InvalidDataException($"Value 0x{value:X} not defined in enum {enumType.FullName}");
+			}
+
+			return value;
+		}
+
+		public string ReadCString(Encoding encoding) {
+			int start = (int)Position;
+			while (Span[(int)(Position++)] != 0x00) ;
+
+			// ignore trailing NULL
+			byte[] data = Span.Slice(start, (int)(Position - start - 1)).ToArray();
+			return encoding.GetString(data);
+		}
+
+		public string ReadCString() => ReadCString(Encoding.ASCII);
+
+		public unsafe T ReadFlagsEnum<T>() where T : unmanaged {
+			object value;
+			switch (sizeof(T)) {
+				case 1:
+					value = ReadByte();
+					break;
+				case 2:
+					value = ReadUInt16();
+					break;
+				case 4:
+					value = ReadUInt32();
+					break;
+				case 8:
+					value = ReadUInt64();
+					break;
+				default:
+					throw new NotImplementedException();
+			}
+
+
+			return (T)value;
+		}
+		public int AlignStream(uint alignment) {
+			long position = (Position + alignment - 1) & ~(alignment - 1);
+			long skipped = position - Position;
+			Position = position;
+			return (int)skipped;
+		}
+
+		public void PerformAt(long offset, Action action) {
+			long curPos = Position;
+			Position = offset;
+			action.Invoke();
+			Position = curPos;
+		}
+
+		public T PerformAt<T>(long offset, Func<T> action) {
+			long curPos = Position;
+			Position = offset;
+			T result = action.Invoke();
+			Position = curPos;
+			return result;
+		}
+
+		public IEnumerable<T> ReadAll<T>(Func<SpanStream, T> reader) {
+			while(Remaining > 0) {
+				T item = reader(this);
+				yield return item;
+			}
+		}
+
+		public void Seek(long offset, SeekOrigin origin) {
+			switch (origin) {
+				case SeekOrigin.Begin:
+					Position = offset;
+					break;
+				case SeekOrigin.Current:
+					Position += offset;
+					break;
+				case SeekOrigin.End:
+					Position = Length - offset;
+					break;
+			}
+		}
+
+		public SpanStream SliceHere(int length) {
+			return new SpanStream(this.Memory.Slice(this.pos, length));
+		}
+
+		public virtual byte[] ReadRemaining() {
+			return ReadBytes((int)Remaining);
+		}
+
+		public byte ReadByte() => Read<byte>();
+		public void WriteByte(byte value) => Write(value);
+
+		public void WriteBytes(byte[] data) {
+			var start = Memory.Span.Slice(pos, data.Length);
+			var dspan = new Span<byte>(data);
+			dspan.CopyTo(start);
+		}
+
+		public short ReadInt16() => (short)u16Reader();
+		public void WriteInt16(Int16 value) => u16Writer((ushort)value);
+
+		public int ReadInt32() => (int)u32Reader();
+		public void WriteInt32(Int32 value) => u32Writer((uint)value);
+
+		public long ReadInt64() => (long)u64Reader();
+		public void WriteInt64(Int64 value) => u64Writer((ulong)value);
+
+		//$TODO: support precisions > 32 and 64 bits?
+		public float ReadSingle() => u32Reader();
+		public void WriteSingle(float value) => u32Writer((uint)value);
+
+		public double ReadDouble() => u64Reader();
+		public void WriteDouble(double value) => u64Writer((ulong)value);
+
+		public ushort ReadUInt16() => u16Reader();
+		public void WriteUInt16(UInt16 value) => u16Writer(value);
+
+		public uint ReadUInt32() => u32Reader();
+		public void WriteUInt32(UInt32 value) => u32Writer(value);
+
+		public ulong ReadUInt64() => u64Reader();
+		public void WriteUInt64(UInt64 value) => u64Writer(value);
+	}
+}

--- a/src/OpenSage.FileFormats.Big/BigArchive.cs
+++ b/src/OpenSage.FileFormats.Big/BigArchive.cs
@@ -61,7 +61,7 @@ namespace OpenSage.FileFormats.Big
             var fileAccess = mode == BigArchiveMode.Read ? FileAccess.Read : FileAccess.ReadWrite;
             var fileShare = mode == BigArchiveMode.Read ? FileShare.Read : FileShare.ReadWrite;
 
-            _stream = AddDisposable(MFile.Open(filePath));
+            _stream = AddDisposable(MFile.Open(filePath, fileMode, fileAccess, fileShare));
 
             // Read if the archive already exists
             if (mode != BigArchiveMode.Create)
@@ -267,21 +267,16 @@ namespace OpenSage.FileFormats.Big
                 int dataStart = headerSize + tableSize;
                 outArchive.SetLength(archiveSize);
 
-#if true
-                throw new NotImplementedException("MFile Write mode");
-#endif
-#if false
+                var spanStream = _stream.NewSpanStream();
                 using (var writer = new BinaryWriter(outArchive))
                 {
                     WriteHeader(writer, archiveSize, dataStart);
                     WriteFileTable(writer, dataStart);
                     WriteFileContent(writer);
-                    _stream.Position = 0;
-                    _stream.SetLength(archiveSize);
-                    outArchive.WriteTo(_stream);
-                    _stream.Flush();
+                    spanStream.Position = 0;
+                    outArchive.WriteTo(spanStream);
+                    spanStream.Flush();
                 }
-#endif
 
                 UpdateOffsets();
             }

--- a/src/OpenSage.FileFormats.Big/BigArchiveEntry.cs
+++ b/src/OpenSage.FileFormats.Big/BigArchiveEntry.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using OpenSage.Core;
 using OpenSage.FileFormats.RefPack;
 
 namespace OpenSage.FileFormats.Big
@@ -56,11 +55,14 @@ namespace OpenSage.FileFormats.Big
             Archive.DeleteEntry(this);
         }
 
+        private Memory<byte> GetMemorySpan()
+        {
+            return Archive.Stream.Memory.Slice((int) Offset, (int) Length);
+        }
+
         private Stream OpenInReadMode()
         {
-            var mem = this.Archive
-                .Stream.Memory.Slice((int) Offset, (int)Length);
-
+            var mem = GetMemorySpan();
             var bigStream = new BigArchiveEntryStream(this, mem);
 
             // Check for refpack compression header.
@@ -80,9 +82,8 @@ namespace OpenSage.FileFormats.Big
 
             CurrentlyOpenForWrite = true;
 
-            // $TODO
-            throw new NotImplementedException("MFile Write Mode");
-            var bigStream = new BigArchiveEntryStream(this, null);
+            var mem = GetMemorySpan();
+            var bigStream = new BigArchiveEntryStream(this, mem);
 
             // Check for refpack compression header.
             // C&C3 started using refpack compression for .big archive entries.
@@ -101,9 +102,8 @@ namespace OpenSage.FileFormats.Big
 
             CurrentlyOpenForWrite = true;
 
-            // $TODO
-            throw new NotImplementedException("MFile Write Mode");
-            var bigStream = new BigArchiveEntryStream(this, null);
+            var mem = GetMemorySpan();
+            var bigStream = new BigArchiveEntryStream(this, mem);
 
             // Check for refpack compression header.
             // C&C3 started using refpack compression for .big archive entries.

--- a/src/OpenSage.FileFormats.Big/BigArchiveEntry.cs
+++ b/src/OpenSage.FileFormats.Big/BigArchiveEntry.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using OpenSage.Core;
 using OpenSage.FileFormats.RefPack;
 
 namespace OpenSage.FileFormats.Big
@@ -21,7 +22,6 @@ namespace OpenSage.FileFormats.Big
         internal MemoryStream OutstandingWriteStream { get; set; }
         internal uint OutstandingOffset { get; set; }
         internal bool CurrentlyOpenForWrite { get; set; }
-
         internal BigArchiveEntry(BigArchive archive, string name, uint offset, uint size)
         {
             Archive = archive;
@@ -58,22 +58,19 @@ namespace OpenSage.FileFormats.Big
 
         private Stream OpenInReadMode()
         {
-            var bigStream = new BigArchiveEntryStream(this, Offset);
+            var mem = this.Archive
+                .Stream.Memory.Slice((int) Offset, (int)Length);
 
-            // Wrapping BigStream in a BufferedStream significantly improves performance.
-            var bufferedBigStream = new BufferedStream(bigStream);
+            var bigStream = new BigArchiveEntryStream(this, mem);
 
             // Check for refpack compression header.
             // C&C3 started using refpack compression for .big archive entries.
-            if (RefPackStream.IsProbablyRefPackCompressed(bufferedBigStream))
+            if (RefPackStream.IsProbablyRefPackCompressed(bigStream))
             {
-                var refPackStream = new RefPackStream(bufferedBigStream);
-
-                // Wrap RefPackStream in (another) BufferedStream, to improve performance.
-                return new BufferedStream(refPackStream);
+                return new RefPackStream(bigStream);
             }
 
-            return bufferedBigStream;
+            return bigStream;
         }
 
         private Stream OpenInWriteMode()
@@ -83,7 +80,9 @@ namespace OpenSage.FileFormats.Big
 
             CurrentlyOpenForWrite = true;
 
-            var bigStream = new BigArchiveEntryStream(this, Offset);
+            // $TODO
+            throw new NotImplementedException("MFile Write Mode");
+            var bigStream = new BigArchiveEntryStream(this, null);
 
             // Check for refpack compression header.
             // C&C3 started using refpack compression for .big archive entries.
@@ -102,7 +101,9 @@ namespace OpenSage.FileFormats.Big
 
             CurrentlyOpenForWrite = true;
 
-            var bigStream = new BigArchiveEntryStream(this, Offset);
+            // $TODO
+            throw new NotImplementedException("MFile Write Mode");
+            var bigStream = new BigArchiveEntryStream(this, null);
 
             // Check for refpack compression header.
             // C&C3 started using refpack compression for .big archive entries.

--- a/src/OpenSage.FileFormats.Big/BigArchiveEntryStream.cs
+++ b/src/OpenSage.FileFormats.Big/BigArchiveEntryStream.cs
@@ -8,7 +8,6 @@ namespace OpenSage.FileFormats.Big
     {
         private readonly BigArchiveEntry _entry;
         private readonly BigArchive _archive;
-        private readonly uint _baseOffset;
         private bool _write;
         private readonly Memory<byte> _mem;
         private readonly SpanStream _spanStream;
@@ -18,7 +17,6 @@ namespace OpenSage.FileFormats.Big
             _write = false;
             _entry = entry;
             _archive = entry.Archive;
-            _baseOffset = entry.Offset;
 
             _mem = mem;
             _spanStream = new SpanStream(_mem);

--- a/src/OpenSage.FileFormats.Big/OpenSage.FileFormats.Big.csproj
+++ b/src/OpenSage.FileFormats.Big/OpenSage.FileFormats.Big.csproj
@@ -4,6 +4,14 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\OpenSage.Core\OpenSage.Core.csproj" />
     <ProjectReference Include="..\OpenSage.FileFormats.RefPack\OpenSage.FileFormats.RefPack.csproj" />


### PR DESCRIPTION
Code is originating from [PDBSharp](https://github.com/smx-smx/PDBSharp/tree/master/PDBSharp) and has undergone some uncommitted/local improvements such as Write mode and Big Endian structure reading while being used in multiple side projects.

Being a separate component, it has been developed under its own code style and license (but i'm open to re-licensing or dual-licensing, as long as i can reuse the shared code).

While it could be refactored to better suit OpenSage, **a possible (and attractive) alternative that i'm considering is to create a Nuget library** that OpenSage (and other projects) can consume

The main feature offered here is the ability to create `Memory<byte>`, and therefore `Span<byte>`, from a `MemoryMappedFile`.
This effectively enables true random access files in C# without having to use intermediate copies or buffered streams.

A subclass of `Stream`, `SpanStream`, makes it possible to use this system as a drop-in replacement in some scenarios (mostly Read-only parsing, as growing of `SpanStream` is not supported).

This PR currently enables this scenario for BIG files

Feel free to leave comments, suggestions or feature requests 🙂 