### PR TITLE
Show veterancy overlays in control bar

### DIFF
--- a/src/OpenSage.Game/Gui/Wnd/Controls/Control.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Controls/Control.cs
@@ -159,6 +159,20 @@ namespace OpenSage.Gui.Wnd.Controls
             }
         }
 
+        private Image _overlayImage;
+        /// <summary>
+        /// Drawn on top of <see cref="BackgroundImage"/>
+        /// </summary>
+        public Image OverlayImage
+        {
+            get => _overlayImage;
+            set
+            {
+                _overlayImage = value;
+                InvalidateLayout();
+            }
+        }
+
         private Image _hoverBackgroundImage;
         public Image HoverBackgroundImage
         {
@@ -305,6 +319,7 @@ namespace OpenSage.Gui.Wnd.Controls
             if (_needsLayout)
             {
                 BackgroundImage?.SetSize(ClientSize);
+                OverlayImage?.SetSize(ClientSize);
                 HoverBackgroundImage?.SetSize(ClientSize);
                 DisabledBackgroundImage?.SetSize(ClientSize);
 
@@ -334,6 +349,7 @@ namespace OpenSage.Gui.Wnd.Controls
 
             DrawBackground(drawingContext);
             DrawBackgroundImage(drawingContext);
+            DrawOverlayImage(drawingContext);
             DrawOverride(drawingContext);
             DrawBorder(drawingContext);
             DrawOverlay(drawingContext);
@@ -382,6 +398,11 @@ namespace OpenSage.Gui.Wnd.Controls
             {
                 image.Draw(drawingContext, ClientRectangle);
             }
+        }
+
+        protected virtual void DrawOverlayImage(DrawingContext2D drawingContext)
+        {
+            OverlayImage?.Draw(drawingContext, ClientRectangle);
         }
 
         private void DrawBorder(DrawingContext2D drawingContext)

--- a/src/OpenSage.Game/Logic/Object/Create/VeterancyGainCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/VeterancyGainCreate.cs
@@ -30,7 +30,12 @@ namespace OpenSage.Logic.Object
                 return;
             }
 
-            _gameObject.Rank = (int) _moduleData.StartingLevel;
+            // units like the minigunner or tank battlemaster can start at vet 1 and be upgraded to vet 2, and so have two VeterancyGainCreate modules
+            var level = (int)_moduleData.StartingLevel;
+            if (level > _gameObject.Rank)
+            {
+                _gameObject.Rank = level;
+            }
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -17,6 +17,7 @@ using OpenSage.Gui.InGame;
 using OpenSage.Logic.Object.Helpers;
 using OpenSage.Mathematics;
 using FixedMath.NET;
+using OpenSage.Diagnostics.Util;
 using OpenSage.Terrain;
 using OpenSage.FileFormats;
 
@@ -359,7 +360,12 @@ namespace OpenSage.Logic.Object
         // to allocate a new object every time.
         private readonly UpgradeSet _upgradesAll = new();
 
-        public int Rank { get; set; }
+        private VeterancyLevel _rank;
+        public int Rank
+        {
+            get => (int) _rank;
+            set => _rank = (VeterancyLevel) value;
+        }
         public int ExperienceValue { get; set; }
         public int ExperienceRequiredForNextLevel { get; set; }
         internal float ExperienceMultiplier { get; set; }
@@ -1330,6 +1336,12 @@ namespace OpenSage.Logic.Object
             if (ImGui.Button("Kill"))
             {
                 Kill(DeathType.Exploded);
+            }
+
+            if ((Definition.IsTrainable || Definition.BuildVariations?.Any(v => v.Value.IsTrainable) == true) &&
+                ImGui.CollapsingHeader("Veterancy"))
+            {
+                ImGuiUtility.ComboEnum("Current Rank", ref _rank);
             }
 
             if (ImGui.CollapsingHeader("General", ImGuiTreeNodeFlags.DefaultOpen))

--- a/src/OpenSage.Mods.Generals/Gui/CommandButtonUtils.cs
+++ b/src/OpenSage.Mods.Generals/Gui/CommandButtonUtils.cs
@@ -15,6 +15,7 @@ namespace OpenSage.Mods.Generals.Gui
         public static void SetCommandButton(Button buttonControl, CommandButton commandButton, GeneralsControlBar controlBar)
         {
             buttonControl.BackgroundImage = buttonControl.Window.ImageLoader.CreateFromMappedImageReference(commandButton.ButtonImage);
+            buttonControl.OverlayImage = null;
 
             buttonControl.DisabledBackgroundImage = buttonControl.BackgroundImage?.WithGrayscale(true);
 


### PR DESCRIPTION
A unit which is promoted now appears as such in the cameo window
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/93229317-1abd-496d-9bda-64bdd5b9956a)

Additionally, the chevrons appear in production where applicable (this is with the technical veterancy science)
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/a63472ad-1c97-4f94-a456-4cdafda204d4)

Without the veterancy science, they aren't present
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/db73d49b-0d26-49e0-8004-0fe288491a60)

I also went ahead and added a veterancy dropdown to the debug tool
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/91c3175e-13f8-425b-bfea-9ce0528c8524)
