### PR TITLE
Play VoiceCreate sound when unit is produced

### DIFF
--- a/src/OpenSage.Game/Logic/Object/UnitSpecificSounds.cs
+++ b/src/OpenSage.Game/Logic/Object/UnitSpecificSounds.cs
@@ -19,6 +19,11 @@ namespace OpenSage.Logic.Object
 
     public sealed class UnitSpecificSounds : Dictionary<string, LazyAssetReference<BaseAudioEventInfo>>
     {
+        /// <summary>
+        /// The sound played when a unit is produced
+        /// </summary>
+        public LazyAssetReference<BaseAudioEventInfo>? VoiceCreate => TryGetValue("VoiceCreate", out var sound) ? sound : null;
+
         internal static UnitSpecificSounds Parse(IniParser parser)
         {
             return parser.ParseBlock(new IniArbitraryFieldParserProvider<UnitSpecificSounds>(

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -71,7 +71,7 @@ namespace OpenSage.Logic.Object
                     _currentDoorState = DoorState.Open;
 
                     GetDoorConditionFlags(out var doorOpening, out var doorWaitingOpen, out var _);
-                   
+
                     _gameObject.ModelConditionFlags.Set(doorOpening, false);
                     _gameObject.ModelConditionFlags.Set(doorWaitingOpen, true);
                     MoveProducedObjectOut();
@@ -281,6 +281,8 @@ namespace OpenSage.Logic.Object
             _producedUnit = _gameObject.GameContext.GameLogic.CreateObject(objectDefinition, _gameObject.Owner);
             _producedUnit.Owner = _gameObject.Owner;
             _producedUnit.ParentHorde = ParentHorde;
+
+            _producedUnit.GameContext.Scene3D.Audio.PlayAudioEvent(_producedUnit, _producedUnit.Definition.UnitSpecificSounds?.VoiceCreate?.Value);
 
             if (!_moduleData.GiveNoXP)
             {
@@ -518,7 +520,7 @@ namespace OpenSage.Logic.Object
     }
 
     /// <summary>
-    /// Required on an object that uses PublicTimer code for any SpecialPower and/or required for 
+    /// Required on an object that uses PublicTimer code for any SpecialPower and/or required for
     /// units/structures with object upgrades.
     /// </summary>
     public sealed class ProductionUpdateModuleData : UpdateModuleData

--- a/src/OpenSage.Game/Logic/OrderGenerators/ConstructBuildingOrderGenerator.cs
+++ b/src/OpenSage.Game/Logic/OrderGenerators/ConstructBuildingOrderGenerator.cs
@@ -98,7 +98,7 @@ namespace OpenSage.Logic.OrderGenerators
                 return OrderGeneratorResult.Failure("Not enough cash for construction");
             }
 
-            scene.Audio.PlayAudioEvent(dozer, dozer.Definition.UnitSpecificSounds?["VoiceCreate"]?.Value);
+            scene.Audio.PlayAudioEvent(dozer, dozer.Definition.UnitSpecificSounds?["VoiceBuildResponse"]?.Value);
 
             var playerIdx = scene.GetPlayerIndex(player);
             var moveOrder = Order.CreateMoveOrder(playerIdx, _position);


### PR DESCRIPTION
This also fixes a small bug where dozers would play the `VoiceCreate` sound when building something, when they instead should be playing the `VoiceBuildResponse` sound.