### PR TITLE
Fix skudef extension file not found for RA3 and Uprising

### DIFF
--- a/src/OpenSage.Game/Data/SkudefReader.cs
+++ b/src/OpenSage.Game/Data/SkudefReader.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -51,7 +52,9 @@ namespace OpenSage.Data
 
         public static void Read(string rootDirectory, Action<string> addBigArchive)
         {
-            var skudefFiles = Directory.GetFiles(rootDirectory, "*.skudef");
+
+            var skudefFiles = Directory.GetFiles(rootDirectory).Where(filename => filename.EndsWith("skudef", StringComparison.OrdinalIgnoreCase)).ToList();
+
             var skudefFile = skudefFiles
                 .OrderBy(SkudefVersion.Parse)
                 .LastOrDefault(); // TODO: This is not the right logic. needs to take into account the language.

--- a/src/OpenSage.Game/Data/SkudefReader.cs
+++ b/src/OpenSage.Game/Data/SkudefReader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -54,7 +54,7 @@ namespace OpenSage.Data
         public static void Read(string rootDirectory, Action<string> addBigArchive)
         {
 
-            var skudefFiles = Directory.GetFiles(rootDirectory).Where(filename => filename.EndsWith("skudef", StringComparison.OrdinalIgnoreCase)).ToList();
+            var skudefFiles = Directory.GetFiles(rootDirectory, "*.skudef", new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive });
 
             var skudefFile = skudefFiles
                 .OrderBy(SkudefVersion.Parse)

--- a/src/OpenSage.Game/Data/SkudefReader.cs
+++ b/src/OpenSage.Game/Data/SkudefReader.cs
@@ -1,7 +1,8 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using OpenSage.IO;
 
 namespace OpenSage.Data
 {
@@ -86,7 +87,7 @@ namespace OpenSage.Data
                 var spaceIndex = line.IndexOf(' ');
                 var command = line.Substring(0, spaceIndex);
                 var parameter = line.Substring(spaceIndex + 1);
-                var fullPath = Path.Combine(skudefDirectory, parameter);
+                var fullPath = FileSystem.NormalizeFilePath(Path.Combine(skudefDirectory, parameter));
 
                 switch (command)
                 {

--- a/src/OpenSage.Game/Utilities/LanguageUtility.cs
+++ b/src/OpenSage.Game/Utilities/LanguageUtility.cs
@@ -39,6 +39,9 @@ namespace OpenSage.Utilities
                 case SageGame.Bfme2:
                 case SageGame.Bfme2Rotwk:
                     return DetectFromFileSystem(fileSystem, "lang", "", "Audio.big");
+                case SageGame.Ra3Uprising:
+                case SageGame.Ra3:
+                    return DetectFromFileSystem(fileSystem, "Data", "", "Audio.big");
             }
 
             return DefaultLanguage;


### PR DESCRIPTION
Fixes the problem of not finding the skudef file for RA3 and Uprising, by ignoring the letter case, Additionally normalizing the file paths constructed from the skudef file.

Also added to extract the default language for RA3 and Uprising. 