### PR TITLE
Play SoundMoveStart and SoundMoveStartDamaged when moving

### DIFF
--- a/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
@@ -211,8 +211,8 @@ namespace OpenSage.Logic.Object
             { "VoiceEnterStateMoveToCamp2", (parser, x) => x.VoiceEnterStateMoveToCamp2 = parser.ParseAudioEventReference() },
             { "VoiceEnterStateMoveWhileAttacking2", (parser, x) => x.VoiceEnterStateMoveWhileAttacking2 = parser.ParseAudioEventReference() },
 
-            { "SoundMoveStart", (parser, x) => x.SoundMoveStart = parser.ParseAssetReference() },
-            { "SoundMoveStartDamaged", (parser, x) => x.SoundMoveStart = parser.ParseAssetReference() },
+            { "SoundMoveStart", (parser, x) => x.SoundMoveStart = parser.ParseAudioEventReference() },
+            { "SoundMoveStartDamaged", (parser, x) => x.SoundMoveStartDamaged = parser.ParseAudioEventReference() },
             { "SoundMoveLoop", (parser, x) => x.SoundMoveLoop = parser.ParseAssetReference() },
             { "SoundMoveLoopDamaged", (parser, x) => x.SoundMoveLoopDamaged = parser.ParseAssetReference() },
             { "SoundOnDamaged", (parser, x) => x.SoundOnDamaged = parser.ParseAudioEventReference() },
@@ -656,10 +656,10 @@ namespace OpenSage.Logic.Object
         public LazyAssetReference<BaseAudioEventInfo> VoiceEnterStateMoveWhileAttacking { get; private set; }
 
         [AddedIn(SageGame.Bfme2)]
-        public LazyAssetReference<BaseAudioEventInfo> VoiceEnterStateMoveToHigherGround { get; private set; } 
+        public LazyAssetReference<BaseAudioEventInfo> VoiceEnterStateMoveToHigherGround { get; private set; }
 
         [AddedIn(SageGame.Bfme2)]
-        public LazyAssetReference<BaseAudioEventInfo> VoiceEnterStateMoveOverWalls { get; private set; } 
+        public LazyAssetReference<BaseAudioEventInfo> VoiceEnterStateMoveOverWalls { get; private set; }
 
         [AddedIn(SageGame.Bfme)]
         public LazyAssetReference<BaseAudioEventInfo> VoiceSelect2 { get; private set; }
@@ -784,8 +784,8 @@ namespace OpenSage.Logic.Object
         [AddedIn(SageGame.Bfme)]
         public LazyAssetReference<BaseAudioEventInfo> VoiceEnterStateMoveWhileAttacking2 { get; private set; }
 
-        public string SoundMoveStart { get; private set; }
-        public string SoundMoveStartDamaged { get; private set; }
+        public LazyAssetReference<BaseAudioEventInfo> SoundMoveStart { get; private set; }
+        public LazyAssetReference<BaseAudioEventInfo> SoundMoveStartDamaged { get; private set; }
         public string SoundMoveLoop { get; private set; }
 
         [AddedIn(SageGame.Bfme)]
@@ -1000,7 +1000,7 @@ namespace OpenSage.Logic.Object
 
         [AddedIn(SageGame.Bfme)]
         public Vector3 LiveCameraOffset { get; private set; }
-        
+
         [AddedIn(SageGame.Bfme)]
         public float LiveCameraPitch { get; private set; }
 

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -6,7 +6,6 @@ using OpenSage.Data.Ini;
 using OpenSage.Diagnostics.Util;
 using OpenSage.Gui.ControlBar;
 using OpenSage.Logic.Object.Production;
-using OpenSage.Logic.Orders;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -6,6 +6,7 @@ using OpenSage.Data.Ini;
 using OpenSage.Diagnostics.Util;
 using OpenSage.Gui.ControlBar;
 using OpenSage.Logic.Object.Production;
+using OpenSage.Logic.Orders;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
@@ -345,6 +346,8 @@ namespace OpenSage.Logic.Object
             {
                 _producedUnit.AIUpdate.AddTargetPoint(_gameObject.RallyPoint.Value);
             }
+
+            _gameObject.GameContext.AudioSystem.PlayAudioEvent(_producedUnit, _producedUnit.Definition.SoundMoveStart.Value);
 
             HandleHordeCreation();
             HandleHarvesterUnitCreation(_gameObject, _producedUnit);

--- a/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
@@ -72,6 +72,13 @@ namespace OpenSage.Logic.Orders
                             foreach (var unit in player.SelectedUnits)
                             {
                                 unit.AIUpdate?.SetTargetPoint(targetPosition);
+                                var sound = unit.IsDamaged ? unit.Definition.SoundMoveStartDamaged?.Value : null;
+                                sound ??= unit.Definition.SoundMoveStart?.Value;
+
+                                if (sound != null)
+                                {
+                                    _game.Audio.PlayAudioEvent(unit, sound);
+                                }
                             }
                         }
                         break;


### PR DESCRIPTION
I actually wasn't able to find any cases in Generals where `SoundMoveStartDamaged` differed from `SoundMoveStart`.