### PR TITLE
Hide supply box bones as supplies are depleted

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Draw/W3dSupplyDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dSupplyDraw.cs
@@ -1,13 +1,39 @@
-﻿using OpenSage.Client;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenSage.Client;
 using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
     public sealed class W3dSupplyDraw : W3dModelDraw
     {
+        private readonly Dictionary<string, int> _boxBoneMap;
+        private readonly string _bonePrefix;
+
         internal W3dSupplyDraw(W3dSupplyDrawModuleData data, Drawable drawable, GameContext context)
             : base(data, drawable, context)
         {
+            _bonePrefix = data.SupplyBonePrefix;
+            _boxBoneMap = string.IsNullOrEmpty(data.SupplyBonePrefix)
+                ? new Dictionary<string, int>()
+                : ActiveModelInstance.Model.BoneHierarchy.Bones.Where(b => b.Name.StartsWith(data.SupplyBonePrefix))
+                    .ToDictionary(b => b.Name, b => b.Index);
+        }
+
+        public void SetBoxesRemaining(float boxPercentage)
+        {
+            var totalBones = _boxBoneMap.Count;
+
+            // use ceiling so we don't hide all the boxes when there are still supplies left
+            var boxesRemaining = (int) Math.Ceiling(totalBones * boxPercentage);
+            for (var i = totalBones; i > boxesRemaining; i--)
+            {
+                if (_boxBoneMap.TryGetValue($"{_bonePrefix}{i:00}", out var boneIndex))
+                {
+                    ActiveModelInstance.BoneVisibilities[boneIndex] = false;
+                }
+            }
         }
 
         internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Update/SupplyWarehouseDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SupplyWarehouseDockUpdate.cs
@@ -1,4 +1,5 @@
-﻿using OpenSage.Data.Ini;
+﻿using System.Linq;
+using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
@@ -7,12 +8,14 @@ namespace OpenSage.Logic.Object
         private GameObject _gameObject;
         private SupplyWarehouseDockUpdateModuleData _moduleData;
         private int _currentBoxes;
+        private readonly W3dSupplyDraw _supplyDraw;
 
         internal SupplyWarehouseDockUpdate(GameObject gameObject, SupplyWarehouseDockUpdateModuleData moduleData) : base(gameObject, moduleData)
         {
             _gameObject = gameObject;
             _moduleData = moduleData;
             _currentBoxes = _moduleData.StartingBoxes;
+            _supplyDraw = _gameObject.Drawable.DrawModules.OfType<W3dSupplyDraw>().Single(); // unsure if there is ever more or less than one
         }
 
         public bool HasBoxes() => _currentBoxes > 0;
@@ -22,6 +25,10 @@ namespace OpenSage.Logic.Object
             if (_currentBoxes > 0)
             {
                 _currentBoxes--;
+
+                var boxPercentage = (float)_currentBoxes / _moduleData.StartingBoxes;
+                _supplyDraw.SetBoxesRemaining(boxPercentage);
+
                 return true;
             }
             return false;


### PR DESCRIPTION
Fixes #682 

Tested in Generals and seems to work for supply docks as well as supply piles.