### PR TITLE
Support additive ColorTransform

### DIFF
--- a/src/OpenSage.Game/Data/Apt/FrameItems/PlaceObject.cs
+++ b/src/OpenSage.Game/Data/Apt/FrameItems/PlaceObject.cs
@@ -72,7 +72,8 @@ namespace OpenSage.Data.Apt.FrameItems
         public int Character { get; private set; }
         public Matrix2x2 RotScale { get; private set; }
         public Vector2 Translation { get; private set; }
-        public ColorRgba Color { get; private set; }
+        public ColorRgba MultiplicativeColor { get; private set; }
+        public ColorRgba AdditiveColor { get; private set; }
         public float Ratio { get; private set; }
         public string Name { get; private set; }
         public int ClipDepth { get; private set; }
@@ -103,11 +104,15 @@ namespace OpenSage.Data.Apt.FrameItems
             }
 
             if (placeobject.Flags.HasFlag(PlaceObjectFlags.HasColorTransform))
-                placeobject.Color = reader.ReadColorRgba();
+            {
+                placeobject.MultiplicativeColor = reader.ReadColorRgba();
+                placeobject.AdditiveColor = reader.ReadColorRgba();
+            }
             else
+            {
                 reader.ReadColorRgba();
-
-            var unknown = reader.ReadUInt32();
+                reader.ReadColorRgba();
+            }
 
             if (placeobject.Flags.HasFlag(PlaceObjectFlags.HasRatio))
                 placeobject.Ratio = reader.ReadSingle();
@@ -173,7 +178,8 @@ namespace OpenSage.Data.Apt.FrameItems
             var matrix = transform.GeometryRotation;
             matrix.Translation = transform.GeometryTranslation;
             SetTransform(matrix);
-            SetColorTransform(transform.ColorTransform.ToColorRgba());
+            SetColorTransform((transform.MultiplicativeColorTransform.ToColorRgba(),
+                               transform.AdditiveColorTransform.ToColorRgba()));
         }
 
         public void SetTransform(in Matrix3x2? matrix)
@@ -190,12 +196,13 @@ namespace OpenSage.Data.Apt.FrameItems
             }
         }
 
-        public void SetColorTransform(in ColorRgba? color)
+        public void SetColorTransform(in (ColorRgba multiply, ColorRgba add)? colorTransform)
         {
-            if (color is ColorRgba value)
+            if (colorTransform is (ColorRgba multiply, ColorRgba add))
             {
                 Flags |= PlaceObjectFlags.HasColorTransform;
-                Color = value;
+                MultiplicativeColor = multiply;
+                AdditiveColor = add;
             }
             else
             {

--- a/src/OpenSage.Game/Data/Apt/FrameItems/PlaceObject.cs
+++ b/src/OpenSage.Game/Data/Apt/FrameItems/PlaceObject.cs
@@ -72,7 +72,7 @@ namespace OpenSage.Data.Apt.FrameItems
         public int Character { get; private set; }
         public Matrix2x2 RotScale { get; private set; }
         public Vector2 Translation { get; private set; }
-        public ColorRgba MultiplicativeColor { get; private set; }
+        public ColorRgba TintColor { get; private set; }
         public ColorRgba AdditiveColor { get; private set; }
         public float Ratio { get; private set; }
         public string Name { get; private set; }
@@ -105,7 +105,7 @@ namespace OpenSage.Data.Apt.FrameItems
 
             if (placeobject.Flags.HasFlag(PlaceObjectFlags.HasColorTransform))
             {
-                placeobject.MultiplicativeColor = reader.ReadColorRgba();
+                placeobject.TintColor = reader.ReadColorRgba();
                 placeobject.AdditiveColor = reader.ReadColorRgba();
             }
             else
@@ -178,7 +178,7 @@ namespace OpenSage.Data.Apt.FrameItems
             var matrix = transform.GeometryRotation;
             matrix.Translation = transform.GeometryTranslation;
             SetTransform(matrix);
-            SetColorTransform((transform.MultiplicativeColorTransform.ToColorRgba(),
+            SetColorTransform((transform.TintColorTransform.ToColorRgba(),
                                transform.AdditiveColorTransform.ToColorRgba()));
         }
 
@@ -196,12 +196,12 @@ namespace OpenSage.Data.Apt.FrameItems
             }
         }
 
-        public void SetColorTransform(in (ColorRgba multiply, ColorRgba add)? colorTransform)
+        public void SetColorTransform(in (ColorRgba tint, ColorRgba add)? colorTransform)
         {
-            if (colorTransform is (ColorRgba multiply, ColorRgba add))
+            if (colorTransform is (ColorRgba tint, ColorRgba add))
             {
                 Flags |= PlaceObjectFlags.HasColorTransform;
-                MultiplicativeColor = multiply;
+                TintColor = tint;
                 AdditiveColor = add;
             }
             else

--- a/src/OpenSage.Game/Diagnostics/AptGeometryView.cs
+++ b/src/OpenSage.Game/Diagnostics/AptGeometryView.cs
@@ -135,6 +135,7 @@ namespace OpenSage.Diagnostics
 
                 var itemTransform = new ItemTransform(
                     ColorRgbaF.White,
+                    ColorRgbaF.Black,
                     Matrix3x2.CreateScale(_scale, _scale),
                     translation);
 

--- a/src/OpenSage.Game/Diagnostics/AptGeometryView.cs
+++ b/src/OpenSage.Game/Diagnostics/AptGeometryView.cs
@@ -135,7 +135,7 @@ namespace OpenSage.Diagnostics
 
                 var itemTransform = new ItemTransform(
                     ColorRgbaF.White,
-                    ColorRgbaF.Black,
+                    ColorRgbaF.Transparent,
                     Matrix3x2.CreateScale(_scale, _scale),
                     translation);
 

--- a/src/OpenSage.Game/Gui/Apt/ActionScript/Library/Builtin.cs
+++ b/src/OpenSage.Game/Gui/Apt/ActionScript/Library/Builtin.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using OpenSage.Mathematics;
 
 namespace OpenSage.Gui.Apt.ActionScript.Library
 {
@@ -45,8 +46,8 @@ namespace OpenSage.Gui.Apt.ActionScript.Library
                 ["_alpha"] = (ctx, v) =>
                 {
                     var transform = ctx.Item.Transform;
-                    ctx.Item.Transform =
-                        transform.WithColorTransform(transform.ColorTransform.WithA(v.ToInteger() / 100.0f));
+                    var color = transform.MultiplicativeColorTransform.WithA(v.ToInteger() / 100.0f);
+                    ctx.Item.Transform = transform.WithColorTransform(color, add: ColorRgbaF.Black);
                 },
                 ["textColor"] = (ctx, v) =>
                 {
@@ -58,8 +59,8 @@ namespace OpenSage.Gui.Apt.ActionScript.Library
                     var r = ((hexColor & 0xFF0000) >> 16) / 255.0f;
 
                     var transform = ctx.Item.Transform;
-                    ctx.Item.Transform =
-                        transform.WithColorTransform(transform.ColorTransform.WithRGB(r, g, b));
+                    var color = transform.MultiplicativeColorTransform.WithRGB(r, g, b);
+                    ctx.Item.Transform = transform.WithColorTransform(color, add: ColorRgbaF.Black);
                 }
             };
 

--- a/src/OpenSage.Game/Gui/Apt/ActionScript/Library/Builtin.cs
+++ b/src/OpenSage.Game/Gui/Apt/ActionScript/Library/Builtin.cs
@@ -47,7 +47,7 @@ namespace OpenSage.Gui.Apt.ActionScript.Library
                 {
                     var transform = ctx.Item.Transform;
                     var color = transform.MultiplicativeColorTransform.WithA(v.ToInteger() / 100.0f);
-                    ctx.Item.Transform = transform.WithColorTransform(color, add: ColorRgbaF.Black);
+                    ctx.Item.Transform = transform.WithColorTransform(color, add: ColorRgbaF.Transparent);
                 },
                 ["textColor"] = (ctx, v) =>
                 {
@@ -60,7 +60,7 @@ namespace OpenSage.Gui.Apt.ActionScript.Library
 
                     var transform = ctx.Item.Transform;
                     var color = transform.MultiplicativeColorTransform.WithRGB(r, g, b);
-                    ctx.Item.Transform = transform.WithColorTransform(color, add: ColorRgbaF.Black);
+                    ctx.Item.Transform = transform.WithColorTransform(color, add: ColorRgbaF.Transparent);
                 }
             };
 

--- a/src/OpenSage.Game/Gui/Apt/ActionScript/Library/Builtin.cs
+++ b/src/OpenSage.Game/Gui/Apt/ActionScript/Library/Builtin.cs
@@ -46,7 +46,7 @@ namespace OpenSage.Gui.Apt.ActionScript.Library
                 ["_alpha"] = (ctx, v) =>
                 {
                     var transform = ctx.Item.Transform;
-                    var color = transform.MultiplicativeColorTransform.WithA(v.ToInteger() / 100.0f);
+                    var color = transform.TintColorTransform.WithA(v.ToInteger() / 100.0f);
                     ctx.Item.Transform = transform.WithColorTransform(color, add: ColorRgbaF.Transparent);
                 },
                 ["textColor"] = (ctx, v) =>
@@ -59,7 +59,7 @@ namespace OpenSage.Gui.Apt.ActionScript.Library
                     var r = ((hexColor & 0xFF0000) >> 16) / 255.0f;
 
                     var transform = ctx.Item.Transform;
-                    var color = transform.MultiplicativeColorTransform.WithRGB(r, g, b);
+                    var color = transform.TintColorTransform.WithRGB(r, g, b);
                     ctx.Item.Transform = transform.WithColorTransform(color, add: ColorRgbaF.Transparent);
                 }
             };

--- a/src/OpenSage.Game/Gui/Apt/AptRenderingContext.cs
+++ b/src/OpenSage.Game/Gui/Apt/AptRenderingContext.cs
@@ -138,7 +138,7 @@ namespace OpenSage.Gui.Apt
                 actualText,
                 font,
                 TextAlignment.Center,
-                character.Color.ToColorRgbaF() * transform.ColorTransform,
+                transform.TransformColor(character.Color.ToColorRgbaF()),
                 RectangleF.Transform(character.Bounds, transform.GeometryRotation));
         }
 
@@ -194,7 +194,7 @@ namespace OpenSage.Gui.Apt
                 {
                     case GeometryLines l:
                         {
-                            var color = l.Color.ToColorRgbaF() * transform.ColorTransform;
+                            var color = transform.TransformColor(l.Color.ToColorRgbaF());
                             foreach (var line in l.Lines)
                             {
                                 _activeDrawingContext.DrawLine(
@@ -207,7 +207,7 @@ namespace OpenSage.Gui.Apt
 
                     case GeometrySolidTriangles st:
                         {
-                            var color = st.Color.ToColorRgbaF() * transform.ColorTransform;
+                            var color = transform.TransformColor(st.Color.ToColorRgbaF());
                             foreach (var tri in st.Triangles)
                             {
                                 if (solidTexture == null)
@@ -254,12 +254,21 @@ namespace OpenSage.Gui.Apt
                                 //    throw new NotImplementedException();
 
                                 var tex = _aptContext.GetTexture(tt.Image, shape);
-
+                                // Currently DrawingContext2D.FillRectangle
+                                // (and the underlying SpriteBatch.DrawImage)
+                                // only accepts an multiplicative tint color.
+                                // Probably we need to change all of them to
+                                // support additive color as well.
+                                var tintColor = transform.AdditiveColorTransform == ColorRgbaF.Black
+                                    ? transform.MultiplicativeColorTransform
+                                    : throw new NotImplementedException(
+                                        $"{nameof(DrawingContext2D)} and {nameof(SpriteBatch)}"
+                                        + " needs to be reworked to accept an additive color");
                                 _activeDrawingContext.FillTriangle(
                                     tex,
                                     Triangle2D.Transform(tri, coordinatesTransform),
                                     Triangle2D.Transform(tri, matrix),
-                                    transform.ColorTransform);
+                                    transform.MultiplicativeColorTransform);
                             }
                             break;
                         }

--- a/src/OpenSage.Game/Gui/Apt/AptRenderingContext.cs
+++ b/src/OpenSage.Game/Gui/Apt/AptRenderingContext.cs
@@ -254,21 +254,12 @@ namespace OpenSage.Gui.Apt
                                 //    throw new NotImplementedException();
 
                                 var tex = _aptContext.GetTexture(tt.Image, shape);
-                                // Currently DrawingContext2D.FillRectangle
-                                // (and the underlying SpriteBatch.DrawImage)
-                                // only accepts an multiplicative tint color.
-                                // Probably we need to change all of them to
-                                // support additive color as well.
-                                var tintColor = transform.AdditiveColorTransform == ColorRgbaF.Black
-                                    ? transform.MultiplicativeColorTransform
-                                    : throw new NotImplementedException(
-                                        $"{nameof(DrawingContext2D)} and {nameof(SpriteBatch)}"
-                                        + " needs to be reworked to accept an additive color");
+                                var tintColor = transform.TransformColor(ColorRgbaF.White);
                                 _activeDrawingContext.FillTriangle(
                                     tex,
                                     Triangle2D.Transform(tri, coordinatesTransform),
                                     Triangle2D.Transform(tri, matrix),
-                                    transform.MultiplicativeColorTransform);
+                                    tintColor);
                             }
                             break;
                         }

--- a/src/OpenSage.Game/Gui/Apt/DisplayItem.cs
+++ b/src/OpenSage.Game/Gui/Apt/DisplayItem.cs
@@ -12,14 +12,14 @@ namespace OpenSage.Gui.Apt
     {
         public static readonly ItemTransform None = new(ColorRgbaF.White, ColorRgbaF.Transparent, Matrix3x2.Identity, Vector2.Zero);
 
-        public ColorRgbaF MultiplicativeColorTransform;
+        public ColorRgbaF TintColorTransform;
         public ColorRgbaF AdditiveColorTransform;
         public Matrix3x2 GeometryRotation;
         public Vector2 GeometryTranslation;
 
-        public ItemTransform(in ColorRgbaF multiply, in ColorRgbaF add, in Matrix3x2 rotation, in Vector2 translation)
+        public ItemTransform(in ColorRgbaF tint, in ColorRgbaF add, in Matrix3x2 rotation, in Vector2 translation)
         {
-            MultiplicativeColorTransform = multiply;
+            TintColorTransform = tint;
             AdditiveColorTransform = add;
             GeometryRotation = rotation;
             GeometryTranslation = translation;
@@ -33,13 +33,13 @@ namespace OpenSage.Gui.Apt
              *  g(f(x)) = (x * a + b) * i + j
              *      = x * (a * i) + (b * i + j)
              */
-            var multiply = a.MultiplicativeColorTransform * b.MultiplicativeColorTransform;
-            var add = a.AdditiveColorTransform * b.MultiplicativeColorTransform;
+            var tint = a.TintColorTransform * b.TintColorTransform;
+            var add = a.AdditiveColorTransform * b.TintColorTransform;
             add += b.AdditiveColorTransform;
             // FIXME: Adobe's specification claims that colors are clamped between 0 and 255
             // during every single step of transformation.
             // Probably We can't achieve that by using our current ItemTransform.
-            return new(multiply,
+            return new(tint,
                        add,
                        a.GeometryRotation * b.GeometryRotation,
                        a.GeometryTranslation + b.GeometryTranslation);
@@ -50,9 +50,9 @@ namespace OpenSage.Gui.Apt
             GeometryRotation = Matrix3x2.Multiply(Matrix3x2.CreateScale(x, y), GeometryRotation);
         }
 
-        public ItemTransform WithColorTransform(in ColorRgbaF multiply, in ColorRgbaF add)
+        public ItemTransform WithColorTransform(in ColorRgbaF tint, in ColorRgbaF add)
         {
-            return new(multiply,
+            return new(tint,
                        add,
                        GeometryRotation,
                        GeometryTranslation);
@@ -60,7 +60,7 @@ namespace OpenSage.Gui.Apt
 
         public ColorRgbaF TransformColor(in ColorRgbaF sourceColor)
         {
-            return sourceColor * MultiplicativeColorTransform + AdditiveColorTransform;
+            return sourceColor * TintColorTransform + AdditiveColorTransform;
         }
 
         public object Clone()

--- a/src/OpenSage.Game/Gui/Apt/DisplayItem.cs
+++ b/src/OpenSage.Game/Gui/Apt/DisplayItem.cs
@@ -36,6 +36,9 @@ namespace OpenSage.Gui.Apt
             var multiply = a.MultiplicativeColorTransform * b.MultiplicativeColorTransform;
             var add = a.AdditiveColorTransform * b.MultiplicativeColorTransform;
             add += b.AdditiveColorTransform;
+            // FIXME: Adobe's specification claims that colors are clamped between 0 and 255
+            // during every single step of transformation.
+            // Probably We can't achieve that by using our current ItemTransform.
             return new(multiply,
                        add,
                        a.GeometryRotation * b.GeometryRotation,

--- a/src/OpenSage.Game/Gui/Apt/DisplayItem.cs
+++ b/src/OpenSage.Game/Gui/Apt/DisplayItem.cs
@@ -10,7 +10,7 @@ namespace OpenSage.Gui.Apt
 {
     public struct ItemTransform : ICloneable
     {
-        public static readonly ItemTransform None = new(ColorRgbaF.White, ColorRgbaF.Black, Matrix3x2.Identity, Vector2.Zero);
+        public static readonly ItemTransform None = new(ColorRgbaF.White, ColorRgbaF.Transparent, Matrix3x2.Identity, Vector2.Zero);
 
         public ColorRgbaF MultiplicativeColorTransform;
         public ColorRgbaF AdditiveColorTransform;
@@ -27,11 +27,11 @@ namespace OpenSage.Gui.Apt
 
         public static ItemTransform operator *(in ItemTransform a, in ItemTransform b)
         {
-            /* Combining ColorTransform:
-             * f(x) = x * a + b
-             * g(x) = x * i + j
-             * g(f(x)) = (x * a + b) * i + j
-             *  = x * (a * i) + (b * i + j)
+            /*  Combining ColorTransform:
+             *  f(x) = x * a + b
+             *  g(x) = x * i + j
+             *  g(f(x)) = (x * a + b) * i + j
+             *      = x * (a * i) + (b * i + j)
              */
             var multiply = a.MultiplicativeColorTransform * b.MultiplicativeColorTransform;
             var add = a.AdditiveColorTransform * b.MultiplicativeColorTransform;

--- a/src/OpenSage.Game/Gui/Apt/SpriteItem.cs
+++ b/src/OpenSage.Game/Gui/Apt/SpriteItem.cs
@@ -273,17 +273,20 @@ namespace OpenSage.Gui.Apt
                 geoTranslate = Vector2.Zero;
             }
 
-            ColorRgbaF colorTransform;
+            ColorRgbaF multiplyColor;
+            ColorRgbaF addColor;
             if (po.Flags.HasFlag(PlaceObjectFlags.HasColorTransform))
             {
-                colorTransform = po.Color.ToColorRgbaF();
+                multiplyColor = po.MultiplicativeColor.ToColorRgbaF();
+                addColor = po.AdditiveColor.ToColorRgbaF();
             }
             else
             {
-                colorTransform = ColorRgbaF.White;
+                multiplyColor = ColorRgbaF.White;
+                addColor = ColorRgbaF.Black;
             }
 
-            return new ItemTransform(colorTransform, geoRotate, geoTranslate);
+            return new ItemTransform(multiplyColor, addColor, geoRotate, geoTranslate);
         }
 
         private void MoveItem(PlaceObject po)
@@ -307,7 +310,8 @@ namespace OpenSage.Gui.Apt
 
             if (po.Flags.HasFlag(PlaceObjectFlags.HasColorTransform))
             {
-                cTransform.ColorTransform = po.Color.ToColorRgbaF();
+                cTransform.MultiplicativeColorTransform = po.MultiplicativeColor.ToColorRgbaF();
+                cTransform.AdditiveColorTransform = po.AdditiveColor.ToColorRgbaF();
             }
 
             if (po.Flags.HasFlag(PlaceObjectFlags.HasName))

--- a/src/OpenSage.Game/Gui/Apt/SpriteItem.cs
+++ b/src/OpenSage.Game/Gui/Apt/SpriteItem.cs
@@ -283,7 +283,7 @@ namespace OpenSage.Gui.Apt
             else
             {
                 multiplyColor = ColorRgbaF.White;
-                addColor = ColorRgbaF.Black;
+                addColor = ColorRgbaF.Transparent;
             }
 
             return new ItemTransform(multiplyColor, addColor, geoRotate, geoTranslate);

--- a/src/OpenSage.Game/Gui/Apt/SpriteItem.cs
+++ b/src/OpenSage.Game/Gui/Apt/SpriteItem.cs
@@ -273,20 +273,20 @@ namespace OpenSage.Gui.Apt
                 geoTranslate = Vector2.Zero;
             }
 
-            ColorRgbaF multiplyColor;
-            ColorRgbaF addColor;
+            ColorRgbaF tintColor;
+            ColorRgbaF additiveColor;
             if (po.Flags.HasFlag(PlaceObjectFlags.HasColorTransform))
             {
-                multiplyColor = po.MultiplicativeColor.ToColorRgbaF();
-                addColor = po.AdditiveColor.ToColorRgbaF();
+                tintColor = po.TintColor.ToColorRgbaF();
+                additiveColor = po.AdditiveColor.ToColorRgbaF();
             }
             else
             {
-                multiplyColor = ColorRgbaF.White;
-                addColor = ColorRgbaF.Transparent;
+                tintColor = ColorRgbaF.White;
+                additiveColor = ColorRgbaF.Transparent;
             }
 
-            return new ItemTransform(multiplyColor, addColor, geoRotate, geoTranslate);
+            return new ItemTransform(tintColor, additiveColor, geoRotate, geoTranslate);
         }
 
         private void MoveItem(PlaceObject po)
@@ -310,7 +310,7 @@ namespace OpenSage.Gui.Apt
 
             if (po.Flags.HasFlag(PlaceObjectFlags.HasColorTransform))
             {
-                cTransform.MultiplicativeColorTransform = po.MultiplicativeColor.ToColorRgbaF();
+                cTransform.TintColorTransform = po.TintColor.ToColorRgbaF();
                 cTransform.AdditiveColorTransform = po.AdditiveColor.ToColorRgbaF();
             }
 

--- a/src/OpenSage.Mathematics/ColorRgbaF.cs
+++ b/src/OpenSage.Mathematics/ColorRgbaF.cs
@@ -34,6 +34,15 @@ namespace OpenSage.Mathematics
                 value1.A * value2.A);
         }
 
+        public static ColorRgbaF operator +(in ColorRgbaF value1, in ColorRgbaF value2)
+        {
+            return new ColorRgbaF(
+                value1.R + value2.R,
+                value1.G + value2.G,
+                value1.B + value2.B,
+                value1.A + value2.A);
+        }
+
         public static bool operator ==(in ColorRgbaF f1, in ColorRgbaF f2)
         {
             return f1.Equals(f2);


### PR DESCRIPTION
https://github.com/OpenSAGE/OpenSAGE/discussions/648

Known issues:
Adobe / [Macromedia's specification](https://www.ics.agh.edu.pl/dydaktyka/mm/lato0405_inf_d/wyklady/w4/SWF7_specification.pdf) says that during every transformation, colors needs to be clamped between 0 and 255.
But we are currently "abusing" the associativity of `ItemTransform` to calculate a pre-computed color transform.
This approach do work, if we ignore about clamping, the pre-computed color transform is equivalent to applying multiple color transforms separately because of the associativity rule.

But if we consider the clamping, then... we might need to rewrite the entire `ItemTransform`...