### PR TITLE
Disable headlights when not night

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
 using OpenSage.Client;
 using OpenSage.Data.Ini;
 using OpenSage.Mathematics;
@@ -64,6 +65,23 @@ namespace OpenSage.Logic.Object
             }
         }
 
+        public override void UpdateConditionState(BitArray<ModelConditionFlag> flags, Random random)
+        {
+            base.UpdateConditionState(flags, random);
+
+            if (flags.BitsChanged)
+            {
+                for (var i = 0; i < ActiveModelInstance.ModelBoneInstances.Length; i++)
+                {
+                    var bone = ActiveModelInstance.ModelBoneInstances[i];
+                    if (bone.Name.StartsWith("HEADLIGHT", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        ActiveModelInstance.BoneVisibilities[i] = flags.Get(ModelConditionFlag.Night);
+                    }
+                }
+            }
+        }
+
         internal override void Load(StatePersister reader)
         {
             reader.PersistVersion(1);
@@ -75,11 +93,11 @@ namespace OpenSage.Logic.Object
     }
 
     /// <summary>
-    /// Hardcoded to call for the TreadDebrisRight and TreadDebrisLeft (unless overriden) particle 
-    /// system definitions and allows use of TruckPowerslideSound and TruckLandingSound within the 
+    /// Hardcoded to call for the TreadDebrisRight and TreadDebrisLeft (unless overriden) particle
+    /// system definitions and allows use of TruckPowerslideSound and TruckLandingSound within the
     /// UnitSpecificSounds section of the object.
-    /// 
-    /// This module also includes automatic logic for showing and hiding of HEADLIGHT bones in and 
+    ///
+    /// This module also includes automatic logic for showing and hiding of HEADLIGHT bones in and
     /// out of the NIGHT ModelConditionState.
     /// </summary>
     public class W3dTruckDrawModuleData : W3dModelDrawModuleData

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -17,6 +17,7 @@ using OpenSage.Gui.InGame;
 using OpenSage.Logic.Object.Helpers;
 using OpenSage.Mathematics;
 using FixedMath.NET;
+using OpenSage.Diagnostics.Util;
 using OpenSage.Terrain;
 using OpenSage.FileFormats;
 
@@ -1342,8 +1343,18 @@ namespace OpenSage.Logic.Object
                     _transform.Translation = translation;
                 }
 
-                // TODO: Make this editable
                 ImGui.LabelText("ModelConditionFlags", ModelConditionFlags.DisplayName);
+                if (ImGui.TreeNodeEx("Select ModelConditionFlags"))
+                {
+                    foreach (var flag in Enum.GetValues<ModelConditionFlag>())
+                    {
+                        if (ImGui.Selectable(flag.ToString(), ModelConditionFlags.Get(flag)))
+                        {
+                            ModelConditionFlags.Set(flag, !ModelConditionFlags.Get(flag));
+                        }
+                    }
+                    ImGui.TreePop();
+                }
 
                 var speed = Speed;
                 if (ImGui.InputFloat("Speed", ref speed))


### PR DESCRIPTION
Note that the objects don't currently have their ModelConditionFlags updated with `NIGHT`. This does, however, update the inspector to allow for setting ModelConditionFlags (and supports enabling/disabling multiple flags).

`NIGHT`:
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/acee50bc-66f3-46d5-b8ca-500c28e53e6b)

`NONE`:
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/fd8d2025-693c-4ed3-8867-167ae2010d5c)
