### PR TITLE
Spawn unit after door opens, not before

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -65,6 +65,8 @@ namespace OpenSage.Logic.Object
             {
                 if (context.LogicFrame >= _currentStepEnd)
                 {
+                    var newObject = _productionQueue[0];
+                    ProduceObject(newObject.ObjectDefinition);
                     _productionQueue.RemoveAt(0);
                     Logger.Info($"Door waiting open for {_moduleData.DoorWaitOpenTime}");
                     _currentStepEnd = context.LogicFrame + _moduleData.DoorWaitOpenTime;
@@ -100,8 +102,6 @@ namespace OpenSage.Logic.Object
 
                             GetDoorConditionFlags(out var doorOpening, out var _, out var _);
                             _gameObject.ModelConditionFlags.Set(doorOpening, true);
-
-                            ProduceObject(front.ObjectDefinition);
                         }
                         else
                         {


### PR DESCRIPTION
Not sure about the other sage games, but this is the way it works in generals/zero hour.

Before:
![OpenSage Launcher_LK6ph1Kb9K](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/bc1bd1e9-8eee-4c49-bd2c-93cf9cc167b9)

After:
![OpenSage Launcher_Ca9Y3mHZ8d](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/ef0342e6-5f0b-4f3a-aba3-51a5490f2032)
