### PR TITLE
Fix clicking empty queue button causes crash

### DIFF
--- a/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
@@ -471,6 +471,11 @@ namespace OpenSage.Mods.Generals.Gui
                         {
                             queueButton.DrawCallback = queueButton.DefaultDraw;
                             queueButton.SystemCallback = null;
+                            queueButton.Hide();
+                        }
+                        else
+                        {
+                            queueButton.Show();
                         }
                     }
                 }


### PR DESCRIPTION
This just hides the production queue button if there isn't a unit actively being produced in that button slot, so that it can't be clicked or trigger a null callback.