### PR TITLE
Implement OverchargeBehavior

### DIFF
--- a/src/OpenSage.Game/Gui/Wnd/Controls/Button.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Controls/Button.cs
@@ -44,7 +44,7 @@ namespace OpenSage.Gui.Wnd.Controls
         {
             DrawText(drawingContext, TextAlignment.Center);
 
-            if (IsMouseDown && PushedOverlayImage != null)
+            if ((IsMouseDown || IsSelected) && PushedOverlayImage != null)
             {
                 PushedOverlayImage.Draw(drawingContext, ClientRectangle);
             }

--- a/src/OpenSage.Game/Gui/Wnd/Controls/Control.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Controls/Control.cs
@@ -211,6 +211,8 @@ namespace OpenSage.Gui.Wnd.Controls
 
         public bool IsMouseOver { get; private set; }
         public bool IsMouseDown { get; private set; }
+        // used for various behaviors
+        public bool IsSelected { get; set; }
 
         /// <summary>
         /// Used to pass arbitrary data items between callbacks.

--- a/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
@@ -1,10 +1,63 @@
-﻿using OpenSage.Data.Ini;
+﻿using FixedMath.NET;
+using ImGuiNET;
+using OpenSage.Data.Ini;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
     public sealed class OverchargeBehavior : UpdateModule
     {
+        private readonly GameObject _gameObject;
+        private readonly OverchargeBehaviorModuleData _moduleData;
+        private bool _enabled;
+        public bool Enabled => _enabled;
+
+        public OverchargeBehavior(GameObject gameObject, OverchargeBehaviorModuleData moduleData)
+        {
+            _gameObject = gameObject;
+            _moduleData = moduleData;
+        }
+
+        public void Activate()
+        {
+            _enabled = true;
+            _gameObject.EnergyProduction += _gameObject.Definition.EnergyBonus;
+
+            foreach (var powerPlantUpdate in _gameObject.FindBehaviors<PowerPlantUpdate>())
+            {
+                powerPlantUpdate.ExtendRods();
+            }
+
+            // todo: this is fine for now, but generals seems to have some way of making sure it doesn't immediately sap health on subsequent toggles
+            NextUpdateFrame.Frame = _gameObject.GameContext.GameLogic.CurrentFrame.Value;
+        }
+
+        public void Deactivate()
+        {
+            _enabled = false;
+            _gameObject.EnergyProduction = _gameObject.Definition.EnergyProduction;
+
+            foreach (var powerPlantUpdate in _gameObject.FindBehaviors<PowerPlantUpdate>())
+            {
+                powerPlantUpdate.RetractRods();
+                NextUpdateFrame.Frame = uint.MaxValue;
+            }
+        }
+
+        internal override void Update(BehaviorUpdateContext context)
+        {
+            if (!_enabled || // nothing to do if we aren't currently overcharging
+                _gameObject.HealthPercentage < (Fix64)(float)_moduleData.NotAllowedWhenHealthBelowPercent || // must be above min health percent
+                context.LogicFrame.Value < NextUpdateFrame.Frame) // must be ready for us to do more damage
+            {
+                return;
+            }
+
+            // todo: is this death type right?
+            _gameObject.DoDamage(DamageType.Penalty, _gameObject.MaxHealth * (Fix64)(float)_moduleData.HealthPercentToDrainPerSecond, DeathType.Normal);
+            NextUpdateFrame.Frame += (uint)Game.LogicFramesPerSecond;
+        }
+
         internal override void Load(StatePersister reader)
         {
             reader.PersistVersion(1);
@@ -13,7 +66,12 @@ namespace OpenSage.Logic.Object
             base.Load(reader);
             reader.EndObject();
 
-            reader.SkipUnknownBytes(1);
+            reader.PersistBoolean(ref _enabled);
+        }
+
+        internal override void DrawInspector()
+        {
+            ImGui.LabelText("Overcharge", _enabled.ToString());
         }
     }
 
@@ -45,7 +103,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new OverchargeBehavior();
+            return new OverchargeBehavior(gameObject, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/PowerPlantUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/PowerPlantUpdate.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ImGuiNET;
 using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
@@ -27,6 +28,16 @@ namespace OpenSage.Logic.Object
             _rodsExtendedEndFrame = _gameObject.GameContext.GameLogic.CurrentFrame + _moduleData.RodsExtendTime;
         }
 
+        // China powerplant overcharge needs to be able to turn off
+        internal void RetractRods()
+        {
+            _rodsExtended = false;
+            _gameObject.Drawable.ModelConditionFlags.Set(ModelConditionFlag.PowerPlantUpgrading, false);
+            _gameObject.Drawable.ModelConditionFlags.Set(ModelConditionFlag.PowerPlantUpgraded, false);
+
+            _rodsExtendedEndFrame = LogicFrame.MaxValue;
+        }
+
         internal override void Update(BehaviorUpdateContext context)
         {
             base.Update(context);
@@ -49,11 +60,27 @@ namespace OpenSage.Logic.Object
 
             reader.PersistBoolean(ref _rodsExtended);
         }
+
+        internal override void DrawInspector()
+        {
+            ImGui.LabelText("Rods extended", _rodsExtended.ToString());
+            if (ImGui.Button("Extend Rods"))
+            {
+                ExtendRods();
+            }
+
+            ImGui.SameLine();
+
+            if (ImGui.Button("Retract Rods"))
+            {
+                RetractRods();
+            }
+        }
     }
 
     /// <summary>
-    /// Allows this object to act as an (upgradeable) power supply, and allows this object to use 
-    /// the <see cref="ModelConditionFlag.PowerPlantUpgrading"/> and 
+    /// Allows this object to act as an (upgradeable) power supply, and allows this object to use
+    /// the <see cref="ModelConditionFlag.PowerPlantUpgrading"/> and
     /// <see cref="ModelConditionFlag.PowerPlantUpgraded"/> model condition states.
     /// </summary>
     public sealed class PowerPlantUpdateModuleData : UpdateModuleData

--- a/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
@@ -2,7 +2,8 @@
 {
     public abstract class UpdateModule : BehaviorModule
     {
-        private UpdateFrame _updateFrame;
+        // it's also possible this is _last_ update, not next update
+        protected UpdateFrame NextUpdateFrame;
 
         internal override void Load(StatePersister reader)
         {
@@ -12,10 +13,10 @@
             base.Load(reader);
             reader.EndObject();
 
-            reader.PersistFrame(ref _updateFrame.RawValue, "UpdateFrame");
+            reader.PersistFrame(ref NextUpdateFrame.RawValue, "UpdateFrame");
         }
 
-        private struct UpdateFrame
+        protected struct UpdateFrame
         {
             public uint RawValue;
 

--- a/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
@@ -362,6 +362,23 @@ namespace OpenSage.Logic.Orders
                             }
                         }
                         break;
+                    case OrderType.ToggleOvercharge:
+                        foreach (var unit in player.SelectedUnits)
+                        {
+                            foreach (var overchargeBehavior in unit.FindBehaviors<OverchargeBehavior>())
+                            {
+                                if (overchargeBehavior.Enabled)
+                                {
+                                    overchargeBehavior.Deactivate();
+                                }
+                                else
+                                {
+                                    overchargeBehavior.Activate();
+                                }
+                            }
+                        }
+
+                        break;
                     case OrderType.Checksum:
                         break;
 

--- a/src/OpenSage.Mods.Generals/Gui/CommandButtonUtils.cs
+++ b/src/OpenSage.Mods.Generals/Gui/CommandButtonUtils.cs
@@ -25,6 +25,8 @@ namespace OpenSage.Mods.Generals.Gui
             buttonControl.HoverOverlayImage = controlBar.CommandButtonHover;
             buttonControl.PushedOverlayImage = controlBar.CommandButtonPush;
 
+            buttonControl.IsSelected = false;
+
             var objectDefinition = commandButton.Object?.Value;
             buttonControl.SystemCallback = (control, message, context) =>
             {

--- a/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
@@ -405,6 +405,10 @@ namespace OpenSage.Mods.Generals.Gui
                             case CommandType.SpecialPower:
                                 buttonControl.Visible = selectedUnit.Owner.SpecialPowerAvailable(commandButton.SpecialPower.Value);
                                 break;
+                            case CommandType.ToggleOvercharge:
+                                buttonControl.IsSelected = selectedUnit.FindBehavior<OverchargeBehavior>().Enabled;
+                                buttonControl.Show();
+                                break;
                             default:
                                 buttonControl.Enabled = true;
                                 buttonControl.Show();


### PR DESCRIPTION
Not sure if this is how UpdateModules were intended to be handled. From what I can tell in the save file, what I've renamed here to `NextUpdateFrame` is the next frame during which the UpdateModule should run. I checked my save file and this seems to apply to other modules like `DozerAIUpdate` as well (which presumably just updates every frame?). UpdateModules which aren't currently active (e.g. AutoHealBehavior in my file) seem to just have their frame set to uint maxvalue.