### PR TITLE
Set ActivelyConstructing and ConstructionComplete ModelConditionFlags

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -80,7 +80,10 @@ namespace OpenSage.Logic.Object
                 return;
             }
 
-            if (_productionQueue.Count > 0)
+            var isProducing = _productionQueue.Count > 0;
+            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.ActivelyConstructing, isProducing);
+
+            if (isProducing)
             {
                 var front = _productionQueue[0];
                 var result = front.Produce();
@@ -100,6 +103,7 @@ namespace OpenSage.Logic.Object
 
                             GetDoorConditionFlags(out var doorOpening, out var _, out var _);
                             _gameObject.ModelConditionFlags.Set(doorOpening, true);
+                            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.ConstructionComplete, true);
 
                             ProduceObject(front.ObjectDefinition);
                         }
@@ -128,6 +132,7 @@ namespace OpenSage.Logic.Object
                 case DoorState.Open:
                     if (context.LogicFrame >= _currentStepEnd)
                     {
+                        _gameObject.ModelConditionFlags.Set(ModelConditionFlag.ConstructionComplete, false);
                         _productionExit ??= _gameObject.FindBehavior<IProductionExit>();
                         if (_productionExit is ParkingPlaceBehaviour)
                         {


### PR DESCRIPTION
Enables some extra animations on production structures. The blinking lights caused by ActivelyConstructing don't seem to be working on the airfield, but I've used the inspector to verify the ModelConditionFlags are as expected so it may just have to do with how we choose which states to animate (I know there's a lot more work to be done there).

![OpenSage Launcher_5Y4EDff8kY-ezgif com-optimize](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/c64938da-64ff-4760-9f6c-eb43c29f1eb3)
