### PR TITLE
Play speech files from scripts

### DIFF
--- a/src/OpenSage.Game/Audio/AudioSystem.cs
+++ b/src/OpenSage.Game/Audio/AudioSystem.cs
@@ -139,6 +139,11 @@ namespace OpenSage.Audio
             return sound.AudioFile.Value?.Entry;
         }
 
+        private FileSystemEntry ResolveDialogEventEntry(DialogEvent ev)
+        {
+            return ev.File.Value.Entry;
+        }
+
         /// <summary>
         /// Open a a music/audio file that gets streamed.
         /// </summary>
@@ -175,31 +180,19 @@ namespace OpenSage.Audio
             _sources.Remove(source);
         }
 
-        private bool ValidateAudioEvent(BaseAudioEventInfo baseAudioEvent)
-        {
-            if (baseAudioEvent == null)
-            {
-                return false;
-            }
-
-            if (!(baseAudioEvent is AudioEvent))
-            {
-                // TODO
-                return false;
-            }
-
-            return true;
-        }
-
         private AudioSource PlayAudioEventBase(BaseAudioEventInfo baseAudioEvent, bool looping = false)
         {
-            if (!ValidateAudioEvent(baseAudioEvent))
+            if (baseAudioEvent is not BaseSingleSound audioEvent)
             {
                 return null;
             }
 
-            var audioEvent = baseAudioEvent as AudioEvent;
-            var entry = ResolveAudioEventEntry(audioEvent);
+            var entry = baseAudioEvent switch
+            {
+                AudioEvent ae => ResolveAudioEventEntry(ae),
+                DialogEvent de => ResolveDialogEventEntry(de),
+                _ => null, // todo
+            };
 
             if (entry == null)
             {

--- a/src/OpenSage.Game/Content/Loaders/OnDemandAudioFileLoader.cs
+++ b/src/OpenSage.Game/Content/Loaders/OnDemandAudioFileLoader.cs
@@ -30,9 +30,11 @@ namespace OpenSage.Content.Loaders
                     }
                 }
             }
-            else // music tracks
+            else
             {
-                entry = context.FileSystem.GetFile(Path.Combine(@"Data\Audio\Tracks", key));
+                entry = context.FileSystem.GetFile(Path.Combine(@"Data\Audio\Tracks", key)) ?? // music tracks
+                        context.FileSystem.GetFile(Path.Combine(@"Data\Audio\Speech", context.Language, key)) ?? // language-specific dialog events
+                        context.FileSystem.GetFile(Path.Combine(@"Data\Audio\Speech", key)); // generic dialog events
             }
 
             if (entry == null)

--- a/src/OpenSage.Game/Content/SubsystemLoader.cs
+++ b/src/OpenSage.Game/Content/SubsystemLoader.cs
@@ -153,7 +153,7 @@ namespace OpenSage.Content
                     break;
             }
 
-            
+
             _subsystems = game.AssetStore.Subsystems;
         }
 
@@ -217,6 +217,7 @@ namespace OpenSage.Content
                     _contentManager.LoadIniFile(@"Data\INI\MiscAudio.ini");
                     _contentManager.LoadIniFile(@"Data\INI\Voice.ini");
                     _contentManager.LoadIniFile(@"Data\INI\Music.ini");
+                    _contentManager.LoadIniFile(@"Data\INI\Speech.ini");
                     break;
 
                 case Subsystem.Wnd:

--- a/src/OpenSage.Game/Scripting/Actions/ScriptActions.Multimedia.cs
+++ b/src/OpenSage.Game/Scripting/Actions/ScriptActions.Multimedia.cs
@@ -7,5 +7,11 @@
         {
             context.Scene.Audio.PlayMusicTrack(context.Scene.AssetLoadContext.AssetStore.MusicTracks.GetByName(trackName), fadeIn, fadeOut);
         }
+
+        [ScriptAction(ScriptActionType.SpeechPlay, "Play a speech file.", "'{0}' plays, allowing overlap {1} (true to allow, false to disallow)")]
+        public static void PlaySpeechFile(ScriptExecutionContext context, [ScriptArgumentType(ScriptArgumentType.SpeechName)] string speechName, bool overlap)
+        {
+            context.Scene.Audio.PlayAudioEvent(context.Scene.AssetLoadContext.AssetStore.DialogEvents.GetByName(speechName));
+        }
     }
 }


### PR DESCRIPTION
The one thing I'm not sure about here is adding `Data\INI\Speech.ini` to `SubsystemLoader`. Was it not added in the first place because BFME or other games don't have it?

Otherwise, this is pretty cool because it plays the voice lines on the shellmap.