### PR TITLE
Fix #691: Add scroll cursors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Generals",
             "type": "coreclr",
             "request": "launch",
-            "program": "${workspaceFolder}/src/OpenSage.Launcher/bin/Debug/net6.0/OpenSage.Launcher.dll",
+            "program": "${workspaceFolder}/src/OpenSage.Launcher/bin/Debug/net7.0/OpenSage.Launcher.dll",
             "args": [
                 "--developermode", "true",
                 "--game", "0"
@@ -18,7 +18,7 @@
           "name": "Generals (Alpine Assault)",
           "type": "coreclr",
           "request": "launch",
-          "program": "${workspaceFolder}/src/OpenSage.Launcher/bin/Debug/net6.0/OpenSage.Launcher.dll",
+          "program": "${workspaceFolder}/src/OpenSage.Launcher/bin/Debug/net7.0/OpenSage.Launcher.dll",
           "args": [
               "--developermode", "true",
               "--game", "0",
@@ -29,7 +29,7 @@
             "name": "Zero Hour",
             "type": "coreclr",
             "request": "launch",
-            "program": "${workspaceFolder}/src/OpenSage.Launcher/bin/Debug/net6.0/OpenSage.Launcher.dll",
+            "program": "${workspaceFolder}/src/OpenSage.Launcher/bin/Debug/net7.0/OpenSage.Launcher.dll",
             "args": [
                 "--developermode", "true",
                 "--game", "1"
@@ -39,7 +39,7 @@
             "name": "Generals Zero Hour (Alpine Assault)",
             "type": "coreclr",
             "request": "launch",
-            "program": "${workspaceFolder}/src/OpenSage.Launcher/bin/Debug/net6.0/OpenSage.Launcher.dll",
+            "program": "${workspaceFolder}/src/OpenSage.Launcher/bin/Debug/net7.0/OpenSage.Launcher.dll",
             "args": [
                 "--developermode", "true",
                 "--game", "1",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,6 +34,17 @@
                 "--developermode", "true",
                 "--game", "1"
             ]
+        },
+        {
+            "name": "Generals Zero Hour (Alpine Assault)",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "${workspaceFolder}/src/OpenSage.Launcher/bin/Debug/net6.0/OpenSage.Launcher.dll",
+            "args": [
+                "--developermode", "true",
+                "--game", "1",
+                "--map", "maps\\Alpine Assault\\Alpine Assault.map"
+            ]
         }
     ]
 }

--- a/docs/cursor-layouts.md
+++ b/docs/cursor-layouts.md
@@ -1,0 +1,62 @@
+This document describe cursor layouts defined by the field **Directions** in the object **MouseCursor**. Currently that field only used by the scroll cursor. If that value is greater than 0 then the cursor name appended by some direction index. All possible cursor directions shown below.
+
+↖&nbsp;&nbsp;&nbsp;↑&nbsp;&nbsp;&nbsp;↗
+
+←&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;→
+
+↙&nbsp;&nbsp;&nbsp;↓&nbsp;&nbsp;&nbsp;↘
+
+### Layout 1
+Original game just hide cursor when Directions == 1. We show cursor with direction index 0.
+
+### Layout 2
+1&nbsp;&nbsp;&nbsp;0&nbsp;&nbsp;&nbsp;0
+
+1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0
+
+1&nbsp;&nbsp;&nbsp;0&nbsp;&nbsp;&nbsp;0
+
+### Layout 3
+2&nbsp;&nbsp;&nbsp;2&nbsp;&nbsp;&nbsp;0
+
+2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0
+
+1&nbsp;&nbsp;&nbsp;1&nbsp;&nbsp;&nbsp;0
+
+### Layout 4
+3&nbsp;&nbsp;&nbsp;3&nbsp;&nbsp;&nbsp;3
+
+2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0
+
+1&nbsp;&nbsp;&nbsp;1&nbsp;&nbsp;&nbsp;1
+
+### Layout 5
+3&nbsp;&nbsp;&nbsp;4&nbsp;&nbsp;&nbsp;4
+
+3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0
+
+2&nbsp;&nbsp;&nbsp;1&nbsp;&nbsp;&nbsp;1
+
+### Layout 6
+4&nbsp;&nbsp;&nbsp;5&nbsp;&nbsp;&nbsp;5
+
+3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0
+
+2&nbsp;&nbsp;&nbsp;1&nbsp;&nbsp;&nbsp;1
+
+### Layout 7
+4&nbsp;&nbsp;&nbsp;5&nbsp;&nbsp;&nbsp;6
+
+4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0
+
+3&nbsp;&nbsp;&nbsp;2&nbsp;&nbsp;&nbsp;1
+
+### Layout 8
+5&nbsp;&nbsp;&nbsp;6&nbsp;&nbsp;&nbsp;7
+
+4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0
+
+3&nbsp;&nbsp;&nbsp;2&nbsp;&nbsp;&nbsp;1
+
+### Other layouts
+Directions number greater than 8 seems like a bugged in the original game. We just cap directions number at 8.

--- a/src/OpenSage.Game.Tests/Graphics/Cameras/RtsCameraControllerTests.cs
+++ b/src/OpenSage.Game.Tests/Graphics/Cameras/RtsCameraControllerTests.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using OpenSage.Graphics.Cameras;
+using OpenSage.Mathematics;
+using OpenSage.Terrain;
+using Xunit;
+
+namespace OpenSage.Tests.Graphics.Cameras
+{
+    public class RtsCameraControllerTests
+    {
+        const float DefaultHeight = 10;
+        const float DefaultPitch = (float)Math.PI / 4;
+        const int MapSize = 1000;
+        const int WindowSize = 100;
+
+        class MockHeightMap : IHeightMap
+        {
+            public int MaxXCoordinate => MapSize;
+
+            public int MaxYCoordinate => MapSize;
+
+            public float GetHeight(float x, float y)
+            {
+                return 0;
+            }
+        }
+
+        class MockCamera : ICamera
+        {
+            public Vector3 CameraPosition { get; private set; }
+            public Vector3 CameraTarget { get; private set; }
+            public Vector3 Up { get; private set; }
+
+            public float FieldOfView
+            {
+                get => (float)Math.PI / 2;
+                set => throw new NotImplementedException();
+            }
+            public float FarPlaneDistance
+            {
+                get => 100;
+                set => throw new NotImplementedException();
+            }
+
+            public Vector3 Position => throw new NotImplementedException();
+
+            public void SetLookAt(in Vector3 cameraPosition, in Vector3 cameraTarget, in Vector3 up)
+            {
+                CameraPosition = cameraPosition;
+                CameraTarget = cameraTarget;
+                Up = up;
+            }
+        }
+
+        class MockPanel : IPanel
+        {
+            public Rectangle Frame => new Rectangle(0, 0, WindowSize, WindowSize);
+        }
+
+        MockCamera Camera { get; }
+        MockHeightMap HeightMap { get; }
+        MockPanel  Panel { get; }
+
+        ICameraController Controller { get; }
+        Vector3 _lastPosition;
+        Vector3 _lastTarget;
+
+        void AssertUp()
+        {
+            Assert.True(Vector3.Dot(Camera.Up, new Vector3(0, 0, 1)) > 0);
+        }
+
+        Vector3 CameraTarget(float pitch)
+        {
+            Vector3 pos = Camera.CameraPosition;
+            return pos - new Vector3(0, 0, (float)Math.Tan(pitch) * pos.Z);
+        }
+
+        public RtsCameraControllerTests()
+        {
+            Camera = new MockCamera();
+            HeightMap = new MockHeightMap();
+            Panel = new MockPanel();
+            Controller = new RtsCameraController(
+                DefaultHeight,
+                DefaultPitch,
+                0,
+                Camera,
+                HeightMap,
+                Panel);
+            Controller.TerrainPosition = new Vector3(MapSize / 2, MapSize / 2, 0);
+            Controller.UpdateCamera(Camera, TimeInterval.Zero);
+            AssertUp();
+            _lastPosition = Camera.CameraPosition;
+            _lastTarget = Camera.CameraTarget;
+        }
+
+        static CameraInputState CreateInputState()
+        {
+            var inputState = new CameraInputState();
+            inputState.PressedKeys = new List<Veldrid.Key>();
+            inputState.LastX = WindowSize / 2;
+            inputState.LastY = WindowSize / 2;
+            return inputState;
+        }
+
+        public static IEnumerable<object[]> PanningData()
+        {
+            foreach (var dir in Enum.GetValues(typeof(CameraPanDirection)))
+            {
+                yield return new object[] { dir };
+            }
+        }
+
+        static (int, int) DirectionTuple(CameraPanDirection panDirection)
+        {
+            return panDirection switch
+            {
+                CameraPanDirection.None => (0, 0),
+                CameraPanDirection.Right => (1, 0),
+                CameraPanDirection.Down => (0, 1),
+                CameraPanDirection.RightDown => (1, 1),
+                CameraPanDirection.LeftDown => (-1, 1),
+                CameraPanDirection.Left => (-1, 0),
+                CameraPanDirection.LeftUp => (-1, -1),
+                CameraPanDirection.Up => (0, -1),
+                CameraPanDirection.RightUp => (1, -1),
+                _ => throw new NotImplementedException()
+            };
+        }
+
+        static Vector3 ClaculatePanDelta(int x, int y, float speed)
+        {
+            return new Vector3(x * speed, y * speed, 0);
+        }
+
+        void DoPanningTest(
+            CameraInputState inputState, int x, int y, 
+            CameraPanDirection panDirection,
+            float speed = RtsCameraController.PanSpeed)
+        {
+            Vector3 delta = ClaculatePanDelta(x, y, speed);
+            Controller.UpdateInput(inputState, TimeInterval.Zero);
+            Controller.UpdateCamera(Camera, TimeInterval.Zero);
+            AssertUp();
+            Assert.Equal(_lastPosition + delta, Camera.CameraPosition);
+            Assert.Equal(_lastTarget + delta, Camera.CameraTarget);
+            Assert.Equal(Controller.PanDirection, panDirection);
+        }
+
+        // Assume lookup direction is (1, 0, 0)
+        [Theory]
+        [MemberData(nameof(PanningData))]
+        public void TestHoverPanning(CameraPanDirection panDirection)
+        {
+            CameraInputState inputState = CreateInputState();
+            (int x, int y) = DirectionTuple(panDirection);
+            inputState.LastX = (1 + x) * WindowSize / 2;
+            inputState.LastY = (1 + y) * WindowSize / 2;
+            DoPanningTest(inputState, -y, -x, panDirection);
+        }
+
+        // Assume lookup direction is (1, 0, 0)
+        [Theory]
+        [MemberData(nameof(PanningData))]
+        public void TestKeyboardPanning(CameraPanDirection panDirection)
+        {
+            CameraInputState inputState = CreateInputState();
+            (int x, int y) = DirectionTuple(panDirection);
+            if (x > 0) inputState.PressedKeys.Add(Veldrid.Key.Right);
+            else if (x < 0) inputState.PressedKeys.Add(Veldrid.Key.Left);
+            if (y > 0) inputState.PressedKeys.Add(Veldrid.Key.Down);
+            else if (y < 0) inputState.PressedKeys.Add(Veldrid.Key.Up);
+            DoPanningTest(inputState, -y, -x, panDirection);
+        }
+
+        // Assume lookup direction is (1, 0, 0)
+        [Theory]
+        [MemberData(nameof(PanningData))]
+        public void TestRightMousePanning(CameraPanDirection panDirection)
+        {
+            CameraInputState inputState = CreateInputState();
+            (int x, int y) = DirectionTuple(panDirection);
+            float speed = RtsCameraController.MousePanSpeed;
+            int movement = (int)Math.Ceiling(RtsCameraController.PanDirectionThreshold / speed);
+            x *= movement;
+            y *= movement;
+            inputState.RightMouseDown = true;
+            inputState.DeltaX = x;
+            inputState.DeltaY = y;
+            if (panDirection == CameraPanDirection.None)
+            {
+                panDirection = CameraPanDirection.Right;
+            }
+            DoPanningTest(inputState, -y, -x, panDirection, speed);
+        }
+
+    }
+}

--- a/src/OpenSage.Game/Data/Sav/SaveFile.cs
+++ b/src/OpenSage.Game/Data/Sav/SaveFile.cs
@@ -63,7 +63,7 @@ namespace OpenSage.Data.Sav
             new ChunkDefinition("CHUNK_Radar", game => game.Scene3D.Radar),
             new ChunkDefinition("CHUNK_ScriptEngine", game => game.Scripting),
             new ChunkDefinition("CHUNK_SidesList", game => game.Scene3D.PlayerScripts),
-            new ChunkDefinition("CHUNK_TacticalView", game => ((RtsCameraController) game.Scene3D.CameraController)),
+            new ChunkDefinition("CHUNK_TacticalView", game => game.Scene3D.CameraController),
             new ChunkDefinition("CHUNK_GameClient", game => game.GameClient),
             new ChunkDefinition("CHUNK_InGameUI", game => game.AssetStore.InGameUI.Current),
             new ChunkDefinition("CHUNK_Partition", game => game.PartitionCellManager),

--- a/src/OpenSage.Game/Diagnostics/CameraView.cs
+++ b/src/OpenSage.Game/Diagnostics/CameraView.cs
@@ -15,8 +15,7 @@ namespace OpenSage.Diagnostics
 
         protected override void DrawOverride(ref bool isGameViewFocused)
         {
-            var cameraController = (RtsCameraController) Context.Game.Scene3D.CameraController;
-            cameraController.DrawInspector();
+            Context.Game.Scene3D.CameraController.DrawInspector();
         }
     }
 }

--- a/src/OpenSage.Game/Diagnostics/DeveloperModeView.cs
+++ b/src/OpenSage.Game/Diagnostics/DeveloperModeView.cs
@@ -47,6 +47,7 @@ namespace OpenSage.Diagnostics
                     if (_isGameViewFocused && message.MessageType == InputMessageType.KeyDown && message.Value.Key == Key.Escape)
                     {
                         _isGameViewFocused = false;
+                        game.Cursors.SetCursor("Arrow", game.RenderTime);
                         return InputMessageResult.Handled;
                     }
 

--- a/src/OpenSage.Game/Diagnostics/DeveloperModeView.cs
+++ b/src/OpenSage.Game/Diagnostics/DeveloperModeView.cs
@@ -88,7 +88,7 @@ namespace OpenSage.Diagnostics
             _commandList.End();
 
             _game.GraphicsDevice.SubmitCommands(_commandList);
-            _game.Scene3D.CameraEnableInput = _isGameViewFocused;
+            _game.Scene3D.CameraSystem.EnableInput = _isGameViewFocused;
         }
 
         private sealed class EmptyInputSnapshot : InputSnapshot

--- a/src/OpenSage.Game/Diagnostics/DeveloperModeView.cs
+++ b/src/OpenSage.Game/Diagnostics/DeveloperModeView.cs
@@ -88,6 +88,7 @@ namespace OpenSage.Diagnostics
             _commandList.End();
 
             _game.GraphicsDevice.SubmitCommands(_commandList);
+            _game.Scene3D.CameraEnableInput = _isGameViewFocused;
         }
 
         private sealed class EmptyInputSnapshot : InputSnapshot

--- a/src/OpenSage.Game/Diagnostics/DeveloperModeView.cs
+++ b/src/OpenSage.Game/Diagnostics/DeveloperModeView.cs
@@ -47,7 +47,7 @@ namespace OpenSage.Diagnostics
                     if (_isGameViewFocused && message.MessageType == InputMessageType.KeyDown && message.Value.Key == Key.Escape)
                     {
                         _isGameViewFocused = false;
-                        game.Cursors.SetCursor("Arrow", game.RenderTime);
+                        game.Cursors.SetArrowCursor(game.RenderTime);
                         return InputMessageResult.Handled;
                     }
 

--- a/src/OpenSage.Game/Diagnostics/GameView.cs
+++ b/src/OpenSage.Game/Diagnostics/GameView.cs
@@ -42,6 +42,7 @@ namespace OpenSage.Diagnostics
                 : Array.Empty<InputMessage>();
 
             Game.Update(inputMessages);
+            if (isGameViewFocused) Game.CursorLogicTick();
             Game.Render();
 
             var imagePointer = ImGuiRenderer.GetOrCreateImGuiBinding(

--- a/src/OpenSage.Game/Diagnostics/RenderedView.cs
+++ b/src/OpenSage.Game/Diagnostics/RenderedView.cs
@@ -44,6 +44,7 @@ namespace OpenSage.Diagnostics
                 WorldLighting.CreateDefault(),
                 Environment.TickCount,
                 isDiagnosticScene: true));
+            _scene3D.CameraEnableInput = true;
 
             createGameObjects?.Invoke(_scene3D.GameObjects);
 

--- a/src/OpenSage.Game/Diagnostics/RenderedView.cs
+++ b/src/OpenSage.Game/Diagnostics/RenderedView.cs
@@ -44,7 +44,7 @@ namespace OpenSage.Diagnostics
                 WorldLighting.CreateDefault(),
                 Environment.TickCount,
                 isDiagnosticScene: true));
-            _scene3D.CameraEnableInput = true;
+            _scene3D.CameraSystem.EnableInput = true;
 
             createGameObjects?.Invoke(_scene3D.GameObjects);
 

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -790,7 +790,15 @@ namespace OpenSage
 
         public void CursorLogicTick()
         {
-            Scene3D.CursorLogicTick(MapTime);
+            CameraPanDirection panDirection = Scene3D.CameraController.PanDirection;
+            if (panDirection != CameraPanDirection.None)
+            {
+                Cursors.SetCursor("Scroll", (uint)panDirection, RenderTime);
+            }
+            else
+            {
+                Scene3D.CursorLogicTick(MapTime);
+            }
         }
 
         public void Update(IEnumerable<InputMessage> messages)

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -793,6 +793,7 @@ namespace OpenSage
             CursorDirection? panDirection = Scene3D.CameraController.PanDirection;
             if (panDirection != null)
             {
+                Scene3D.CursorUpdatePosition();
                 Cursors.IsCursorVisible = true;
                 Cursors.SetScrollCursor(panDirection.Value, RenderTime);
             }

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -793,6 +793,7 @@ namespace OpenSage
             CursorDirection? panDirection = Scene3D.CameraController.PanDirection;
             if (panDirection != null)
             {
+                Cursors.IsCursorVisible = true;
                 Cursors.SetScrollCursor(panDirection.Value, RenderTime);
             }
             else

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -788,6 +788,11 @@ namespace OpenSage
             _nextScriptingUpdate = totalGameTime;
         }
 
+        public void CursorLogicTick()
+        {
+            Scene3D.CursorLogicTick(MapTime);
+        }
+
         public void Update(IEnumerable<InputMessage> messages)
         {
             // Update timers, input and UI state

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -441,7 +441,7 @@ namespace OpenSage
 
                             if (message.MessageType == InputMessageType.KeyDown && message.Value.Key == Key.Comma)
                             {
-                                var rtsCam = Scene3D.CameraController as RtsCameraController;
+                                var rtsCam = Scene3D.CameraController;
                                 rtsCam.CanPlayerInputChangePitch = !rtsCam.CanPlayerInputChangePitch;
                                 return InputMessageResult.Handled;
                             }

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -790,10 +790,10 @@ namespace OpenSage
 
         public void CursorLogicTick()
         {
-            CameraPanDirection panDirection = Scene3D.CameraController.PanDirection;
-            if (panDirection != CameraPanDirection.None)
+            CursorDirection? panDirection = Scene3D.CameraController.PanDirection;
+            if (panDirection != null)
             {
-                Cursors.SetCursor("Scroll", (uint)panDirection, RenderTime);
+                Cursors.SetCursor("Scroll", panDirection.Value, RenderTime);
             }
             else
             {

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -537,7 +537,7 @@ namespace OpenSage
                 GameSystems.ForEach(gs => gs.Initialize());
 
                 Cursors = AddDisposable(new CursorManager(AssetStore, ContentManager, window));
-                Cursors.SetCursor("Arrow", _renderTimer.CurrentGameTime);
+                Cursors.SetArrowCursor(_renderTimer.CurrentGameTime);
 
                 LauncherImage = LoadLauncherImage();
 
@@ -793,7 +793,7 @@ namespace OpenSage
             CursorDirection? panDirection = Scene3D.CameraController.PanDirection;
             if (panDirection != null)
             {
-                Cursors.SetCursor("Scroll", panDirection.Value, RenderTime);
+                Cursors.SetScrollCursor(panDirection.Value, RenderTime);
             }
             else
             {

--- a/src/OpenSage.Game/GamePanel.cs
+++ b/src/OpenSage.Game/GamePanel.cs
@@ -5,7 +5,7 @@ using Rectangle = OpenSage.Mathematics.Rectangle;
 
 namespace OpenSage
 {
-    public sealed class GamePanel : DisposableBase
+    public sealed class GamePanel : DisposableBase, IPanel
     {
         private readonly RenderTarget _renderTarget;
 

--- a/src/OpenSage.Game/Graphics/Cameras/ArcballCameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/ArcballCameraController.cs
@@ -26,6 +26,7 @@ namespace OpenSage.Graphics.Cameras
         void ICameraController.SetPitch(float pitch) => throw new NotImplementedException();
         float ICameraController.Zoom { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         Vector3 ICameraController.TerrainPosition { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        CameraPanDirection ICameraController.PanDirection { get => throw new NotImplementedException(); }
 
         public ArcballCameraController(Vector3 target, float radius)
         {

--- a/src/OpenSage.Game/Graphics/Cameras/ArcballCameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/ArcballCameraController.cs
@@ -110,7 +110,7 @@ namespace OpenSage.Graphics.Cameras
             throw new NotImplementedException();
         }
 
-        void ICameraController.UpdateCamera(Camera camera, in CameraInputState inputState, in TimeInterval gameTime)
+        void ICameraController.UpdateCameraInput(Camera camera, in CameraInputState inputState, in TimeInterval gameTime)
         {
             if (inputState.LeftMouseDown)
             {
@@ -123,7 +123,10 @@ namespace OpenSage.Graphics.Cameras
             }
 
             ZoomCamera(-inputState.ScrollWheelValue);
+        }
 
+        void ICameraController.UpdateCamera(Camera camera, in TimeInterval gameTime)
+        {
             var position = Vector3.Transform(
                 -Vector3.UnitY,
                 QuaternionUtility.CreateFromYawPitchRoll_ZUp(_yaw, _pitch, 0));

--- a/src/OpenSage.Game/Graphics/Cameras/ArcballCameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/ArcballCameraController.cs
@@ -24,6 +24,12 @@ namespace OpenSage.Graphics.Cameras
         private float _zoom;
         private Vector3 _translation;
 
+        public bool CanPlayerInputChangePitch
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
         void ICameraController.SetPitch(float pitch) => throw new NotImplementedException();
         float ICameraController.Zoom { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         Vector3 ICameraController.TerrainPosition { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
@@ -141,5 +147,10 @@ namespace OpenSage.Graphics.Cameras
         }
 
         public void GoToObject(GameObject gameObject) { }
+
+        public void Persist(StatePersister reader) { }
+
+        public void DrawInspector() { }
+
     }
 }

--- a/src/OpenSage.Game/Graphics/Cameras/ArcballCameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/ArcballCameraController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using OpenSage.Logic.Object;
@@ -110,7 +110,7 @@ namespace OpenSage.Graphics.Cameras
             throw new NotImplementedException();
         }
 
-        void ICameraController.UpdateCameraInput(Camera camera, in CameraInputState inputState, in TimeInterval gameTime)
+        void ICameraController.UpdateInput(in CameraInputState inputState, in TimeInterval gameTime)
         {
             if (inputState.LeftMouseDown)
             {

--- a/src/OpenSage.Game/Graphics/Cameras/ArcballCameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/ArcballCameraController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using OpenSage.Input.Cursors;
 using OpenSage.Logic.Object;
 using OpenSage.Mathematics;
 
@@ -26,7 +27,7 @@ namespace OpenSage.Graphics.Cameras
         void ICameraController.SetPitch(float pitch) => throw new NotImplementedException();
         float ICameraController.Zoom { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         Vector3 ICameraController.TerrainPosition { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-        CameraPanDirection ICameraController.PanDirection { get => throw new NotImplementedException(); }
+        CursorDirection? ICameraController.PanDirection { get => throw new NotImplementedException(); }
 
         public ArcballCameraController(Vector3 target, float radius)
         {

--- a/src/OpenSage.Game/Graphics/Cameras/ArcballCameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/ArcballCameraController.cs
@@ -125,7 +125,7 @@ namespace OpenSage.Graphics.Cameras
             ZoomCamera(-inputState.ScrollWheelValue);
         }
 
-        void ICameraController.UpdateCamera(Camera camera, in TimeInterval gameTime)
+        void ICameraController.UpdateCamera(ICamera camera, in TimeInterval gameTime)
         {
             var position = Vector3.Transform(
                 -Vector3.UnitY,

--- a/src/OpenSage.Game/Graphics/Cameras/Camera.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/Camera.cs
@@ -5,7 +5,7 @@ using Viewport = Veldrid.Viewport;
 
 namespace OpenSage.Graphics.Cameras
 {
-    public sealed class Camera
+    public sealed class Camera : ICamera
     {
         private readonly Func<Viewport> _getViewport;
         private Viewport _viewport;

--- a/src/OpenSage.Game/Graphics/Cameras/CameraHoverMessageHandler.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/CameraHoverMessageHandler.cs
@@ -1,0 +1,38 @@
+
+using OpenSage.Input;
+
+namespace OpenSage.Graphics.Cameras
+{
+    public sealed class CameraHoverMessageHandler : InputMessageHandler
+    {
+        private int _lastX, _lastY;
+
+        public override HandlingPriority Priority => HandlingPriority.MoveCameraPriority;
+
+        public override InputMessageResult HandleMessage(InputMessage message)
+        {
+            switch (message.MessageType)
+            {
+                case InputMessageType.MouseMove:
+                    {
+                        _lastX = message.Value.MousePosition.X;
+                        _lastY = message.Value.MousePosition.Y;
+                        break;
+                    }
+            }
+            return InputMessageResult.NotHandled;
+        }
+
+        public void ResetMouse(IPanel panel)
+        {
+            _lastX = panel.Frame.Width / 2;
+            _lastY = panel.Frame.Height / 2;
+        }
+
+        public void UpdateInputState(ref CameraInputState state)
+        {
+            state.LastX = _lastX;
+            state.LastY = _lastY;
+        }
+    }
+}

--- a/src/OpenSage.Game/Graphics/Cameras/CameraInputMessageHandler.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/CameraInputMessageHandler.cs
@@ -17,6 +17,24 @@ namespace OpenSage.Graphics.Cameras
 
         private int _scrollWheelValue;
 
+        private void SetPosition(InputMessage message)
+        {
+            var position = message.Value.MousePosition;
+            _lastX = position.X;
+            _lastY = position.Y;
+        }
+
+        private InputMessageResult ResetDelta()
+        {
+            InputMessageResult result = InputMessageResult.NotHandled;
+            if (_deltaX != 0 || _deltaY != 0)
+            {
+                result = InputMessageResult.Handled;
+            }
+            _deltaX = _deltaY = 0;
+            return result;
+        }
+
         public override HandlingPriority Priority =>
             _rightMouseDown || _middleMouseDown || _pressedKeys.Contains(Key.AltLeft)
                 ? HandlingPriority.MoveCameraPriority
@@ -49,29 +67,19 @@ namespace OpenSage.Graphics.Cameras
                     }
 
                 case InputMessageType.MouseLeftButtonDown:
+                    SetPosition(message);
+                    _leftMouseDown = true;
+                    break;
+
                 case InputMessageType.MouseMiddleButtonDown:
+                    SetPosition(message);
+                    _middleMouseDown = true;
+                    break;
+
                 case InputMessageType.MouseRightButtonDown:
-                    {
-                        var position = message.Value.MousePosition;
-                        _lastX = position.X;
-                        _lastY = position.Y;
-
-                        switch (message.MessageType)
-                        {
-                            case InputMessageType.MouseLeftButtonDown:
-                                _leftMouseDown = true;
-                                break;
-
-                            case InputMessageType.MouseMiddleButtonDown:
-                                _middleMouseDown = true;
-                                break;
-
-                            case InputMessageType.MouseRightButtonDown:
-                                _rightMouseDown = true;
-                                break;
-                        }
-                        break;
-                    }
+                    SetPosition(message);
+                    _rightMouseDown = true;
+                    break;
 
                 case InputMessageType.MouseLeftButtonUp:
                     _leftMouseDown = false;
@@ -83,8 +91,7 @@ namespace OpenSage.Graphics.Cameras
 
                 case InputMessageType.MouseRightButtonUp:
                     _rightMouseDown = false;
-                    _deltaX = _deltaY = 0;
-                    return InputMessageResult.NotHandled;
+                    return ResetDelta();
 
                 case InputMessageType.MouseWheel:
                     _scrollWheelValue += message.Value.ScrollWheel;

--- a/src/OpenSage.Game/Graphics/Cameras/CameraInputMessageHandler.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/CameraInputMessageHandler.cs
@@ -33,10 +33,9 @@ namespace OpenSage.Graphics.Cameras
                         {
                             _deltaX += position.X - _lastX;
                             _deltaY += position.Y - _lastY;
-
-                            _lastX = position.X;
-                            _lastY = position.Y;
                         }
+                        _lastX = position.X;
+                        _lastY = position.Y;
                         break;
                     }
 
@@ -111,6 +110,8 @@ namespace OpenSage.Graphics.Cameras
 
             state.DeltaX = _deltaX;
             state.DeltaY = _deltaY;
+            state.LastX = _lastX;
+            state.LastY = _lastY;
 
             state.ScrollWheelValue = _scrollWheelValue;
 

--- a/src/OpenSage.Game/Graphics/Cameras/CameraInputMessageHandler.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/CameraInputMessageHandler.cs
@@ -119,8 +119,6 @@ namespace OpenSage.Graphics.Cameras
 
             state.DeltaX = _deltaX;
             state.DeltaY = _deltaY;
-            state.LastX = _lastX;
-            state.LastY = _lastY;
 
             state.ScrollWheelValue = _scrollWheelValue;
 

--- a/src/OpenSage.Game/Graphics/Cameras/CameraInputMessageHandler.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/CameraInputMessageHandler.cs
@@ -22,6 +22,15 @@ namespace OpenSage.Graphics.Cameras
                 ? HandlingPriority.MoveCameraPriority
                 : HandlingPriority.CameraPriority;
 
+        public void ResetMouse(IPanel panel)
+        {
+            _leftMouseDown = false;
+            _middleMouseDown = false;
+            _rightMouseDown = false;
+            _lastX = panel.Frame.Width / 2;
+            _lastY = panel.Frame.Height / 2;
+        }
+
         public override InputMessageResult HandleMessage(InputMessage message)
         {
             switch (message.MessageType)

--- a/src/OpenSage.Game/Graphics/Cameras/CameraInputState.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/CameraInputState.cs
@@ -11,6 +11,8 @@ namespace OpenSage.Graphics.Cameras
 
         public int DeltaX;
         public int DeltaY;
+        public int LastX;
+        public int LastY;
 
         public int ScrollWheelValue;
 

--- a/src/OpenSage.Game/Graphics/Cameras/CameraSystem.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/CameraSystem.cs
@@ -15,6 +15,7 @@ namespace OpenSage.Graphics.Cameras
     {
         private CameraInputState _cameraInputState;
         private readonly CameraInputMessageHandler _cameraInputMessageHandler;
+        private readonly CameraHoverMessageHandler _cameraHoverMessageHandler;
         private readonly GamePanel Panel;
         public readonly Camera Camera;
         public readonly ICameraController Controller;
@@ -29,6 +30,7 @@ namespace OpenSage.Graphics.Cameras
                 if (value && !_cameraEnableInput)
                 {
                     _cameraInputMessageHandler.ResetMouse(Panel);
+                    _cameraHoverMessageHandler.ResetMouse(Panel);
                 }
                 _cameraEnableInput = value;
             }
@@ -45,7 +47,9 @@ namespace OpenSage.Graphics.Cameras
             Camera = new Camera(getViewport);
             Panel = game.Panel;
             _cameraInputMessageHandler = new CameraInputMessageHandler();
+            _cameraHoverMessageHandler = new CameraHoverMessageHandler();
             RegisterInputHandler(_cameraInputMessageHandler, inputMessageBuffer);
+            RegisterInputHandler(_cameraHoverMessageHandler, inputMessageBuffer);
         }
 
         public CameraSystem(
@@ -77,6 +81,7 @@ namespace OpenSage.Graphics.Cameras
         public void LogicTick(in TimeInterval gameTime)
         {
             _cameraInputMessageHandler?.UpdateInputState(ref _cameraInputState);
+            _cameraHoverMessageHandler?.UpdateInputState(ref _cameraInputState);
 
             if (EnableInput)
             {

--- a/src/OpenSage.Game/Graphics/Cameras/CameraSystem.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/CameraSystem.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
+using OpenSage.Input;
+using OpenSage.Input.Cursors;
+using OpenSage.Logic.Object;
+using OpenSage.Mathematics;
+using Veldrid;
+
+namespace OpenSage.Graphics.Cameras
+{
+    public class CameraSystem : DisposableBase
+    {
+        private CameraInputState _cameraInputState;
+        private readonly CameraInputMessageHandler _cameraInputMessageHandler;
+        private readonly GamePanel Panel;
+        public readonly Camera Camera;
+        public readonly ICameraController Controller;
+
+
+        private bool _cameraEnableInput;
+        public bool EnableInput
+        { 
+            get => _cameraEnableInput;
+            set
+            {
+                if (value && !_cameraEnableInput)
+                {
+                    _cameraInputMessageHandler.ResetMouse(Panel);
+                }
+                _cameraEnableInput = value;
+            }
+        }
+
+        private void RegisterInputHandler(InputMessageHandler handler, InputMessageBuffer inputMessageBuffer)
+        {
+            inputMessageBuffer.Handlers.Add(handler);
+            AddDisposeAction(() => inputMessageBuffer.Handlers.Remove(handler));
+        }
+
+        private CameraSystem(Game game, Func<Viewport> getViewport, InputMessageBuffer inputMessageBuffer)
+        {
+            Camera = new Camera(getViewport);
+            Panel = game.Panel;
+            _cameraInputMessageHandler = new CameraInputMessageHandler();
+            RegisterInputHandler(_cameraInputMessageHandler, inputMessageBuffer);
+        }
+
+        public CameraSystem(
+            Game game, 
+            ICameraController controller, 
+            Func<Viewport> getViewport, 
+            InputMessageBuffer inputMessageBuffer)
+            : this(game, getViewport, inputMessageBuffer)
+        {
+            Controller = controller;
+        }
+
+        public CameraSystem(
+            Game game,
+            Terrain.Terrain terrain,
+            Func<Viewport> getViewport,
+            InputMessageBuffer inputMessageBuffer)
+            : this(game, getViewport, inputMessageBuffer)
+        {
+            Controller = new RtsCameraController(
+                game.AssetStore.GameData.Current, Camera, terrain.HeightMap, game.Panel)
+                {
+                    TerrainPosition = terrain.HeightMap.GetPosition(
+                        terrain.HeightMap.Width / 2,
+                        terrain.HeightMap.Height / 2)
+                };
+        }
+
+        public void LogicTick(in TimeInterval gameTime)
+        {
+            _cameraInputMessageHandler?.UpdateInputState(ref _cameraInputState);
+
+            if (EnableInput)
+            {
+                Controller.UpdateInput(_cameraInputState, gameTime);
+            }
+            Controller.UpdateCamera(Camera, gameTime);
+        }
+    }
+}

--- a/src/OpenSage.Game/Graphics/Cameras/ICamera.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/ICamera.cs
@@ -1,0 +1,12 @@
+using System.Numerics;
+
+namespace OpenSage.Graphics.Cameras
+{
+    public interface ICamera
+    {
+        public float FieldOfView { get; set; }
+        public float FarPlaneDistance { get; set; }
+        public Vector3 Position { get; }
+        public void SetLookAt(in Vector3 cameraPosition, in Vector3 cameraTarget, in Vector3 up);
+    }
+}

--- a/src/OpenSage.Game/Graphics/Cameras/ICameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/ICameraController.cs
@@ -7,11 +7,13 @@ using OpenSage.Logic.Object;
 
 namespace OpenSage.Graphics.Cameras
 {
-    public interface ICameraController
+    public interface ICameraController : IPersistableObject
     {
         float Zoom { get; set; }
 
         Vector3 TerrainPosition { get; set; }
+
+        bool CanPlayerInputChangePitch { get; set; }
 
         void SetPitch(float pitch);
 
@@ -35,8 +37,8 @@ namespace OpenSage.Graphics.Cameras
 
         void UpdateCamera(ICamera camera, in TimeInterval gameTime);
 
-
         void GoToObject(GameObject gameObject);
 
+        void DrawInspector();
     }
 }

--- a/src/OpenSage.Game/Graphics/Cameras/ICameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/ICameraController.cs
@@ -1,22 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using OpenSage.Input.Cursors;
 using OpenSage.Logic.Object;
+
 
 namespace OpenSage.Graphics.Cameras
 {
-    public enum CameraPanDirection
-    {
-        Right,
-        RightDown,
-        Down,
-        LeftDown,
-        Left,
-        LeftUp,
-        Up,
-        RightUp,
-        None
-    }
     public interface ICameraController
     {
         float Zoom { get; set; }
@@ -32,7 +22,7 @@ namespace OpenSage.Graphics.Cameras
         void ModFinalLookToward(in Vector3 position);
         void ModLookToward(in Vector3 position);
 
-        CameraPanDirection PanDirection { get; }
+        CursorDirection? PanDirection { get; }
 
         CameraAnimation StartAnimation(
             IReadOnlyList<Vector3> points,

--- a/src/OpenSage.Game/Graphics/Cameras/ICameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/ICameraController.cs
@@ -43,7 +43,7 @@ namespace OpenSage.Graphics.Cameras
 
         void UpdateInput(in CameraInputState inputState, in TimeInterval gameTime);
 
-        void UpdateCamera(Camera camera, in TimeInterval gameTime);
+        void UpdateCamera(ICamera camera, in TimeInterval gameTime);
 
 
         void GoToObject(GameObject gameObject);

--- a/src/OpenSage.Game/Graphics/Cameras/ICameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/ICameraController.cs
@@ -41,7 +41,10 @@ namespace OpenSage.Graphics.Cameras
 
         void EndAnimation();
 
-        void UpdateCamera(Camera camera, in CameraInputState inputState, in TimeInterval gameTime);
+        void UpdateCameraInput(Camera camera, in CameraInputState inputState, in TimeInterval gameTime);
+
+        void UpdateCamera(Camera camera, in TimeInterval gameTime);
+
 
         void GoToObject(GameObject gameObject);
 

--- a/src/OpenSage.Game/Graphics/Cameras/ICameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/ICameraController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using OpenSage.Logic.Object;
@@ -41,7 +41,7 @@ namespace OpenSage.Graphics.Cameras
 
         void EndAnimation();
 
-        void UpdateCameraInput(Camera camera, in CameraInputState inputState, in TimeInterval gameTime);
+        void UpdateInput(in CameraInputState inputState, in TimeInterval gameTime);
 
         void UpdateCamera(Camera camera, in TimeInterval gameTime);
 

--- a/src/OpenSage.Game/Graphics/Cameras/ICameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/ICameraController.cs
@@ -5,6 +5,18 @@ using OpenSage.Logic.Object;
 
 namespace OpenSage.Graphics.Cameras
 {
+    public enum CameraPanDirection
+    {
+        Right,
+        RightDown,
+        Down,
+        LeftDown,
+        Left,
+        LeftUp,
+        Up,
+        RightUp,
+        None
+    }
     public interface ICameraController
     {
         float Zoom { get; set; }
@@ -19,6 +31,8 @@ namespace OpenSage.Graphics.Cameras
         void ModSetFinalZoom(float finalZoom);
         void ModFinalLookToward(in Vector3 position);
         void ModLookToward(in Vector3 position);
+
+        CameraPanDirection PanDirection { get; }
 
         CameraAnimation StartAnimation(
             IReadOnlyList<Vector3> points,

--- a/src/OpenSage.Game/Graphics/Cameras/RtsCameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/RtsCameraController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Numerics;
 using ImGuiNET;
 using OpenSage.Data.Sav;
+using OpenSage.Input.Cursors;
 using OpenSage.Mathematics;
 using OpenSage.Terrain;
 using Veldrid;
@@ -33,8 +34,8 @@ namespace OpenSage.Graphics.Cameras
 
         public bool CanPlayerInputChangePitch { get; set; }
 
-        private CameraPanDirection _panDirection = CameraPanDirection.None;
-        CameraPanDirection ICameraController.PanDirection { get => _panDirection; }
+        private CursorDirection? _panDirection = null;
+        CursorDirection? ICameraController.PanDirection { get => _panDirection; }
 
         private float _yaw;
         public void SetLookDirection(Vector3 lookDirection)
@@ -187,33 +188,33 @@ namespace OpenSage.Graphics.Cameras
             return 0;
         }
 
-        static CameraPanDirection CalculatePanDirection(int up, int right, bool rmb)
+        private static CursorDirection? CalculatePanDirection(int up, int right, bool rmb)
         {
             int thresh = rmb ? PanDirectionThreshold : 0;
             if (up > thresh)
             {
-                if (right > thresh) return CameraPanDirection.RightUp;
-                else if (right < -thresh) return CameraPanDirection.LeftUp;
-                else return CameraPanDirection.Up;
+                if (right > thresh) return CursorDirection.RightUp;
+                else if (right < -thresh) return CursorDirection.LeftUp;
+                else return CursorDirection.Up;
             }
             else if (up < -thresh)
             {
-                if (right > thresh) return CameraPanDirection.RightDown;
-                else if (right < -thresh) return CameraPanDirection.LeftDown;
-                else return CameraPanDirection.Down;
+                if (right > thresh) return CursorDirection.RightDown;
+                else if (right < -thresh) return CursorDirection.LeftDown;
+                else return CursorDirection.Down;
             }
             else
             {
                 if (rmb)
                 {
-                    if (right >= 0) return CameraPanDirection.Right;
-                    else return CameraPanDirection.Left;
+                    if (right >= 0) return CursorDirection.Right;
+                    else return CursorDirection.Left;
                 }
                 else
                 {
-                    if (right > 0) return CameraPanDirection.Right;
-                    else if (right < 0) return CameraPanDirection.Left;
-                    else return CameraPanDirection.None;
+                    if (right > 0) return CursorDirection.Right;
+                    else if (right < 0) return CursorDirection.Left;
+                    else return null;
                 }
                 
             }
@@ -224,7 +225,7 @@ namespace OpenSage.Graphics.Cameras
             if (inputState.LeftMouseDown && inputState.PressedKeys.Contains(Key.AltLeft) || inputState.MiddleMouseDown)
             {
                 RotateCamera(inputState.DeltaX, inputState.DeltaY);
-                _panDirection = CameraPanDirection.None;
+                _panDirection = null;
             }
             else
             {
@@ -250,7 +251,7 @@ namespace OpenSage.Graphics.Cameras
                     else up = GetKeyMovement(inputState, Key.Up, Key.Down);
 
                     _panDirection = CalculatePanDirection(up, right, false);
-                    if (_panDirection != CameraPanDirection.None)
+                    if (_panDirection != null)
                     {
                         PanCamera(up, right, PanSpeed);
                     }

--- a/src/OpenSage.Game/Graphics/Cameras/RtsCameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/RtsCameraController.cs
@@ -10,7 +10,7 @@ using Veldrid;
 
 namespace OpenSage.Graphics.Cameras
 {
-    public sealed class RtsCameraController : ICameraController, IPersistableObject
+    public sealed class RtsCameraController : ICameraController
     {
         public const float RotationSpeed = 0.003f;
         public const float ZoomSpeed = 0.0005f;
@@ -398,7 +398,7 @@ namespace OpenSage.Graphics.Cameras
             reader.PersistVector3(ref _terrainPosition);
         }
 
-        internal void DrawInspector()
+        public void DrawInspector()
         {
             var pitchDegrees = MathUtility.ToDegrees(_currentPitchAngle);
             if (ImGui.DragFloat("Pitch", ref pitchDegrees, 1, -90, 90))

--- a/src/OpenSage.Game/Graphics/Cameras/RtsCameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/RtsCameraController.cs
@@ -20,8 +20,8 @@ namespace OpenSage.Graphics.Cameras
         public const int PanDirectionThreshold = 10;
 
 
-        private readonly Camera _camera;
-        private readonly HeightMap _heightMap;
+        private readonly ICamera _camera;
+        private readonly IHeightMap _heightMap;
         private IPanel _panel;
 
         private readonly float _defaultHeight;
@@ -87,7 +87,24 @@ namespace OpenSage.Graphics.Cameras
 
         public CameraAnimation CurrentAnimation => _animation;
 
-        public RtsCameraController(GameData gameData, Camera camera, HeightMap heightMap, IPanel panel)
+        public RtsCameraController(
+            float defaultHeight,
+            float defaultPitchAngle,
+            float defaultYaw,
+            ICamera camera,
+            IHeightMap heightMap,
+            IPanel panel)
+        {
+            _camera = camera;
+            _heightMap = heightMap;
+            _panel = panel;
+            _defaultHeight = defaultHeight;
+            _defaultPitchAngle = defaultPitchAngle;
+            _currentPitchAngle = -_defaultPitchAngle;
+            _yaw = defaultYaw;
+        }
+
+        public RtsCameraController(GameData gameData, ICamera camera, IHeightMap heightMap, IPanel panel)
         {
             _camera = camera;
             _heightMap = heightMap;
@@ -242,7 +259,7 @@ namespace OpenSage.Graphics.Cameras
             ZoomCamera(-inputState.ScrollWheelValue);
         }
 
-        void ICameraController.UpdateCamera(Camera camera, in TimeInterval gameTime)
+        void ICameraController.UpdateCamera(ICamera camera, in TimeInterval gameTime)
         {
             if (_animation != null)
             {

--- a/src/OpenSage.Game/Graphics/Cameras/RtsCameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/RtsCameraController.cs
@@ -15,9 +15,11 @@ namespace OpenSage.Graphics.Cameras
         private const float ZoomSpeed = 0.0005f;
         private const float PanSpeed = 3f;
         private const float MousePanSpeed = 0.1f;
+        private const float PanBorderWith = 10f;
 
         private readonly Camera _camera;
         private readonly HeightMap _heightMap;
+        private IPanel _panel;
 
         private readonly float _defaultHeight;
         private readonly float _defaultPitchAngle;
@@ -82,10 +84,11 @@ namespace OpenSage.Graphics.Cameras
 
         public CameraAnimation CurrentAnimation => _animation;
 
-        public RtsCameraController(GameData gameData, Camera camera, HeightMap heightMap)
+        public RtsCameraController(GameData gameData, Camera camera, HeightMap heightMap, IPanel panel)
         {
             _camera = camera;
             _heightMap = heightMap;
+            _panel = panel;
 
             _defaultHeight = gameData.DefaultCameraMaxHeight > 0
                 ? gameData.DefaultCameraMaxHeight
@@ -182,8 +185,15 @@ namespace OpenSage.Graphics.Cameras
                 }
                 else
                 {
-                    up = GetKeyMovement(inputState, Key.Up, Key.Down);
-                    right = GetKeyMovement(inputState, Key.Right, Key.Left);
+                    OpenSage.Mathematics.Rectangle bounds = _panel.Frame;
+
+                    if (inputState.LastX < PanBorderWith) right = -1;
+                    else if (inputState.LastX > bounds.Width - PanBorderWith) right = 1;
+                    else right = GetKeyMovement(inputState, Key.Right, Key.Left);
+
+                    if (inputState.LastY < PanBorderWith) up = 1;
+                    else if (inputState.LastY > bounds.Height - PanBorderWith) up = -1;
+                    else up = GetKeyMovement(inputState, Key.Up, Key.Down);
                 }
                 if (up != 0 || right != 0)
                 {

--- a/src/OpenSage.Game/Graphics/Cameras/RtsCameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/RtsCameraController.cs
@@ -14,6 +14,7 @@ namespace OpenSage.Graphics.Cameras
         private const float RotationSpeed = 0.003f;
         private const float ZoomSpeed = 0.0005f;
         private const float PanSpeed = 3f;
+        private const float MousePanSpeed = 0.1f;
 
         private readonly Camera _camera;
         private readonly HeightMap _heightMap;
@@ -172,8 +173,8 @@ namespace OpenSage.Graphics.Cameras
                 float forwards, right;
                 if (inputState.RightMouseDown)
                 {
-                    forwards = -inputState.DeltaY;
-                    right = inputState.DeltaX;
+                    forwards = -MousePanSpeed * inputState.DeltaY;
+                    right = MousePanSpeed * inputState.DeltaX;
                 }
                 else
                 {

--- a/src/OpenSage.Game/Graphics/Cameras/RtsCameraController.cs
+++ b/src/OpenSage.Game/Graphics/Cameras/RtsCameraController.cs
@@ -167,7 +167,7 @@ namespace OpenSage.Graphics.Cameras
             return 0;
         }
 
-        void ICameraController.UpdateCamera(Camera camera, in CameraInputState inputState, in TimeInterval gameTime)
+        void ICameraController.UpdateCameraInput(Camera camera, in CameraInputState inputState, in TimeInterval gameTime)
         {
             if (inputState.LeftMouseDown && inputState.PressedKeys.Contains(Key.AltLeft) || inputState.MiddleMouseDown)
             {
@@ -222,9 +222,11 @@ namespace OpenSage.Graphics.Cameras
                     _panDirection = CameraPanDirection.None;
                 }
             }
-
             ZoomCamera(-inputState.ScrollWheelValue);
+        }
 
+        void ICameraController.UpdateCamera(Camera camera, in TimeInterval gameTime)
+        {
             if (_animation != null)
             {
                 _animation.Update(this, gameTime);

--- a/src/OpenSage.Game/Gui/Wnd/WndInputMessageHandler.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndInputMessageHandler.cs
@@ -76,10 +76,9 @@ namespace OpenSage.Gui.Wnd
                                 new WndWindowMessage(WndWindowMessageType.MouseMove, control, mousePosition),
                                 context);
                         }
-                        /*return mouseOverControls.Count > 0
+                        return mouseOverControls.Count > 0
                             ? InputMessageResult.Handled
-                            : InputMessageResult.NotHandled;*/
-                        return InputMessageResult.NotHandled;
+                            : InputMessageResult.NotHandled;
                     }
 
                 case InputMessageType.MouseLeftButtonDown:

--- a/src/OpenSage.Game/Gui/Wnd/WndInputMessageHandler.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndInputMessageHandler.cs
@@ -76,9 +76,10 @@ namespace OpenSage.Gui.Wnd
                                 new WndWindowMessage(WndWindowMessageType.MouseMove, control, mousePosition),
                                 context);
                         }
-                        return mouseOverControls.Count > 0
+                        /*return mouseOverControls.Count > 0
                             ? InputMessageResult.Handled
-                            : InputMessageResult.NotHandled;
+                            : InputMessageResult.NotHandled;*/
+                        return InputMessageResult.NotHandled;
                     }
 
                 case InputMessageType.MouseLeftButtonDown:

--- a/src/OpenSage.Game/IPanel.cs
+++ b/src/OpenSage.Game/IPanel.cs
@@ -1,0 +1,9 @@
+using OpenSage.Mathematics;
+
+namespace OpenSage
+{
+    public interface IPanel
+    {
+        public Rectangle Frame { get; }
+    }
+}

--- a/src/OpenSage.Game/Input/Cursors/CursorDirection.cs
+++ b/src/OpenSage.Game/Input/Cursors/CursorDirection.cs
@@ -1,0 +1,14 @@
+namespace OpenSage.Input.Cursors
+{
+    public enum CursorDirection
+    {
+        Right,
+        RightDown,
+        Down,
+        LeftDown,
+        Left,
+        LeftUp,
+        Up,
+        RightUp
+    }
+}

--- a/src/OpenSage.Game/Input/Cursors/CursorManager.cs
+++ b/src/OpenSage.Game/Input/Cursors/CursorManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using OpenSage.Content;
 
@@ -6,7 +7,7 @@ namespace OpenSage.Input.Cursors
 {
     internal sealed class CursorManager : DisposableBase
     {
-        private readonly Dictionary<(string, uint), Cursor> _cachedCursors;
+        private readonly Dictionary<(string, CursorDirection), Cursor> _cachedCursors;
         private Cursor _currentCursor;
 
         private readonly AssetStore _assetStore;
@@ -26,21 +27,137 @@ namespace OpenSage.Input.Cursors
 
         public CursorManager(AssetStore assetStore, ContentManager contentManager, GameWindow window)
         {
-            _cachedCursors = new Dictionary<(string, uint), Cursor>();
+            _cachedCursors = new Dictionary<(string, CursorDirection), Cursor>();
 
             _assetStore = assetStore;
             _contentManager = contentManager;
             _window = window;
         }
 
-        public void SetCursor(string cursorName, in TimeInterval time)
+        private static uint DirectionLayout1(CursorDirection direction)
         {
-            SetCursor(cursorName, 0, time);
+            return 0;
+        }
+        private static uint DirectionLayout2(CursorDirection direction)
+        {
+            return direction switch
+            {
+                CursorDirection.Up => 0,
+                CursorDirection.RightUp => 0,
+                CursorDirection.Right => 0,
+                CursorDirection.RightDown => 0,
+                CursorDirection.Down => 0,
+                CursorDirection.LeftDown => 1,
+                CursorDirection.Left => 1,
+                CursorDirection.LeftUp => 1,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+        private static uint DirectionLayout3(CursorDirection direction)
+        {
+            return direction switch
+            {
+                CursorDirection.RightUp => 0,
+                CursorDirection.Right => 0,
+                CursorDirection.RightDown => 0,
+                CursorDirection.Down => 1,
+                CursorDirection.LeftDown => 1,
+                CursorDirection.Left => 2,
+                CursorDirection.LeftUp => 2,
+                CursorDirection.Up => 2,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+        private static uint DirectionLayout4(CursorDirection direction)
+        {
+            return direction switch
+            {
+                CursorDirection.Right => 0,
+                CursorDirection.RightDown => 1,
+                CursorDirection.Down => 1,
+                CursorDirection.LeftDown => 1,
+                CursorDirection.Left => 2,
+                CursorDirection.LeftUp => 3,
+                CursorDirection.Up => 3,
+                CursorDirection.RightUp => 3,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+        private static uint DirectionLayout5(CursorDirection direction)
+        {
+            return direction switch
+            {
+                CursorDirection.Right => 0,
+                CursorDirection.RightDown => 1,
+                CursorDirection.Down => 1,
+                CursorDirection.LeftDown => 2,
+                CursorDirection.Left => 3,
+                CursorDirection.LeftUp => 3,
+                CursorDirection.Up => 4,
+                CursorDirection.RightUp => 4,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+        private static uint DirectionLayout6(CursorDirection direction)
+        {
+            return direction switch
+            {
+                CursorDirection.Right => 0,
+                CursorDirection.RightDown => 1,
+                CursorDirection.Down => 1,
+                CursorDirection.LeftDown => 2,
+                CursorDirection.Left => 3,
+                CursorDirection.LeftUp => 4,
+                CursorDirection.Up => 5,
+                CursorDirection.RightUp => 5,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+        private static uint DirectionLayout7(CursorDirection direction)
+        {
+            return direction switch
+            {
+                CursorDirection.Right => 0,
+                CursorDirection.RightDown => 1,
+                CursorDirection.Down => 2,
+                CursorDirection.LeftDown => 3,
+                CursorDirection.Left => 4,
+                CursorDirection.LeftUp => 4,
+                CursorDirection.Up => 5,
+                CursorDirection.RightUp => 6,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+        private static uint DirectionLayout8(CursorDirection direction)
+        {
+            return direction switch
+            {
+                CursorDirection.Right => 0,
+                CursorDirection.RightDown => 1,
+                CursorDirection.Down => 2,
+                CursorDirection.LeftDown => 3,
+                CursorDirection.Left => 4,
+                CursorDirection.LeftUp => 5,
+                CursorDirection.Up => 6,
+                CursorDirection.RightUp => 7,
+                _ => throw new ArgumentOutOfRangeException()
+            };
         }
 
-        public void SetCursor(string cursorName, uint direction, in TimeInterval time)
+        private delegate uint DirectionLayoutDelegate(CursorDirection direction);
+        private static readonly DirectionLayoutDelegate[] DirectionLayout = {
+            DirectionLayout1, DirectionLayout2, DirectionLayout3, DirectionLayout4,
+            DirectionLayout5, DirectionLayout6, DirectionLayout7, DirectionLayout8
+        };
+
+        public void SetCursor(string cursorName, in TimeInterval time)
         {
-            (string, uint)key = (cursorName, direction);
+            SetCursor(cursorName, CursorDirection.Right, time);
+        }
+
+        public void SetCursor(string cursorName, CursorDirection direction, in TimeInterval time)
+        {
+            (string, CursorDirection)key = (cursorName, direction);
             if (!_cachedCursors.TryGetValue(key, out var cursor))
             {
                 var mouseCursor = _assetStore.MouseCursors.GetByName(cursorName);
@@ -50,9 +167,10 @@ namespace OpenSage.Input.Cursors
                 }
 
                 var cursorFileName = mouseCursor.Image;
-                if (mouseCursor.Directions != 0)
+                if (mouseCursor.Directions > 0)
                 {
-                    cursorFileName += direction;
+                    int directions = mouseCursor.Directions > 8 ? 8 : mouseCursor.Directions;
+                    cursorFileName += DirectionLayout[directions - 1](direction);
                 }
                 if (string.IsNullOrEmpty(Path.GetExtension(cursorFileName)))
                 {

--- a/src/OpenSage.Game/Input/Cursors/CursorManager.cs
+++ b/src/OpenSage.Game/Input/Cursors/CursorManager.cs
@@ -150,12 +150,7 @@ namespace OpenSage.Input.Cursors
             DirectionLayout5, DirectionLayout6, DirectionLayout7, DirectionLayout8
         };
 
-        public void SetCursor(string cursorName, in TimeInterval time)
-        {
-            SetCursor(cursorName, CursorDirection.Right, time);
-        }
-
-        public void SetCursor(string cursorName, CursorDirection direction, in TimeInterval time)
+        private void SetCursor(string cursorName, CursorDirection direction, in TimeInterval time)
         {
             (string, CursorDirection)key = (cursorName, direction);
             if (!_cachedCursors.TryGetValue(key, out var cursor))
@@ -199,6 +194,21 @@ namespace OpenSage.Input.Cursors
 
             _currentCursor = cursor;
             _currentCursor.Apply(time);
+        }
+
+        public void SetArrowCursor(in TimeInterval time)
+        {
+            SetCursor("Arrow", time);
+        }
+
+        public void SetScrollCursor(CursorDirection direction, in TimeInterval time)
+        {
+            SetCursor("Scroll", direction, time);
+        }
+
+        public void SetCursor(string cursorName, in TimeInterval time)
+        {
+            SetCursor(cursorName, CursorDirection.Right, time);
         }
 
         public void Update(in TimeInterval time)

--- a/src/OpenSage.Game/Logic/OrderGeneratorInputHandler.cs
+++ b/src/OpenSage.Game/Logic/OrderGeneratorInputHandler.cs
@@ -18,6 +18,8 @@ namespace OpenSage.Logic
 
         internal KeyModifiers KeyModifiers => _keyModifiers;
 
+        internal Point2D LastMousePosition { get => _mousePosition; }
+
         public OrderGeneratorInputHandler(OrderGeneratorSystem orderGeneratorSystem)
         {
             _orderGeneratorSystem = orderGeneratorSystem;

--- a/src/OpenSage.Game/Logic/OrderGeneratorInputHandler.cs
+++ b/src/OpenSage.Game/Logic/OrderGeneratorInputHandler.cs
@@ -68,7 +68,7 @@ namespace OpenSage.Logic
                     }
                     break;
 
-                case InputMessageType.MouseRightButtonDown:
+                case InputMessageType.MouseRightButtonUp:
                     // TODO: is this desirable if we don't actually deselect the unit, but simply pan the camera?
                     _orderGeneratorSystem.CancelOrderGenerator();
                     break;

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -363,6 +363,12 @@ namespace OpenSage
             GameObjects.DeleteDestroyed();
         }
 
+        internal void CursorUpdatePosition()
+        {
+            Vector2 pos = _orderGeneratorInputHandler.LastMousePosition.ToVector2();
+            _orderGeneratorSystem.UpdatePosition(pos);
+        }
+
         internal void CursorLogicTick(in TimeInterval gameTime)
         {
             if (_orderGeneratorInputHandler != null)

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -149,7 +149,8 @@ namespace OpenSage
                 ScriptLists = mapScriptLists
             };
 
-            CameraController = new RtsCameraController(game.AssetStore.GameData.Current, Camera, Terrain.HeightMap)
+            CameraController = new RtsCameraController(
+                game.AssetStore.GameData.Current, Camera, Terrain.HeightMap, Game.Panel)
             {
                 TerrainPosition = Terrain.HeightMap.GetPosition(
                     Terrain.HeightMap.Width / 2,

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
@@ -396,7 +396,7 @@ namespace OpenSage
 
             if (CameraEnableInput)
             {
-                CameraController.UpdateCameraInput(Camera, _cameraInputState, gameTime);
+                CameraController.UpdateInput(_cameraInputState, gameTime);
             }
             CameraController.UpdateCamera(Camera, gameTime);
             

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -361,6 +361,13 @@ namespace OpenSage
             GameObjects.DeleteDestroyed();
         }
 
+        internal void CursorLogicTick(in TimeInterval gameTime)
+        {
+            if (_orderGeneratorInputHandler != null)
+            {
+                _orderGeneratorSystem.Update(gameTime, _orderGeneratorInputHandler.KeyModifiers);
+            }
+        }
         internal void LocalLogicTick(in TimeInterval gameTime, float tickT)
         {
             _orderGeneratorInputHandler?.Update();
@@ -374,11 +381,6 @@ namespace OpenSage
             CameraController.UpdateCamera(Camera, _cameraInputState, gameTime);
 
             DebugOverlay.Update(gameTime);
-
-            if (_orderGeneratorInputHandler != null)
-            {
-                _orderGeneratorSystem.Update(gameTime, _orderGeneratorInputHandler.KeyModifiers);
-            }
 
             Terrain?.Update(Waters, gameTime);
 

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -108,6 +108,20 @@ namespace OpenSage
 
         public readonly RenderScene RenderScene;
 
+        private bool _cameraEnableInput;
+        public bool CameraEnableInput
+        { 
+            get => _cameraEnableInput;
+            set
+            {
+                if (value && !_cameraEnableInput)
+                {
+                    _cameraInputMessageHandler.ResetMouse(Game.Panel);
+                }
+                _cameraEnableInput = value;
+            }
+        }
+
         internal Scene3D(
             Game game,
             MapFile mapFile,
@@ -379,7 +393,13 @@ namespace OpenSage
             }
 
             _cameraInputMessageHandler?.UpdateInputState(ref _cameraInputState);
-            CameraController.UpdateCamera(Camera, _cameraInputState, gameTime);
+
+            if (CameraEnableInput)
+            {
+                CameraController.UpdateCameraInput(Camera, _cameraInputState, gameTime);
+            }
+            CameraController.UpdateCamera(Camera, gameTime);
+            
 
             DebugOverlay.Update(gameTime);
 

--- a/src/OpenSage.Game/Terrain/HeightMap.cs
+++ b/src/OpenSage.Game/Terrain/HeightMap.cs
@@ -6,7 +6,7 @@ using OpenSage.Mathematics;
 
 namespace OpenSage.Terrain
 {
-    public sealed class HeightMap
+    public sealed class HeightMap : IHeightMap
     {
         internal const int HorizontalScale = 10;
 

--- a/src/OpenSage.Game/Terrain/IHeightMap.cs
+++ b/src/OpenSage.Game/Terrain/IHeightMap.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace OpenSage.Terrain
+{
+    public interface IHeightMap
+    {
+        public float GetHeight(float x, float y);
+        public int MaxXCoordinate { get; }
+        public int MaxYCoordinate { get; }
+    }
+}

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -253,6 +253,7 @@ namespace OpenSage.Launcher
                     else
                     {
                         game.Update(window.MessageQueue);
+                        game.CursorLogicTick();
 
                         game.Panel.EnsureFrame(window.ClientBounds);
 

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -252,7 +252,7 @@ namespace OpenSage.Launcher
                     }
                     else
                     {
-                        game.Scene3D.CameraEnableInput = true;
+                        game.Scene3D.CameraSystem.EnableInput = true;
                         game.Update(window.MessageQueue);
                         game.CursorLogicTick();
 

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -252,6 +252,7 @@ namespace OpenSage.Launcher
                     }
                     else
                     {
+                        game.Scene3D.CameraEnableInput = true;
                         game.Update(window.MessageQueue);
                         game.CursorLogicTick();
 


### PR DESCRIPTION
Show scroll cursors when camera is moving by mouse or keyboard.  Also fix some other camera and mouse cursor issues:
1. Reset mouse cursor to arrow, when game is unfocused in developer mode
2. Reduce RMB camera movement speed
3. Allow camera moving by hovering mouse cursor at window border