### PR TITLE
Respect RequireStatus and ExemptStatus in die behaviors

### DIFF
--- a/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
+++ b/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
@@ -9,7 +9,7 @@ namespace OpenSage.Logic.Object
     {
         internal virtual void Update(BehaviorUpdateContext context) { }
 
-        internal virtual void OnDie(BehaviorUpdateContext context, DeathType deathType) { }
+        internal virtual void OnDie(BehaviorUpdateContext context, DeathType deathType, ObjectStatus? status) { }
 
         internal virtual void OnDamageStateChanged(BehaviorUpdateContext context, BodyDamageType fromDamage, BodyDamageType toDamage) { }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/InstantDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/InstantDeathBehavior.cs
@@ -5,13 +5,15 @@ using OpenSage.FX;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class InstantDeathBehavior : DieModule<InstantDeathBehaviorModuleData>
+    public sealed class InstantDeathBehavior : DieModule
     {
         private readonly GameObject _gameObject;
+        private new InstantDeathBehaviorModuleData ModuleData { get; }
 
         internal InstantDeathBehavior(GameObject gameObject, InstantDeathBehaviorModuleData moduleData) : base(moduleData)
         {
             _gameObject = gameObject;
+            ModuleData = moduleData;
         }
 
         private protected override void Die(BehaviorUpdateContext context, DeathType deathType)

--- a/src/OpenSage.Game/Logic/Object/Behaviors/InstantDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/InstantDeathBehavior.cs
@@ -45,7 +45,7 @@ namespace OpenSage.Logic.Object
     {
         internal static InstantDeathBehaviorModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
 
-        private static readonly IniParseTable<InstantDeathBehaviorModuleData> FieldParseTable = DieModuleData.FieldParseTable
+        private static new readonly IniParseTable<InstantDeathBehaviorModuleData> FieldParseTable = DieModuleData.FieldParseTable
             .Concat(new IniParseTable<InstantDeathBehaviorModuleData>
             {
                 { "FX", (parser, x) => x.FX = parser.ParseFXListReference() },

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
@@ -33,11 +33,22 @@ namespace OpenSage.Logic.Object
             _moduleData = moduleData;
         }
 
-        internal bool IsApplicable(DeathType deathType) => _moduleData.DeathTypes?.Get(deathType) ?? true;
+        internal bool IsApplicable(DeathType deathType, ObjectStatus? status) =>
+            (_moduleData.DeathTypes?.Get(deathType) ?? true) && IsCorrectStatus(status);
 
-        internal override void OnDie(BehaviorUpdateContext context, DeathType deathType)
+        private bool IsCorrectStatus(ObjectStatus? status)
         {
-            if (!IsApplicable(deathType))
+            var required = !_moduleData.RequiredStatus.AnyBitSet || // if nothing is required, we pass
+                                (status.HasValue && _moduleData.RequiredStatus.Get(status.Value)); // or if we are the one of the required statuses, we pass
+            var notExempt = !_moduleData.ExemptStatus.AnyBitSet || // if nothing is exempt, we pass
+                                !status.HasValue || // if we don't have a status, we can't be exempt, so we pass
+                                !_moduleData.ExemptStatus.Get(status.Value); // or if we are not one of the exempt statuses, we pass
+            return required && notExempt;
+        }
+
+        internal override void OnDie(BehaviorUpdateContext context, DeathType deathType, ObjectStatus? status)
+        {
+            if (!IsApplicable(deathType, status))
             {
                 return;
             }

--- a/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
@@ -3,9 +3,12 @@ using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class CreateCrateDie : DieModule
+    public sealed class CreateCrateDie : DieModule<CreateCrateDieModuleData>
     {
         // TODO
+        public CreateCrateDie(CreateCrateDieModuleData moduleData) : base(moduleData)
+        {
+        }
 
         internal override void Load(StatePersister reader)
         {
@@ -28,10 +31,5 @@ namespace OpenSage.Logic.Object
             });
 
         public LazyAssetReference<CrateData> CrateData { get; private set; }
-
-        internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
-        {
-            return new CreateCrateDie();
-        }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
@@ -3,7 +3,7 @@ using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class CreateCrateDie : DieModule<CreateCrateDieModuleData>
+    public sealed class CreateCrateDie : DieModule
     {
         // TODO
         public CreateCrateDie(CreateCrateDieModuleData moduleData) : base(moduleData)

--- a/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
@@ -1,12 +1,15 @@
-using OpenSage.Content;
+﻿using OpenSage.Content;
 using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class CreateObjectDie : DieModule<CreateObjectDieModuleData>
+    public sealed class CreateObjectDie : DieModule
     {
+        private new CreateObjectDieModuleData ModuleData { get; }
+
         internal CreateObjectDie(CreateObjectDieModuleData moduleData) : base(moduleData)
         {
+            ModuleData = moduleData;
         }
 
         private protected override void Die(BehaviorUpdateContext context, DeathType deathType)

--- a/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
@@ -1,20 +1,17 @@
-﻿using OpenSage.Content;
+using OpenSage.Content;
 using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class CreateObjectDie : DieModule
+    public sealed class CreateObjectDie : DieModule<CreateObjectDieModuleData>
     {
-        private readonly CreateObjectDieModuleData _moduleData;
-
-        internal CreateObjectDie(CreateObjectDieModuleData moduleData)
+        internal CreateObjectDie(CreateObjectDieModuleData moduleData) : base(moduleData)
         {
-            _moduleData = moduleData;
         }
 
-        internal override void OnDie(BehaviorUpdateContext context, DeathType deathType)
+        private protected override void Die(BehaviorUpdateContext context, DeathType deathType)
         {
-            context.GameContext.ObjectCreationLists.Create(_moduleData.CreationList.Value, context);
+            context.GameContext.ObjectCreationLists.Create(ModuleData.CreationList.Value, context);
         }
 
         internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Die/CrushDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CrushDie.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class CrushDie : DieModule<CrushDieModuleData>
+    public sealed class CrushDie : DieModule
     {
         public CrushDie(CrushDieModuleData moduleData) : base(moduleData)
         {

--- a/src/OpenSage.Game/Logic/Object/Die/CrushDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CrushDie.cs
@@ -2,8 +2,12 @@
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class CrushDie : DieModule
+    public sealed class CrushDie : DieModule<CrushDieModuleData>
     {
+        public CrushDie(CrushDieModuleData moduleData) : base(moduleData)
+        {
+        }
+
         internal override void Load(StatePersister reader)
         {
             reader.PersistVersion(1);
@@ -31,17 +35,12 @@ namespace OpenSage.Logic.Object
                 { "BackEndCrushSoundPercent", (parser, x) => x.BackEndCrushSoundPercent = parser.ParseInteger() },
                 { "FrontEndCrushSoundPercent", (parser, x) => x.FrontEndCrushSoundPercent = parser.ParseInteger() }
             });
-        
+
         public string TotalCrushSound { get; private set; }
         public string BackEndCrushSound { get; private set; }
         public string FrontEndCrushSound { get; private set; }
         public int TotalCrushSoundPercent { get; private set; }
         public int BackEndCrushSoundPercent { get; private set; }
         public int FrontEndCrushSoundPercent { get; private set; }
-
-        internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
-        {
-            return new CrushDie();
-        }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/DamDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DamDie.cs
@@ -2,9 +2,12 @@
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class DamDie : DieModule
+    public sealed class DamDie : DieModule<DamDieModuleData>
     {
         // TODO
+        public DamDie(DamDieModuleData moduleData) : base(moduleData)
+        {
+        }
 
         internal override void Load(StatePersister reader)
         {
@@ -17,7 +20,7 @@ namespace OpenSage.Logic.Object
     }
 
     /// <summary>
-    /// Allows object to continue to exist as an obstacle but allowing water terrain to move 
+    /// Allows object to continue to exist as an obstacle but allowing water terrain to move
     /// through. The module must be applied after any other death modules.
     /// </summary>
     public sealed class DamDieModuleData : DieModuleData
@@ -26,10 +29,5 @@ namespace OpenSage.Logic.Object
 
         private static new readonly IniParseTable<DamDieModuleData> FieldParseTable = DieModuleData.FieldParseTable
             .Concat(new IniParseTable<DamDieModuleData>());
-
-        internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
-        {
-            return new DamDie();
-        }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/DamDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DamDie.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class DamDie : DieModule<DamDieModuleData>
+    public sealed class DamDie : DieModule
     {
         // TODO
         public DamDie(DamDieModuleData moduleData) : base(moduleData)

--- a/src/OpenSage.Game/Logic/Object/Die/DestroyDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DestroyDie.cs
@@ -2,18 +2,16 @@
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class DestroyDie : DieModule
+    public sealed class DestroyDie : DieModule<DestroyDieModuleData>
     {
         private readonly GameObject _gameObject;
-        private readonly DestroyDieModuleData _moduleData;
 
-        internal DestroyDie(GameObject gameObject, DestroyDieModuleData moduleData)
+        internal DestroyDie(GameObject gameObject, DestroyDieModuleData moduleData) : base(moduleData)
         {
             _gameObject = gameObject;
-            _moduleData = moduleData;
         }
 
-        internal override void OnDie(BehaviorUpdateContext context, DeathType deathType)
+        private protected override void Die(BehaviorUpdateContext context, DeathType deathType)
         {
             context.GameContext.GameObjects.DestroyObject(_gameObject);
         }

--- a/src/OpenSage.Game/Logic/Object/Die/DestroyDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DestroyDie.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class DestroyDie : DieModule<DestroyDieModuleData>
+    public sealed class DestroyDie : DieModule
     {
         private readonly GameObject _gameObject;
 

--- a/src/OpenSage.Game/Logic/Object/Die/DieModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DieModule.cs
@@ -3,11 +3,11 @@ using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
-    public abstract class DieModule<T> : BehaviorModule where T : DieModuleData
+    public abstract class DieModule : BehaviorModule
     {
-        protected T ModuleData { get; }
+        protected DieModuleData ModuleData { get; }
 
-        protected DieModule(T moduleData)
+        protected DieModule(DieModuleData moduleData)
         {
             ModuleData = moduleData;
         }

--- a/src/OpenSage.Game/Logic/Object/Die/DieModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DieModule.cs
@@ -3,8 +3,15 @@ using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
-    public abstract class DieModule : BehaviorModule
+    public abstract class DieModule<T> : BehaviorModule where T : DieModuleData
     {
+        protected T ModuleData { get; }
+
+        protected DieModule(T moduleData)
+        {
+            ModuleData = moduleData;
+        }
+
         internal override void Load(StatePersister reader)
         {
             reader.PersistVersion(1);
@@ -13,6 +20,28 @@ namespace OpenSage.Logic.Object
             base.Load(reader);
             reader.EndObject();
         }
+
+        internal sealed override void OnDie(BehaviorUpdateContext context, DeathType deathType, ObjectStatus? status)
+        {
+            if (!IsCorrectStatus(status))
+            {
+                return;
+            }
+
+            Die(context, deathType);
+        }
+
+        private bool IsCorrectStatus(ObjectStatus? status)
+        {
+            var required = !ModuleData.RequiredStatus.HasValue || // if nothing is required, we pass
+                                (status.HasValue && ModuleData.RequiredStatus == status); // or if we are the one of the required statuses, we pass
+            var notExempt = !ModuleData.ExemptStatus.HasValue || // if nothing is exempt, we pass
+                                !status.HasValue || // if we don't have a status, we can't be exempt, so we pass
+                                ModuleData.ExemptStatus != status.Value; // or if we are not one of the exempt statuses, we pass
+            return required && notExempt;
+        }
+
+        private protected virtual void Die(BehaviorUpdateContext context, DeathType deathType) { }
     }
 
     public abstract class DieModuleData : BehaviorModuleData
@@ -29,7 +58,7 @@ namespace OpenSage.Logic.Object
 
         public BitArray<VeterancyLevel> VeterancyLevels { get; private set; }
         public BitArray<DeathType> DeathTypes { get; private set; }
-        public ObjectStatus ExemptStatus { get; private set; }
-        public ObjectStatus RequiredStatus { get; private set; }
+        public ObjectStatus? ExemptStatus { get; private set; }
+        public ObjectStatus? RequiredStatus { get; private set; }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/EjectPilotDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/EjectPilotDie.cs
@@ -3,7 +3,7 @@ using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class EjectPilotDie : DieModule<EjectPilotDieModuleData>
+    public sealed class EjectPilotDie : DieModule
     {
         // TODO
         public EjectPilotDie(EjectPilotDieModuleData moduleData) : base(moduleData)

--- a/src/OpenSage.Game/Logic/Object/Die/EjectPilotDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/EjectPilotDie.cs
@@ -3,9 +3,12 @@ using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class EjectPilotDie : DieModule
+    public sealed class EjectPilotDie : DieModule<EjectPilotDieModuleData>
     {
         // TODO
+        public EjectPilotDie(EjectPilotDieModuleData moduleData) : base(moduleData)
+        {
+        }
 
         internal override void Load(StatePersister reader)
         {
@@ -33,10 +36,5 @@ namespace OpenSage.Logic.Object
 
         public LazyAssetReference<ObjectCreationList> GroundCreationList { get; private set; }
         public LazyAssetReference<ObjectCreationList> AirCreationList { get; private set; }
-
-        internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
-        {
-            return new EjectPilotDie();
-        }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/FXListDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/FXListDie.cs
@@ -4,10 +4,13 @@ using OpenSage.FX;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class FXListDie : DieModule<FXListDieModuleData>
+    public sealed class FXListDie : DieModule
     {
+        private new FXListDieModuleData ModuleData { get; }
+
         internal FXListDie(FXListDieModuleData moduleData) : base(moduleData)
         {
+            ModuleData = moduleData;
         }
 
         private protected override void Die(BehaviorUpdateContext context, DeathType deathType)

--- a/src/OpenSage.Game/Logic/Object/Die/FXListDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/FXListDie.cs
@@ -4,18 +4,15 @@ using OpenSage.FX;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class FXListDie : DieModule
+    public sealed class FXListDie : DieModule<FXListDieModuleData>
     {
-        private readonly FXListDieModuleData _moduleData;
-
-        internal FXListDie(FXListDieModuleData moduleData)
+        internal FXListDie(FXListDieModuleData moduleData) : base(moduleData)
         {
-            _moduleData = moduleData;
         }
 
-        internal override void OnDie(BehaviorUpdateContext context, DeathType deathType)
+        private protected override void Die(BehaviorUpdateContext context, DeathType deathType)
         {
-            _moduleData.DeathFX.Value.Execute(new FXListExecutionContext(
+            ModuleData.DeathFX.Value.Execute(new FXListExecutionContext(
                 context.GameObject.Rotation,
                 context.GameObject.Translation,
                 context.GameContext));

--- a/src/OpenSage.Game/Logic/Object/Die/KeepObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/KeepObjectDie.cs
@@ -2,8 +2,12 @@
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class KeepObjectDie : DieModule
+    public sealed class KeepObjectDie : DieModule<KeepObjectDieModuleData>
     {
+        public KeepObjectDie(KeepObjectDieModuleData moduleData) : base(moduleData)
+        {
+        }
+
         internal override void Load(StatePersister reader)
         {
             reader.PersistVersion(1);
@@ -30,10 +34,5 @@ namespace OpenSage.Logic.Object
 
         [AddedIn(SageGame.Bfme2)]
         public bool StayOnRadar { get; private set; }
-
-        internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
-        {
-            return new KeepObjectDie();
-        }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/KeepObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/KeepObjectDie.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class KeepObjectDie : DieModule<KeepObjectDieModuleData>
+    public sealed class KeepObjectDie : DieModule
     {
         public KeepObjectDie(KeepObjectDieModuleData moduleData) : base(moduleData)
         {

--- a/src/OpenSage.Game/Logic/Object/Die/RebuildHoleExposeDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/RebuildHoleExposeDie.cs
@@ -2,8 +2,12 @@
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class RebuildHoleExposeDie : DieModule
+    public sealed class RebuildHoleExposeDie : DieModule<RebuildHoleExposeDieModuleData>
     {
+        public RebuildHoleExposeDie(RebuildHoleExposeDieModuleData moduleData) : base(moduleData)
+        {
+        }
+
         internal override void Load(StatePersister reader)
         {
             reader.PersistVersion(1);
@@ -15,7 +19,7 @@ namespace OpenSage.Logic.Object
     }
 
     /// <summary>
-    /// Requires the object specified in <see cref="HoleName"/> to have the REBUILD_HOLE KindOf and 
+    /// Requires the object specified in <see cref="HoleName"/> to have the REBUILD_HOLE KindOf and
     /// <see cref="RebuildHoleBehaviorModuleData"/> module in order to work.
     /// </summary>
     public sealed class RebuildHoleExposeDieModuleData : DieModuleData
@@ -39,10 +43,5 @@ namespace OpenSage.Logic.Object
 
         [AddedIn(SageGame.Bfme2)]
         public bool TransferAttackers { get; private set; }
-
-        internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
-        {
-            return new RebuildHoleExposeDie();
-        }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/RebuildHoleExposeDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/RebuildHoleExposeDie.cs
@@ -2,7 +2,7 @@
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class RebuildHoleExposeDie : DieModule<RebuildHoleExposeDieModuleData>
+    public sealed class RebuildHoleExposeDie : DieModule
     {
         public RebuildHoleExposeDie(RebuildHoleExposeDieModuleData moduleData) : base(moduleData)
         {

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -193,6 +193,9 @@ namespace OpenSage.Logic.Object
         private byte _weaponSomethingTertiary;
         private BitArray<SpecialPowerType> _specialPowers = new();
 
+        // todo: is this one of the unknown fields above?
+        private ObjectStatus? _status;
+
         public Transform Transform => _transform;
         public float Yaw => _transform.Yaw;
         public Vector3 EulerAngles => _transform.EulerAngles;
@@ -852,6 +855,8 @@ namespace OpenSage.Logic.Object
                 ModelConditionFlags.Set(ModelConditionFlag.ActivelyBeingConstructed, false);
                 ModelConditionFlags.Set(ModelConditionFlag.AwaitingConstruction, true);
                 ModelConditionFlags.Set(ModelConditionFlag.PartiallyConstructed, false);
+
+                _status = ObjectStatus.UnderConstruction;
             }
         }
 
@@ -882,6 +887,12 @@ namespace OpenSage.Logic.Object
         internal void FinishConstruction()
         {
             ClearModelConditionFlags();
+
+            if (_status == ObjectStatus.UnderConstruction)
+            {
+                _status = null;
+            }
+
             EnergyProduction += Definition.EnergyProduction;
 
             foreach (var module in FindBehaviors<ICreateModule>())
@@ -1159,7 +1170,7 @@ namespace OpenSage.Logic.Object
                 // If there are multiple SlowDeathBehavior modules,
                 // we need to use ProbabilityModifier to choose between them.
                 var slowDeathBehaviors = FindBehaviors<SlowDeathBehavior>()
-                    .Where(x => x.IsApplicable(deathType))
+                    .Where(x => x.IsApplicable(deathType, _status))
                     .ToList();
                 if (slowDeathBehaviors.Count > 1)
                 {
@@ -1171,7 +1182,7 @@ namespace OpenSage.Logic.Object
                         cumulative += deathBehavior.ProbabilityModifier;
                         if (random < cumulative)
                         {
-                            deathBehavior.OnDie(_behaviorUpdateContext, deathType);
+                            deathBehavior.OnDie(_behaviorUpdateContext, deathType, _status);
                             return;
                         }
                     }
@@ -1183,7 +1194,7 @@ namespace OpenSage.Logic.Object
 
             foreach (var module in _behaviorModules)
             {
-                module.OnDie(_behaviorUpdateContext, deathType);
+                module.OnDie(_behaviorUpdateContext, deathType, _status);
             }
         }
 


### PR DESCRIPTION
This utilizes the `RequiredStatus` and `ExemptStatus` fields in the die behaviors which have at least partial implementations. It does not implement those fields in other behaviors (die or otherwise) which do not have implementations.

- `IsCorrectStatus` is defined in two separate places in this PR. I opted not to extract it out further as I don't know how the other non-die behaviors will use it (if at all). There are currently two other non-die behaviors that have these object status properties to my knowledge (`FireWeaponWhenDeadBehavior` and `FireWeaponCollide`).
- This adds an `ObjectStatus` field to `GameObject`, but does not persist it in any way. I _assume_ one of the unknown fields is this (how else would you persist whether a vehicle has been hijacked?), but I'm not sure. The other Generals/ZH ObjectStatus values all have equivalents in `ModelConditionFlag` (though `UNDER_CONSTRUCTION` would be computed based on one of a few condition flags) - is it possible we're missing one? I tried to load a save file to inspect it, but it seems save file loading is broken at the moment.

At any rate, this results in no rangers spawned when building construction is canceled.