### PR TITLE
Text cache expiration & debug view

### DIFF
--- a/src/OpenSage.Game/Diagnostics/AssetViews/TextureAssetView.cs
+++ b/src/OpenSage.Game/Diagnostics/AssetViews/TextureAssetView.cs
@@ -1,0 +1,23 @@
+using OpenSage.Graphics;
+
+namespace OpenSage.Diagnostics.AssetViews
+{
+    // This is just a simple wrapper around TextureView, so that we can inspect both TextureAssets and in-memory Textures.
+    // TextureAsset has an implicit cast to Texture, but since AssetViews are discovered via reflection, we need to have
+    // a separate class for this.
+    [AssetView(typeof(TextureAsset))]
+    internal sealed class TextureAssetView : AssetView
+    {
+        private readonly TextureView _textureView;
+
+        public TextureAssetView(DiagnosticViewContext context, TextureAsset textureAsset) : base(context)
+        {
+            _textureView = new TextureView(context, textureAsset);
+        }
+
+        public override void Draw()
+        {
+            _textureView.Draw();
+        }
+    }
+}

--- a/src/OpenSage.Game/Diagnostics/AssetViews/TextureView.cs
+++ b/src/OpenSage.Game/Diagnostics/AssetViews/TextureView.cs
@@ -1,39 +1,68 @@
 ﻿using System.Collections.Generic;
 using System.Numerics;
 using ImGuiNET;
-using OpenSage.Graphics;
 using OpenSage.Mathematics;
 using Veldrid;
 
 namespace OpenSage.Diagnostics.AssetViews
 {
-    [AssetView(typeof(TextureAsset))]
+    [AssetView(typeof(Texture))]
     internal sealed class TextureView : AssetView
     {
         private readonly Texture _texture;
         private readonly Dictionary<TextureViewDescription, Veldrid.TextureView> _textureViews;
 
         private uint _mipLevel;
+        private BackgroundColor _backgroundColor;
+        private bool _scaleToFit = true;
 
-        public TextureView(DiagnosticViewContext context, TextureAsset textureAsset)
+        public TextureView(DiagnosticViewContext context, Texture texture)
             : base(context)
         {
-            _texture = textureAsset;
+            _texture = texture;
             _textureViews = new Dictionary<TextureViewDescription, Veldrid.TextureView>();
         }
 
         public override void Draw()
         {
-            ImGui.BeginChild("mip level", new Vector2(150, 0), true, 0);
-
-            for (var i = 0u; i < _texture.MipLevels; i++)
+            ImGui.BeginChild("sidebar", new Vector2(150, 0), false);
             {
-                if (ImGui.Selectable($"MipMap {i}", i == _mipLevel))
+                ImGui.BeginChild("mip level", new Vector2(150, 200), true, 0);
                 {
-                    _mipLevel = i;
+                    for (var i = 0u; i < _texture.MipLevels; i++)
+                    {
+                        if (ImGui.Selectable($"MipMap {i}", i == _mipLevel))
+                        {
+                            _mipLevel = i;
+                        }
+                    }
                 }
-            }
+                ImGui.EndChild();
 
+                ImGui.BeginChild("texture viewer settings", new Vector2(150, 0), true, 0);
+                {
+                    ImGui.Text("Background color");
+                    {
+                        if (ImGui.RadioButton("None", _backgroundColor == BackgroundColor.None))
+                        {
+                            _backgroundColor = BackgroundColor.None;
+                        }
+
+                        if (ImGui.RadioButton("Black", _backgroundColor == BackgroundColor.Black))
+                        {
+                            _backgroundColor = BackgroundColor.Black;
+                        }
+
+                        if (ImGui.RadioButton("White", _backgroundColor == BackgroundColor.White))
+                        {
+                            _backgroundColor = BackgroundColor.White;
+                        }
+                    }
+
+                    ImGui.Checkbox("Scale to fit", ref _scaleToFit);
+                }
+                ImGui.EndChild();
+            }
             ImGui.EndChild();
 
             ImGui.SameLine();
@@ -51,17 +80,42 @@ namespace OpenSage.Diagnostics.AssetViews
 
             var availableSize = ImGui.GetContentRegionAvail();
 
-            var size = SizeF.CalculateSizeFittingAspectRatio(
-                new SizeF(_texture.Width, _texture.Height),
-                new Size((int) availableSize.X, (int) availableSize.Y));
+            var size = _scaleToFit
+                ? SizeF.CalculateSizeFittingAspectRatio(
+                    new SizeF(_texture.Width, _texture.Height),
+                    new Size((int) availableSize.X, (int) availableSize.Y)
+                )
+                : new Size((int)_texture.Width, (int)_texture.Height);
 
-            ImGui.Image(
-                imagePointer,
-                new Vector2(size.Width, size.Height),
-                Vector2.Zero,
-                Vector2.One,
-                Vector4.One,
-                Vector4.Zero);
+            var uiSize = _scaleToFit ? size.ToVector2() : new Vector2(_texture.Width, _texture.Height);
+
+            ImGui.PushStyleColor(ImGuiCol.ChildBg, _backgroundColor switch {
+                BackgroundColor.None => Vector4.Zero,
+                BackgroundColor.Black => new Vector4(0, 0, 0, 1),
+                BackgroundColor.White => new Vector4(1, 1, 1, 1),
+                _ => throw new System.InvalidOperationException()
+            });
+
+            ImGui.BeginChild("texture", _scaleToFit ? Vector2.Zero : size.ToVector2(), false, 0);
+            {
+                ImGui.Image(
+                    imagePointer,
+                    new Vector2(size.Width, size.Height),
+                    Vector2.Zero,
+                    Vector2.One,
+                    Vector4.One,
+                    Vector4.Zero);
+            }
+            ImGui.EndChild();
+
+            ImGui.PopStyleColor();
+        }
+
+        private enum BackgroundColor
+        {
+            None,
+            Black,
+            White
         }
     }
 }

--- a/src/OpenSage.Game/Diagnostics/MainView.cs
+++ b/src/OpenSage.Game/Diagnostics/MainView.cs
@@ -68,6 +68,7 @@ namespace OpenSage.Diagnostics
             AddView(new PreviewView(context));
             AddView(new CameraView(context));
             AddView(new PartitionView(context));
+            AddView(new TextCacheView(context));
 
             if (File.Exists(IniFileName))
             {

--- a/src/OpenSage.Game/Diagnostics/PreviewView.cs
+++ b/src/OpenSage.Game/Diagnostics/PreviewView.cs
@@ -35,7 +35,7 @@ namespace OpenSage.Diagnostics
         public PreviewView(DiagnosticViewContext context)
             : base(context)
         {
-            
+
         }
 
         public override string DisplayName { get; } = "Preview";
@@ -46,7 +46,18 @@ namespace OpenSage.Diagnostics
             {
                 RemoveAndDispose(ref _currentAssetView);
 
-                if (AssetViewConstructors.TryGetValue(Context.SelectedObject.GetType(), out var assetViewConstructor))
+                var assetViewConstructor = AssetViewConstructors.GetValueOrDefault(Context.SelectedObject.GetType());
+
+                // If there's no AssetView for this type, search with the base type.
+                if (assetViewConstructor == null) {
+                    var baseType = Context.SelectedObject.GetType().BaseType;
+                    while (baseType != null && assetViewConstructor == null) {
+                        assetViewConstructor = AssetViewConstructors.GetValueOrDefault(baseType);
+                        baseType = baseType.BaseType;
+                    }
+                }
+
+                if (assetViewConstructor != null)
                 {
                     AssetView createAssetView() => (AssetView) assetViewConstructor.Invoke(new object[] { Context, Context.SelectedObject });
 

--- a/src/OpenSage.Game/Diagnostics/TextCacheView.cs
+++ b/src/OpenSage.Game/Diagnostics/TextCacheView.cs
@@ -1,0 +1,20 @@
+namespace OpenSage.Diagnostics {
+    internal sealed class TextCacheView : DiagnosticView
+    {
+        public TextCacheView(DiagnosticViewContext context) : base(context)
+        {
+        }
+
+        public override string DisplayName => "Text Cache";
+
+        protected override void DrawOverride(ref bool isGameViewFocused)
+        {
+            var newSelectedObject = Context.SelectedObject;
+            Context.Game.Graphics.RenderPipeline.DrawingContext.TextCache.DrawDiagnostic(ref newSelectedObject);
+            if (newSelectedObject != Context.SelectedObject)
+            {
+                Context.SelectedObject = newSelectedObject;
+            }
+        }
+    }
+}

--- a/src/OpenSage.Game/Graphics/Rendering/RenderPipeline.cs
+++ b/src/OpenSage.Game/Graphics/Rendering/RenderPipeline.cs
@@ -32,7 +32,7 @@ namespace OpenSage.Graphics.Rendering
         private readonly GlobalShaderResources _globalShaderResources;
         private readonly GlobalShaderResourceData _globalShaderResourceData;
 
-        private readonly DrawingContext2D _drawingContext;
+        internal readonly DrawingContext2D DrawingContext;
 
         private readonly ShadowMapRenderer _shadowMapRenderer;
         private readonly WaterMapRenderer _waterMapRenderer;
@@ -63,7 +63,7 @@ namespace OpenSage.Graphics.Rendering
 
             _commandList = AddDisposable(graphicsDevice.ResourceFactory.CreateCommandList());
 
-            _drawingContext = AddDisposable(new DrawingContext2D(
+            DrawingContext = AddDisposable(new DrawingContext2D(
                 game.ContentManager,
                 game.GraphicsLoadContext,
                 BlendStateDescription.SingleAlphaBlend,
@@ -135,21 +135,22 @@ namespace OpenSage.Graphics.Rendering
             {
                 _commandList.PushDebugGroup("2D Scene");
 
-                _drawingContext.Begin(
+                DrawingContext.Begin(
                     _commandList,
                     _loadContext.StandardGraphicsResources.LinearClampSampler,
-                    new SizeF(context.RenderTarget.Width, context.RenderTarget.Height));
+                    new SizeF(context.RenderTarget.Width, context.RenderTarget.Height),
+                    context.GameTime);
 
-                context.Scene3D?.Render(_drawingContext);
-                context.Scene2D?.Render(_drawingContext);
+                context.Scene3D?.Render(DrawingContext);
+                context.Scene2D?.Render(DrawingContext);
 
                 _shadowMapRenderer.DrawDebugOverlay(
                     context.Scene3D,
-                    _drawingContext);
+                    DrawingContext);
 
-                Rendering2D?.Invoke(this, new Rendering2DEventArgs(_drawingContext));
+                Rendering2D?.Invoke(this, new Rendering2DEventArgs(DrawingContext));
 
-                _drawingContext.End();
+                DrawingContext.End();
 
                 _commandList.PopDebugGroup();
             }

--- a/src/OpenSage.Game/Gui/Apt/AptRenderingContext.cs
+++ b/src/OpenSage.Game/Gui/Apt/AptRenderingContext.cs
@@ -80,7 +80,10 @@ namespace OpenSage.Gui.Apt
                 _clipMaskDrawingContext.Begin(
                     _commandList,
                     _graphicsLoadContext.StandardGraphicsResources.LinearClampSampler,
-                    new SizeF(renderTarget.ColorTarget.Width, renderTarget.ColorTarget.Height));
+                    new SizeF(renderTarget.ColorTarget.Width, renderTarget.ColorTarget.Height),
+                    // TODO: Pass correct time here
+                    TimeInterval.Zero
+                );
 
                 _activeDrawingContext = _clipMaskDrawingContext;
             }

--- a/src/OpenSage.Game/Gui/DrawingContext2D.cs
+++ b/src/OpenSage.Game/Gui/DrawingContext2D.cs
@@ -185,6 +185,11 @@ namespace OpenSage.Gui
                 return;
             }
 
+            if (color.A == 0)
+            {
+                return;
+            }
+
             var actualFont = _contentManager.FontManager.GetOrCreateFont(font.Name, font.Size * _currentScale, font.Bold ? FontWeight.Bold : FontWeight.Normal);
             var actualRect = RectangleF.Transform(rect, _currentTransform);
 

--- a/src/OpenSage.Game/Gui/TextCache.cs
+++ b/src/OpenSage.Game/Gui/TextCache.cs
@@ -139,7 +139,7 @@ namespace OpenSage.Gui
 
         public void ClearExpiredEntries(in TimeInterval now)
         {
-            var removedEntries = new List<TextKey>();
+            var removedEntries = new List<TextKey>(0);
 
             foreach (var (key, value) in _cache)
             {
@@ -164,11 +164,14 @@ namespace OpenSage.Gui
             var size = key.Size;
             var actualFont = key.Font;
 
-            var image = _textImagePool.Acquire(new ImageKey
-            {
-                Width = (int) MathF.Ceiling(size.Width),
-                Height = (int) MathF.Ceiling(size.Height)
-            });
+            var image = _textImagePool.Acquire(
+                new ImageKey
+                {
+                    Width = (int) MathF.Ceiling(size.Width),
+                    Height = (int) MathF.Ceiling(size.Height)
+                },
+                out var isNew
+            );
 
             image.Mutate(x =>
             {
@@ -179,9 +182,11 @@ namespace OpenSage.Gui
 
                 var color = key.Color;
 
-                // Clear image to transparent.
-                // TODO: Don't need to do this for a newly created image.
-                x.Clear(Color.Transparent);
+                // Clear re-used image buffers
+                if (!isNew)
+                {
+                    x.Clear(Color.Transparent);
+                }
 
                 try
                 {

--- a/src/OpenSage.Game/Gui/TextCache.cs
+++ b/src/OpenSage.Game/Gui/TextCache.cs
@@ -176,10 +176,6 @@ namespace OpenSage.Gui
             image.Mutate(x =>
             {
                 var location = new PointF(0, size.Height / 2.0f);
-
-                // TODO: Vertical centering is not working properly.
-                location.Y *= 0.8f;
-
                 var color = key.Color;
 
                 // Clear re-used image buffers

--- a/src/OpenSage.Game/Scripting/CameraFadeOverlay.cs
+++ b/src/OpenSage.Game/Scripting/CameraFadeOverlay.cs
@@ -1,7 +1,4 @@
-﻿using System.IO;
-using System.Numerics;
-using OpenSage.Data.Sav;
-using OpenSage.FileFormats;
+﻿using System.Numerics;
 using OpenSage.Graphics.Rendering;
 using OpenSage.Gui;
 using OpenSage.Mathematics;
@@ -93,7 +90,9 @@ namespace OpenSage.Scripting
             _drawingContext.Begin(
                 commandList,
                 _game.AssetStore.LoadContext.StandardGraphicsResources.LinearClampSampler,
-                outputSize);
+                outputSize,
+                // TODO: Pass correct time here
+                TimeInterval.Zero);
 
             switch (FadeType)
             {

--- a/src/OpenSage.Game/Utilities/Extensions/EnumerableExtensions.cs
+++ b/src/OpenSage.Game/Utilities/Extensions/EnumerableExtensions.cs
@@ -110,5 +110,15 @@ namespace OpenSage.Utilities.Extensions
 
             return minMax;
         }
+
+        public static IEnumerable<(T, int)> WithIndex<T>(this IEnumerable<T> enumerable)
+        {
+            var index = 0;
+            foreach (var item in enumerable)
+            {
+                yield return (item, index);
+                index++;
+            }
+        }
     }
 }

--- a/src/OpenSage.Game/Utilities/ResourcePool.cs
+++ b/src/OpenSage.Game/Utilities/ResourcePool.cs
@@ -20,7 +20,7 @@ namespace OpenSage.Utilities
             _leased = new Dictionary<TKey, List<T>>();
         }
 
-        public T Acquire(in TKey key)
+        public T Acquire(in TKey key, out bool isNew)
         {
             if (!_available.TryGetValue(key, out var available))
             {
@@ -31,11 +31,13 @@ namespace OpenSage.Utilities
             if (available.Count == 0)
             {
                 result = AddDisposable(_creator(key));
+                isNew = true;
             }
             else
             {
                 result = available[available.Count - 1];
                 available.RemoveAt(available.Count - 1);
+                isNew = false;
             }
 
             if (!_leased.TryGetValue(key, out var leased))

--- a/src/OpenSage.Mathematics/Size.cs
+++ b/src/OpenSage.Mathematics/Size.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Numerics;
 
 namespace OpenSage.Mathematics
 {
@@ -37,6 +38,16 @@ namespace OpenSage.Mathematics
         public Size(int value)
         {
             Width = Height = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="Size"/>.
+        /// </summary>
+        /// <param name="vector">Value for the width and height components.</param>
+        public Size(Vector2 vector)
+        {
+            Width = (int) vector.X;
+            Height = (int) vector.Y;
         }
 
         /// <summary>
@@ -80,5 +91,7 @@ namespace OpenSage.Mathematics
         }
 
         public SizeF ToSizeF() => new SizeF(Width, Height);
+
+        public Vector2 ToVector2() => new Vector2(Width, Height);
     }
 }


### PR DESCRIPTION
Depends on #701.

* Implement cache expiration for the text cache. Textures which not have been used for 5 seconds are purged from the cache at the end of each render frame.
* Add a new dev mode view for exploring text cache entries.
* To support the dev mode view the asset preview system has been extended to support raw Veldrid textures in addition to `TextureAsset`s.
* Vertical text centering has been fixed 🎉 
* Small optimizations to text rendering. For example, fully transparent text is no longer rendered.