### PR TITLE
Enable nullable reference types in smaller projects

### DIFF
--- a/src/OpenSage.Core/OpenSage.Core.csproj
+++ b/src/OpenSage.Core/OpenSage.Core.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Veldrid.SDL2" Version="$(VeldridVersion)" />
     <PackageReference Include="NLog" Version="5.1.4" />

--- a/src/OpenSage.FileFormats.Big/BigArchive.cs
+++ b/src/OpenSage.FileFormats.Big/BigArchive.cs
@@ -128,7 +128,7 @@ namespace OpenSage.FileFormats.Big
             return entry;
         }
 
-        public BigArchiveEntry GetEntry(string entryName)
+        public BigArchiveEntry? GetEntry(string entryName)
         {
             if (entryName == null)
             {

--- a/src/OpenSage.FileFormats.Big/BigArchiveEntry.cs
+++ b/src/OpenSage.FileFormats.Big/BigArchiveEntry.cs
@@ -18,7 +18,7 @@ namespace OpenSage.FileFormats.Big
 
         // Internal members
         internal bool OnDisk { get; set; }
-        internal MemoryStream OutstandingWriteStream { get; set; }
+        internal MemoryStream? OutstandingWriteStream { get; set; }
         internal uint OutstandingOffset { get; set; }
         internal bool CurrentlyOpenForWrite { get; set; }
 

--- a/src/OpenSage.FileFormats.Big/BigArchiveEntryStream.cs
+++ b/src/OpenSage.FileFormats.Big/BigArchiveEntryStream.cs
@@ -44,7 +44,7 @@ namespace OpenSage.FileFormats.Big
             }
             else
             {
-                result = _entry.OutstandingWriteStream.Read(buffer, offset, count);
+                result = _entry.OutstandingWriteStream!.Read(buffer, offset, count); // set when _write is set to true
                 Position += result;
             }
             _archive.ReleaseLock();
@@ -90,7 +90,7 @@ namespace OpenSage.FileFormats.Big
             EnsureWriteMode();
 
             _entry.OnDisk = false;
-            _entry.OutstandingWriteStream.SetLength(value);
+            _entry.OutstandingWriteStream?.SetLength(value); // set in EnsureWriteMode()
         }
 
         public override void Write(byte[] buffer, int offset, int count)
@@ -98,7 +98,7 @@ namespace OpenSage.FileFormats.Big
             EnsureWriteMode();
 
             _entry.OnDisk = false;
-            _entry.OutstandingWriteStream.Position = Position;
+            _entry.OutstandingWriteStream!.Position = Position; // set in EnsureWriteMode()
             _entry.OutstandingWriteStream.Write(buffer, offset, count);
         }
 
@@ -108,7 +108,7 @@ namespace OpenSage.FileFormats.Big
 
         public override bool CanWrite => true;
 
-        public override long Length => _write ? _entry.OutstandingWriteStream.Length : _entry.Length;
+        public override long Length => _write ? _entry.OutstandingWriteStream!.Length : _entry.Length; // set when _write is set to true
 
         public override long Position { get; set; }
 

--- a/src/OpenSage.FileFormats.Big/OpenSage.FileFormats.Big.csproj
+++ b/src/OpenSage.FileFormats.Big/OpenSage.FileFormats.Big.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\OpenSage.Core\OpenSage.Core.csproj" />
     <ProjectReference Include="..\OpenSage.FileFormats.RefPack\OpenSage.FileFormats.RefPack.csproj" />

--- a/src/OpenSage.FileFormats.RefPack/OpenSage.FileFormats.RefPack.csproj
+++ b/src/OpenSage.FileFormats.RefPack/OpenSage.FileFormats.RefPack.csproj
@@ -1,3 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
 </Project>

--- a/src/OpenSage.FileFormats/BinaryReaderExtensions.cs
+++ b/src/OpenSage.FileFormats/BinaryReaderExtensions.cs
@@ -537,10 +537,10 @@ namespace OpenSage.FileFormats
         }
 
         // TODO: remove this in favour of ReadArrayAtOffset
-        public static List<T> ReadListAtOffset<T>(this BinaryReader reader, Func<T> creator, bool ptr = false)
+        public static List<T?> ReadListAtOffset<T>(this BinaryReader reader, Func<T> creator, bool ptr = false)
         {
             var capacity = reader.ReadInt32();
-            List<T> result = new List<T>(capacity);
+            var result = new List<T?>(capacity);
 
             //get the offset
             var listOffset = reader.ReadUInt32();
@@ -551,7 +551,7 @@ namespace OpenSage.FileFormats
 
             for (var i = 0; i < capacity; i++)
             {
-                T item = default(T);
+                var item = default(T);
                 if (!ptr)
                 {
                     item = creator();
@@ -574,7 +574,7 @@ namespace OpenSage.FileFormats
                     }
                 }
 
-                result.Add(item);
+                result.Add(item); // todo: can definitely be null, but it seems like we really assume it isn't?
             }
 
             //jump back to where we came from
@@ -582,10 +582,10 @@ namespace OpenSage.FileFormats
             return result;
         }
 
-        public static T[] ReadArrayAtOffset<T>(this BinaryReader reader, Func<T> creator, bool ptr = false)
+        public static T?[] ReadArrayAtOffset<T>(this BinaryReader reader, Func<T> creator, bool ptr = false)
         {
             var capacity = reader.ReadInt32();
-            var result = new T[capacity];
+            var result = new T?[capacity];
 
             //get the offset
             var listOffset = reader.ReadUInt32();
@@ -596,7 +596,7 @@ namespace OpenSage.FileFormats
 
             for (var i = 0; i < capacity; i++)
             {
-                T item = default(T);
+                var item = default(T);
                 if (!ptr)
                 {
                     item = creator();
@@ -632,7 +632,7 @@ namespace OpenSage.FileFormats
             //get the offset
             var listOffset = reader.ReadUInt32();
             var oldOffset = reader.BaseStream.Position;
-            
+
             //jump to the location and read the data
             reader.BaseStream.Seek(listOffset, SeekOrigin.Begin);
 
@@ -642,14 +642,14 @@ namespace OpenSage.FileFormats
             reader.BaseStream.Seek(oldOffset, SeekOrigin.Begin);
         }
 
-        public static T ReadAtOffset<T>(this BinaryReader reader, Func<T> callback)
+        public static T? ReadAtOffset<T>(this BinaryReader reader, Func<T> callback)
         {
             //get the offset
             var listOffset = reader.ReadUInt32();
 
             if (listOffset == 0)
             {
-                return default(T);
+                return default;
             }
 
             var oldOffset = reader.BaseStream.Position;
@@ -844,7 +844,7 @@ namespace OpenSage.FileFormats
 
         }
 
-        public static T ReadOptionalClassTypedValueAtOffset<T>(this BinaryReader reader, Func<T> readCallback)
+        public static T? ReadOptionalClassTypedValueAtOffset<T>(this BinaryReader reader, Func<T> readCallback)
             where T : class
         {
             var offset = reader.ReadUInt32();
@@ -856,10 +856,8 @@ namespace OpenSage.FileFormats
                 reader.BaseStream.Seek(current, SeekOrigin.Begin);
                 return value;
             }
-            else
-            {
-                return null;
-            }
+
+            return null;
         }
 
         public static byte ReadVersion(this BinaryReader reader) => reader.ReadByte();

--- a/src/OpenSage.FileFormats/OpenSage.FileFormats.csproj
+++ b/src/OpenSage.FileFormats/OpenSage.FileFormats.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
   </ItemGroup>

--- a/src/OpenSage.Game/IGameDefinition.cs
+++ b/src/OpenSage.Game/IGameDefinition.cs
@@ -12,7 +12,7 @@ namespace OpenSage
     {
         SageGame Game { get; }
         string DisplayName { get; }
-        IGameDefinition BaseGame { get; }
+        IGameDefinition? BaseGame { get; }
 
         bool LauncherImagePrefixLang { get; }
         string LauncherImagePath { get; }
@@ -20,10 +20,10 @@ namespace OpenSage
 
         IEnumerable<RegistryKeyPath> RegistryKeys { get; }
         IEnumerable<RegistryKeyPath> LanguageRegistryKeys { get; }
-        
+
         IMainMenuSource MainMenu { get; }
-        IControlBarSource ControlBar { get; }
-        ICommandListOverlaySource CommandListOverlay { get; }
+        IControlBarSource? ControlBar { get; }
+        ICommandListOverlaySource? CommandListOverlay { get; }
 
         string Identifier { get; }
 

--- a/src/OpenSage.Launcher/OpenSage.Launcher.csproj
+++ b/src/OpenSage.Launcher/OpenSage.Launcher.csproj
@@ -5,6 +5,7 @@
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <ApplicationIcon>Resources\AppIcon.ico</ApplicationIcon>
     <ApplicationManifest>Resources\app.manifest</ApplicationManifest>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenSage.Launcher/Program.cs
+++ b/src/OpenSage.Launcher/Program.cs
@@ -30,7 +30,7 @@ namespace OpenSage.Launcher
             public SageGame Game { get; set; }
 
             [Option('m', "map", Required = false, HelpText = "Immediately starts a new skirmish with default settings in the specified map. The map file must be specified with the full path.")]
-            public string Map { get; set; }
+            public string? Map { get; set; }
 
             [Option("novsync", Default = false, Required = false, HelpText = "Disable vsync.")]
             public bool DisableVsync { get; set; }
@@ -45,13 +45,13 @@ namespace OpenSage.Launcher
             public bool DeveloperMode { get; set; }
 
             [Option("tracefile", Default = null, Required = false, HelpText = "Generate trace output to the specified path, for example `--tracefile trace.json`. Trace files can be loaded into Chrome's tracing GUI at chrome://tracing")]
-            public string TraceFile { get; set; }
+            public string? TraceFile { get; set; }
 
             [Option("replay", Default = null, Required = false, HelpText = "Specify a replay file to immediately start replaying")]
-            public string ReplayFile { get; set; }
+            public string? ReplayFile { get; set; }
 
             [Option('p', "gamepath", Default = null, Required = false, HelpText = "Force game to use this gamepath")]
-            public string GamePath { get; set; }
+            public string? GamePath { get; set; }
 
             [Option('u', "uniqueports", Default = false, Required = false, HelpText = "Use a unique port for each client in a multiplayer game. Normally, port 8088 is used, but when we want to run multiple game instances on the same machine (for debugging purposes), each client needs a different port.")]
             public bool UseUniquePorts { get; set; }
@@ -92,7 +92,7 @@ namespace OpenSage.Launcher
             }
 
             var definition = GameDefinition.FromGame(DetectedGame);
-            GameInstallation installation;
+            GameInstallation? installation;
             if (UseLocators)
             {
                 installation = GameInstallation

--- a/src/OpenSage.Mathematics/BitArray`1.cs
+++ b/src/OpenSage.Mathematics/BitArray`1.cs
@@ -124,7 +124,7 @@ namespace OpenSage.Mathematics
             }
         }
 
-        public bool Equals(BitArray<TEnum> other) => _data.Equals(other._data);
+        public bool Equals(BitArray<TEnum>? other) => _data.Equals(other?._data);
 
         public override int GetHashCode()
         {

--- a/src/OpenSage.Mathematics/Bool32.cs
+++ b/src/OpenSage.Mathematics/Bool32.cs
@@ -11,7 +11,7 @@ namespace OpenSage.Graphics.Mathematics
             _value = val ? 1 : 0;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is Bool32 @bool && Equals(@bool);
         }

--- a/src/OpenSage.Mathematics/BoundingFrustum.cs
+++ b/src/OpenSage.Mathematics/BoundingFrustum.cs
@@ -57,7 +57,7 @@ namespace OpenSage.Mathematics
             return this == other;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is BoundingFrustum frustum && this == frustum;
         }

--- a/src/OpenSage.Mathematics/ColorRgbaF.cs
+++ b/src/OpenSage.Mathematics/ColorRgbaF.cs
@@ -63,7 +63,7 @@ namespace OpenSage.Mathematics
             return new ColorRgbaF(r, g, b, A);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ColorRgbaF && Equals((ColorRgbaF) obj);
         }

--- a/src/OpenSage.Mathematics/DFloat.cs
+++ b/src/OpenSage.Mathematics/DFloat.cs
@@ -61,7 +61,7 @@ namespace OpenSage.Mathematics
         {
             return new DFloat(a._value * b._value);
         }
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator <(DFloat a, DFloat b)
         {
@@ -79,7 +79,7 @@ namespace OpenSage.Mathematics
             return _value.GetHashCode();
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is DFloat f && _value == f._value;
         }

--- a/src/OpenSage.Mathematics/DVector3.cs
+++ b/src/OpenSage.Mathematics/DVector3.cs
@@ -75,7 +75,7 @@ namespace OpenSage.Mathematics
             return vec * c;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is DVector3 f && this == f;
         }

--- a/src/OpenSage.Mathematics/Matrix4x3.cs
+++ b/src/OpenSage.Mathematics/Matrix4x3.cs
@@ -52,7 +52,7 @@ namespace OpenSage.Mathematics
             M43 = m43;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is Matrix4x3 x && Equals(x);
         }

--- a/src/OpenSage.Mathematics/OpenSage.Mathematics.csproj
+++ b/src/OpenSage.Mathematics/OpenSage.Mathematics.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/src/OpenSage.Mathematics/Rectangle.cs
+++ b/src/OpenSage.Mathematics/Rectangle.cs
@@ -55,7 +55,7 @@ namespace OpenSage.Mathematics
         //        Top < value.Bottom;
         //}
 
-        
+
         //public static Rectangle Intersect(in Rectangle value1, in Rectangle value2)
         //{
         //    if (value1.Intersects(value2))
@@ -86,7 +86,7 @@ namespace OpenSage.Mathematics
 
         public RectangleF ToRectangleF() => new RectangleF(X, Y, Width, Height);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (!(obj is Rectangle))
             {

--- a/src/OpenSage.Mathematics/RectangleF.cs
+++ b/src/OpenSage.Mathematics/RectangleF.cs
@@ -102,7 +102,7 @@ namespace OpenSage.Mathematics
             var newX = (int) MathF.Round(rect.X * ratio);
             var newY = (int) MathF.Round(rect.Y * ratio);
 
-            // Now calculate the X,Y position of the upper-left corner 
+            // Now calculate the X,Y position of the upper-left corner
             // (one of these will always be zero for the top level window)
             var posX = (int) MathF.Round((viewportSize.Width - (boundsSize.Width * ratio)) / 2.0f) + newX;
             var posY = (int) MathF.Round((viewportSize.Height - (boundsSize.Height * ratio)) / 2.0f) + newY;
@@ -125,7 +125,7 @@ namespace OpenSage.Mathematics
             var newX = (int) MathF.Round(rect.X * ratio);
             var newY = (int) MathF.Round(rect.Y * ratio);
 
-            // Now calculate the X,Y position of the upper-left corner 
+            // Now calculate the X,Y position of the upper-left corner
             // (one of these will always be zero for the top level window)
             var posX = (int) MathF.Round((viewportSize.Width - (boundsSize.Width * ratio)) / 2.0f) + newX;
             var posY = (int) MathF.Round((viewportSize.Height - (boundsSize.Height * ratio)) / 2.0f) + newY;
@@ -224,7 +224,7 @@ namespace OpenSage.Mathematics
             return X.Equals(other.X) && Y.Equals(other.Y) && Width.Equals(other.Width) && Height.Equals(other.Height);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (obj is null)
             {

--- a/src/OpenSage.Mathematics/Size.cs
+++ b/src/OpenSage.Mathematics/Size.cs
@@ -59,7 +59,7 @@ namespace OpenSage.Mathematics
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             return obj is Size && Equals((Size) obj);

--- a/src/OpenSage.Mathematics/SizeF.cs
+++ b/src/OpenSage.Mathematics/SizeF.cs
@@ -28,7 +28,7 @@ namespace OpenSage.Mathematics
             return rect.Size;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is SizeF && Equals((SizeF) obj);
         }

--- a/src/OpenSage.Mathematics/SoftFloat.cs
+++ b/src/OpenSage.Mathematics/SoftFloat.cs
@@ -422,7 +422,7 @@ namespace OpenSage.Mathematics
             return *(float*) &i;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (obj == null || GetType() != obj.GetType())
             {
@@ -653,17 +653,17 @@ namespace OpenSage.Mathematics
             return (_raw & 0x7FFFFFFF) == 0;
         }
 
-        public int CompareTo(object obj)
+        public int CompareTo(object? obj)
         {
-            if (!(obj is SoftFloat))
+            if (obj is not SoftFloat softFloat)
             {
                 throw new ArgumentException("obj");
             }
 
-            return CompareTo((SoftFloat) obj);
+            return CompareTo(softFloat);
         }
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
         {
             return ((float) this).ToString(format, formatProvider);
         }

--- a/src/OpenSage.Mods.Bfme2/Bfme2Definition.cs
+++ b/src/OpenSage.Mods.Bfme2/Bfme2Definition.cs
@@ -15,7 +15,7 @@ namespace OpenSage.Mods.Bfme2
     {
         public SageGame Game => SageGame.Bfme2;
         public string DisplayName => "The Lord of the Rings (tm): The Battle for Middle-earth (tm) II";
-        public IGameDefinition BaseGame => null;
+        public IGameDefinition? BaseGame => null;
 
         public bool LauncherImagePrefixLang => true;
         public string LauncherImagePath => "Splash.jpg";

--- a/src/OpenSage.Mods.Bfme2/Bfme2RotwkDefinition.cs
+++ b/src/OpenSage.Mods.Bfme2/Bfme2RotwkDefinition.cs
@@ -31,8 +31,8 @@ namespace OpenSage.Mods.Bfme2
         public string Identifier { get; } = "bfme2_rotwk";
 
         public IMainMenuSource MainMenu { get; } = new AptMainMenuSource("MainMenu.apt");
-        public IControlBarSource ControlBar { get; }
-        public ICommandListOverlaySource CommandListOverlay => null;
+        public IControlBarSource? ControlBar { get; }
+        public ICommandListOverlaySource? CommandListOverlay => null;
 
         public uint ScriptingTicksPerSecond => 5;
 

--- a/src/OpenSage.Mods.Bfme2/OpenSage.Mods.Bfme2.csproj
+++ b/src/OpenSage.Mods.Bfme2/OpenSage.Mods.Bfme2.csproj
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenSage.Game\OpenSage.Game.csproj" />
     <ProjectReference Include="..\OpenSage.Mods.Bfme\OpenSage.Mods.Bfme.csproj" />

--- a/src/OpenSage.Mods.BuiltIn/GameDefinition.cs
+++ b/src/OpenSage.Mods.BuiltIn/GameDefinition.cs
@@ -14,7 +14,7 @@ namespace OpenSage.Mods.BuiltIn
         public static IEnumerable<IGameDefinition> All => Games.Values;
         public static IGameDefinition FromGame(SageGame game) => Games[game];
 
-        public static bool TryGetByName(string name, out IGameDefinition definition)
+        public static bool TryGetByName(string name, out IGameDefinition? definition)
         {
             // TODO: Use a short identifier defined in IGameDefinition instead of stringified SageGame
             definition = All.FirstOrDefault(def =>

--- a/src/OpenSage.Mods.BuiltIn/OpenSage.Mods.BuiltIn.csproj
+++ b/src/OpenSage.Mods.BuiltIn/OpenSage.Mods.BuiltIn.csproj
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenSage.Game\OpenSage.Game.csproj" />
     <ProjectReference Include="..\OpenSage.Mods.Bfme2\OpenSage.Mods.Bfme2.csproj" />

--- a/src/OpenSage.Rendering/OpenSage.Rendering.csproj
+++ b/src/OpenSage.Rendering/OpenSage.Rendering.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Veldrid" Version="$(VeldridVersion)" />
     <PackageReference Include="Veldrid.SPIRV" Version="1.0.15" />

--- a/src/OpenSage.Rendering/RenderScene.cs
+++ b/src/OpenSage.Rendering/RenderScene.cs
@@ -111,7 +111,7 @@ public sealed class RenderScene
         return result;
     }
 
-    private RenderBucket GetRenderBucketImpl(string name)
+    private RenderBucket? GetRenderBucketImpl(string name)
     {
         foreach (var renderBucket in _renderBuckets)
         {

--- a/src/OpenSage.Rendering/Shaders/ShaderCacheFile.cs
+++ b/src/OpenSage.Rendering/Shaders/ShaderCacheFile.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using Veldrid;
 
 namespace OpenSage.Rendering;
@@ -12,7 +13,7 @@ internal sealed class ShaderCacheFile
 
     public readonly ResourceLayoutDescription[] ResourceLayoutDescriptions;
 
-    public static bool TryLoad(string filePath, out ShaderCacheFile result)
+    public static bool TryLoad(string filePath, [NotNullWhen(true)] out ShaderCacheFile? result)
     {
         if (!File.Exists(filePath))
         {

--- a/src/OpenSage.Rendering/Shaders/ShaderCrossCompiler.cs
+++ b/src/OpenSage.Rendering/Shaders/ShaderCrossCompiler.cs
@@ -110,7 +110,7 @@ internal static class ShaderCrossCompiler
         using (var shaderStream = assembly.GetManifestResourceStream(bytecodeShaderName))
         using (var memoryStream = new MemoryStream())
         {
-            shaderStream.CopyTo(memoryStream);
+            shaderStream?.CopyTo(memoryStream);
             return memoryStream.ToArray();
         }
     }
@@ -124,7 +124,7 @@ internal static class ShaderCrossCompiler
         var compilationResult = Vortice.D3DCompiler.Compiler.Compile(
             hlsl,
             EntryPoint,
-            null,
+            null!, // digging into the source, this seems to be ok
             profile,
             flags);
 


### PR DESCRIPTION
I went through some of the smaller projects that were easy to enable nullable reference types in with minimal changes, and did so. These are done as separate commits so we can pull them out into separate PRs if desired, merge some but not others, etc. We can also just not merge this at all if we opt not to enable nullable reference types, but personally I think it's a huge help as it makes the contract of a method signature more explicit, and also encourages writing code without nullable types (where possible).