### PR TITLE
Disable DOZER_CONSTRUCT commands while dozer is building

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAIUpdate.cs
@@ -6,6 +6,8 @@ namespace OpenSage.Logic.Object
 {
     public sealed class DozerAIUpdate : AIUpdate, IBuilderAIUpdate
     {
+        public bool HasBuildTarget => _buildTarget != null;
+
         private readonly DozerAndWorkerState _state = new();
 
         private GameObject _buildTarget;

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/IBuilderAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/IBuilderAIUpdate.cs
@@ -7,8 +7,9 @@
     /// This interface is implemented by <see cref="DozerAIUpdate"/> and <see cref="WorkerAIUpdate"/>, since the GLA
     /// worker is also a supply unit.
     /// </remarks>
-    internal interface IBuilderAIUpdate
+    public interface IBuilderAIUpdate
     {
         void SetBuildTarget(GameObject gameObject);
+        bool HasBuildTarget { get; }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
@@ -8,6 +8,8 @@ namespace OpenSage.Logic.Object
 {
     public class WorkerAIUpdate : SupplyAIUpdate, IBuilderAIUpdate
     {
+        public bool HasBuildTarget => _buildTarget != null;
+
         private WorkerAIUpdateModuleData _moduleData;
         private GameObject _buildTarget;
 

--- a/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
@@ -318,6 +318,10 @@ namespace OpenSage.Mods.Generals.Gui
                         {
                             // Disable the button when the unit is not produceable
                             case CommandType.DozerConstruct:
+                                var isBuilding = selectedUnit.IsKindOf(ObjectKinds.Dozer) && (selectedUnit.AIUpdate as IBuilderAIUpdate)?.HasBuildTarget == true; // todo: can we remove this cast in the future?
+                                buttonControl.Enabled = selectedUnit.CanConstructUnit(objectDefinition) && !isBuilding;
+                                buttonControl.Show();
+                                break;
                             case CommandType.UnitBuild:
                                 buttonControl.Enabled = selectedUnit.CanConstructUnit(objectDefinition);
                                 buttonControl.Show();


### PR DESCRIPTION
Fixes #694 

This is the second place I've written a kindof check followed by an AIUpdate cast. Not sure if this is something that will become more common and we should consider ways to get more discrete GameObject types?