### PR TITLE
Play die sounds on death

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Body/BodyModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/BodyModule.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using FixedMath.NET;
 using ImGuiNET;
 using OpenSage.Data.Ini;
+using OpenSage.Diagnostics.Util;
 
 namespace OpenSage.Logic.Object
 {
@@ -34,6 +35,10 @@ namespace OpenSage.Logic.Object
             }
         }
 
+        private DamageType _inspectorDamageType = DamageType.Explosion;
+        private float _inspectorDamageAmount;
+        private DeathType _inspectorDeathType = DeathType.Normal;
+
         internal override void DrawInspector()
         {
             var maxHealth = (float) MaxHealth;
@@ -46,6 +51,16 @@ namespace OpenSage.Logic.Object
             if (ImGui.InputFloat("Health", ref health))
             {
                 Health = (Fix64) health;
+            }
+
+            ImGui.Separator();
+
+            ImGuiUtility.ComboEnum("Damage Type", ref _inspectorDamageType);
+            ImGui.InputFloat("Damage Amount", ref _inspectorDamageAmount);
+            ImGuiUtility.ComboEnum("Death Type", ref _inspectorDeathType);
+            if (ImGui.Button("Apply Damage"))
+            {
+                DoDamage(_inspectorDamageType, (Fix64) _inspectorDamageAmount, _inspectorDeathType);
             }
         }
     }

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -1116,9 +1116,26 @@ namespace OpenSage.Logic.Object
                 }
             }
 
+            PlayDieSound(deathType);
+
             foreach (var module in _behaviorModules)
             {
                 module.OnDie(_behaviorUpdateContext, deathType);
+            }
+        }
+
+        private void PlayDieSound(DeathType deathType)
+        {
+            var voiceDie = deathType switch
+            {
+                DeathType.Burned => Definition.SoundDieFire?.Value,
+                DeathType.Poisoned or DeathType.PoisonedGamma or DeathType.PoisonedBeta => Definition.SoundDieToxin?.Value,
+                _ => null,
+            } ?? Definition.SoundDie?.Value;
+
+            if (voiceDie != null)
+            {
+                GameContext.AudioSystem.PlayAudioEvent(this, voiceDie);
             }
         }
 
@@ -1402,8 +1419,6 @@ namespace OpenSage.Logic.Object
             {
                 DrawInspector(drawModule);
             }
-
-            DrawInspector(_body);
 
             if (CurrentWeapon != null)
             {

--- a/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
@@ -218,8 +218,8 @@ namespace OpenSage.Logic.Object
             { "SoundOnDamaged", (parser, x) => x.SoundOnDamaged = parser.ParseAudioEventReference() },
             { "SoundOnReallyDamaged", (parser, x) => x.SoundOnReallyDamaged = parser.ParseAudioEventReference() },
             { "SoundDie", (parser, x) => x.SoundDie = parser.ParseAudioEventReference() },
-            { "SoundDieFire", (parser, x) => x.SoundDieFire = parser.ParseAssetReference() },
-            { "SoundDieToxin", (parser, x) => x.SoundDieToxin = parser.ParseAssetReference() },
+            { "SoundDieFire", (parser, x) => x.SoundDieFire = parser.ParseAudioEventReference() },
+            { "SoundDieToxin", (parser, x) => x.SoundDieToxin = parser.ParseAudioEventReference() },
             { "SoundStealthOn", (parser, x) => x.SoundStealthOn = parser.ParseAssetReference() },
             { "SoundStealthOff", (parser, x) => x.SoundStealthOff = parser.ParseAssetReference() },
             { "SoundCrush", (parser, x) => x.SoundCrush = parser.ParseAssetReference() },
@@ -793,9 +793,9 @@ namespace OpenSage.Logic.Object
 
         public LazyAssetReference<BaseAudioEventInfo> SoundOnDamaged { get; private set; }
         public LazyAssetReference<BaseAudioEventInfo> SoundOnReallyDamaged { get; private set; }
-        public LazyAssetReference<BaseAudioEventInfo> SoundDie { get; private set; }
-        public string SoundDieFire { get; private set; }
-        public string SoundDieToxin { get; private set; }
+        public LazyAssetReference<BaseAudioEventInfo>? SoundDie { get; private set; }
+        public LazyAssetReference<BaseAudioEventInfo>? SoundDieFire { get; private set; }
+        public LazyAssetReference<BaseAudioEventInfo>? SoundDieToxin { get; private set; }
         public string SoundStealthOn { get; private set; }
         public string SoundStealthOff { get; private set; }
         public string SoundCrush { get; private set; }


### PR DESCRIPTION
This also adds the ability to damage and kill units in a specific way via the inspector, and removes the duplicate ActiveBody that was being displayed which caused for weird behavior.

![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/3ed99f74-435f-424e-9be4-56a60cbb8ad8)
