### PR TITLE
Bump LiteNetLib from 1.1.0 to 1.2.0

### DIFF
--- a/src/OpenSage.Game/Network/NetworkConnection.cs
+++ b/src/OpenSage.Game/Network/NetworkConnection.cs
@@ -90,7 +90,7 @@ namespace OpenSage.Network
             {
                 if (peer != sender)
                 {
-                    Logger.Trace($"  Redistributing to {peer.EndPoint}");
+                    Logger.Trace($"  Redistributing to {peer}");
                     peer.Send(_writer, DeliveryMethod.ReliableUnordered);
                 }
             }
@@ -122,12 +122,12 @@ namespace OpenSage.Network
                 _manager.DisconnectTimeout = 600000;
             }
 
-            _listener.PeerConnectedEvent += peer => Logger.Trace($"{peer.EndPoint} connected");
-            _listener.PeerDisconnectedEvent += (peer, info) => Logger.Trace($"{peer.EndPoint} disconnected with reason {info.Reason}");
+            _listener.PeerConnectedEvent += peer => Logger.Trace($"{peer} connected");
+            _listener.PeerDisconnectedEvent += (peer, info) => Logger.Trace($"{peer} disconnected with reason {info.Reason}");
             _listener.NetworkReceiveEvent += (NetPeer peer, NetPacketReader reader, byte channel, DeliveryMethod deliveryMethod) => _processor.ReadAllPackets(reader, peer);
 
             _writer = new NetDataWriter();
-            _processor = new NetPacketProcessor();            
+            _processor = new NetPacketProcessor();
             _processor.RegisterNestedType<Order>(WriteOrder, ReadOrder);
             _processor.Subscribe<SkirmishOrderPacket, NetPeer>(ReceiveOrderPacket, () => new SkirmishOrderPacket());
         }
@@ -136,7 +136,7 @@ namespace OpenSage.Network
 
         private void ReceiveOrderPacket(SkirmishOrderPacket packet, NetPeer sender)
         {
-            Logger.Trace($"Received packet for frame {packet.Frame} from {sender.EndPoint}");
+            Logger.Trace($"Received packet for frame {packet.Frame} from {sender}");
             ProcessOrderPacket(packet, sender);
         }
 

--- a/src/OpenSage.Game/OpenSage.Game.csproj
+++ b/src/OpenSage.Game/OpenSage.Game.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="FixedMath.NET" Version="1.0.1" />
     <PackageReference Include="ImGui.NET" Version="1.89.5" />
-    <PackageReference Include="LiteNetLib" Version="1.1.0" />
+    <PackageReference Include="LiteNetLib" Version="1.2.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="MoonSharp" Version="2.0.0" />
     <PackageReference Include="Open.NAT.Core" Version="2.1.0.5" />


### PR DESCRIPTION
`NetPeer.EndPoint` [was removed](https://github.com/RevenantX/LiteNetLib/commit/f7be6d5c5bd5e2f8065d1dbdbaaceaf9ce9c7172#diff-69e59952dff5ea4e78ec35e49c73f8cf93fce65884a02590f56dd656e31149a8) and `NetPeer` now inherits `IPEndPoint`, so this just effectively removes `.EndPoint` everywhere.

Supercedes #759