### PR TITLE
Delay building construction until dozer arrives on site

### DIFF
--- a/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
+++ b/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
@@ -117,6 +117,11 @@ namespace OpenSage.Logic.Object
             return new LogicFrameSpan(left.Value + right.Value);
         }
 
+        public static LogicFrameSpan operator ++(LogicFrameSpan left)
+        {
+            return new LogicFrameSpan(left.Value + 1);
+        }
+
         public static LogicFrameSpan operator *(LogicFrameSpan left, Percentage right)
         {
             return new LogicFrameSpan((uint)MathF.Ceiling(left.Value * (float)right));
@@ -130,6 +135,11 @@ namespace OpenSage.Logic.Object
         public static LogicFrameSpan operator /(LogicFrameSpan left, float right)
         {
             return new LogicFrameSpan((uint)MathF.Ceiling(left.Value / right));
+        }
+
+        public static float operator /(LogicFrameSpan left, LogicFrameSpan right)
+        {
+            return left.Value / (float)right.Value;
         }
 
         public static LogicFrameSpan operator /(LogicFrameSpan left, Percentage right)

--- a/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
@@ -71,7 +71,8 @@ namespace OpenSage.Logic.Object
 
                     if (!instant)
                     {
-                        baseObject.StartConstruction();
+                        baseObject.PrepareConstruction();
+                        baseObject.Construct();
                         baseObject.BuildProgress = 0.0f;
                     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.Collections.Generic;
 using System.Numerics;
 using OpenSage.Data.Ini;
@@ -183,6 +182,10 @@ namespace OpenSage.Logic.Object
             MoveToNextWaypointOrStop();
         }
 
+        protected virtual void ArrivedAtDestination()
+        {
+        }
+
         internal void Stop()
         {
             GameObject.ModelConditionFlags.Set(ModelConditionFlag.Moving, false);
@@ -212,6 +215,7 @@ namespace OpenSage.Logic.Object
             }
             else
             {
+                ArrivedAtDestination();
                 Stop();
             }
         }
@@ -439,7 +443,7 @@ namespace OpenSage.Logic.Object
         };
 
         /// <summary>
-        /// Allows the use of TurretMoveStart and TurretMoveLoop within the UnitSpecificSounds 
+        /// Allows the use of TurretMoveStart and TurretMoveLoop within the UnitSpecificSounds
         /// section of the object.
         /// </summary>
         public TurretAIUpdateModuleData Turret { get; private set; }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/IBuilderAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/IBuilderAIUpdate.cs
@@ -1,0 +1,14 @@
+﻿namespace OpenSage.Logic.Object
+{
+    /// <summary>
+    /// Should be implemented by any class which inherits <see cref="AIUpdate"/> and is used by a <see cref="ObjectKinds.Dozer"/> unit.
+    /// </summary>
+    /// <remarks>
+    /// This interface is implemented by <see cref="DozerAIUpdate"/> and <see cref="WorkerAIUpdate"/>, since the GLA
+    /// worker is also a supply unit.
+    /// </remarks>
+    internal interface IBuilderAIUpdate
+    {
+        void SetBuildTarget(GameObject gameObject);
+    }
+}

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Numerics;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.Logic.AI;
@@ -8,9 +6,10 @@ using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
-    public class WorkerAIUpdate : SupplyAIUpdate
+    public class WorkerAIUpdate : SupplyAIUpdate, IBuilderAIUpdate
     {
-        private readonly WorkerAIUpdateModuleData _moduleData;
+        private WorkerAIUpdateModuleData _moduleData;
+        private GameObject _buildTarget;
 
         private readonly DozerAndWorkerState _state = new();
 
@@ -23,6 +22,44 @@ namespace OpenSage.Logic.Object
         {
             _moduleData = moduleData;
         }
+
+        #region Dozer stuff
+
+        public void SetBuildTarget(GameObject gameObject)
+        {
+            // note that the order here is important, as SetTargetPoint will clear any existing buildTarget
+            // TODO: target should not be directly on the building, but rather a point along the foundation perimeter
+            SetTargetPoint(gameObject.Translation);
+            CurrentSupplyTarget = null;
+            SupplyGatherState = SupplyGatherStates.Default;
+            _buildTarget = gameObject;
+        }
+
+        internal override void SetTargetPoint(Vector3 targetPoint)
+        {
+            base.SetTargetPoint(targetPoint);
+            GameObject.ModelConditionFlags.Set(ModelConditionFlag.ActivelyConstructing, false);
+            _buildTarget?.PauseConstruction();
+            ClearBuildTarget();
+        }
+
+        protected override void ArrivedAtDestination()
+        {
+            base.ArrivedAtDestination();
+
+            if (_buildTarget is not null)
+            {
+                _buildTarget.Construct();
+                GameObject.ModelConditionFlags.Set(ModelConditionFlag.ActivelyConstructing, true);
+            }
+        }
+
+        private void ClearBuildTarget()
+        {
+            _buildTarget = null;
+        }
+
+        #endregion
 
         internal override void ClearConditionFlags()
         {
@@ -129,18 +166,26 @@ namespace OpenSage.Logic.Object
         {
             base.Update(context);
 
-            var isMoving = GameObject.ModelConditionFlags.Get(ModelConditionFlag.Moving);
-
-            switch (SupplyGatherState)
+            if (_buildTarget != null && _buildTarget.BuildProgress >= 1)
             {
-                case SupplyGatherStates.Default:
-                    if (!isMoving)
-                    {
-                        SupplyGatherState = SupplyGatherStateToResume;
+                ClearBuildTarget();
+                GameObject.ModelConditionFlags.Set(ModelConditionFlag.ActivelyConstructing, false);
+            }
+            else
+            {
+                var isMoving = GameObject.ModelConditionFlags.Get(ModelConditionFlag.Moving);
+
+                switch (SupplyGatherState)
+                {
+                    case SupplyGatherStates.Default:
+                        if (!isMoving)
+                        {
+                            SupplyGatherState = SupplyGatherStateToResume;
+                            break;
+                        }
+                        _waitUntil = context.LogicFrame + _moduleData.BoredTime;
                         break;
-                    }
-                    _waitUntil = context.LogicFrame + _moduleData.BoredTime;
-                    break;
+                }
             }
         }
 
@@ -273,7 +318,7 @@ namespace OpenSage.Logic.Object
         {
             public override void Persist(StatePersister reader)
             {
-                
+
             }
         }
 
@@ -281,7 +326,7 @@ namespace OpenSage.Logic.Object
         {
             public override void Persist(StatePersister reader)
             {
-                
+
             }
         }
 
@@ -295,7 +340,7 @@ namespace OpenSage.Logic.Object
     }
 
     /// <summary>
-    /// Allows the use of VoiceRepair, VoiceBuildResponse, VoiceSupply, VoiceNoBuild, and 
+    /// Allows the use of VoiceRepair, VoiceBuildResponse, VoiceSupply, VoiceNoBuild, and
     /// VoiceTaskComplete within UnitSpecificSounds section of the object.
     /// Requires Kindof = DOZER.
     /// </summary>

--- a/src/OpenSage.Game/Logic/OrderGenerators/ConstructBuildingOrderGenerator.cs
+++ b/src/OpenSage.Game/Logic/OrderGenerators/ConstructBuildingOrderGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Numerics;
 using OpenSage.Graphics.Cameras;
@@ -120,7 +120,10 @@ namespace OpenSage.Logic.OrderGenerators
                 _previewObject.Geometry.BoundingSphereRadius,
                 new PartitionQueries.CollidesWithObjectQuery(_previewObject));
 
-            return !existingObjects.Any();
+            // as long as the items in our way are not structures and not owned by our enemy, we can build here
+            return !_scene.Quadtree.FindIntersecting(_previewObject).Any(u =>
+                u.Definition.KindOf.Get(ObjectKinds.Structure) ||
+                _scene.LocalPlayer.Enemies.Contains(u.Owner));
         }
 
         public void UpdatePosition(Vector2 mousePosition, Vector3 worldPosition)

--- a/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
@@ -86,7 +86,11 @@ namespace OpenSage.Logic.Orders
                             var gameObject = _game.Scene3D.GameObjects.Add(objectDefinition, player);
                             gameObject.Owner = player;
                             gameObject.UpdateTransform(position, Quaternion.CreateFromAxisAngle(Vector3.UnitZ, angle));
-                            gameObject.StartConstruction();
+
+                            gameObject.PrepareConstruction();
+
+                            var dozer = player.SelectedUnits.SingleOrDefault(u => u.Definition.KindOf.Get(ObjectKinds.Dozer));
+                            (dozer?.AIUpdate as IBuilderAIUpdate)?.SetBuildTarget(gameObject); // todo: I don't love this cast; it would be nice to get rid of it
                         }
                         break;
                     case OrderType.CancelBuild:


### PR DESCRIPTION
This isn't perfect, but should be a start at the dozer logic.

This PR changes building construction so that:
- construction doesn't begin until the dozer is at the building 
  - _**future task** - define a new destination for the dozer that is at the edge of the building instead of directly inside it_
- construction pauses when the dozer is ordered away
  - _**future task** - add commands to allow dozer to be ordered back to resume construction_
- construction no longer relies on the logic frame on which construction was started, and instead tracks the logic frame span over which construction has occurred

The logic between the AI handler for Dozers and Workers is duplicated, so it might be nice to extract that out into a separate module in the future. It also results in a cast in `OrderProcessor` which, though it may be safe, isn't a pattern I typically like to follow.

![](https://thumbs.gfycat.com/BlandUnlawfulBluetonguelizard-size_restricted.gif)