### PR TITLE
Add color-changing health + construction bars

### DIFF
--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -730,7 +730,16 @@ namespace OpenSage.Logic.Object
             // Check if the unit is being constructed
             if (IsUnderActiveConstruction())
             {
+                var lastBuildProgress = BuildProgress;
                 BuildProgress = Math.Clamp(++ConstructionProgress / Definition.BuildTime, 0.0f, 1.0f);
+                // structures can be attacked while under construction, and their health is a factor of their build progress;
+                Health += (Fix64)(BuildProgress - lastBuildProgress) * MaxHealth;
+
+                if (Health > MaxHealth)
+                {
+                    // just in case we end up over somehow
+                    Health = MaxHealth;
+                }
 
                 if (BuildProgress >= 1.0f)
                 {
@@ -789,6 +798,7 @@ namespace OpenSage.Logic.Object
         {
             if (IsStructure)
             {
+                Health = Fix64.Zero;
                 ClearModelConditionFlags();
 
                 ModelConditionFlags.Set(ModelConditionFlag.ActivelyBeingConstructed, false);

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -473,23 +473,30 @@ namespace OpenSage
                 // TODO: Not sure what to draw for InactiveBody?
                 if (gameObject.HasActiveBody())
                 {
+                    var red = 0f;
+                    float green;
+                    var blue = 0f;
+
+                    if (gameObject.IsBeingConstructed())
+                    {
+                        green = (float)gameObject.HealthPercentage;
+                        blue = 1;
+                    }
+                    else
+                    {
+                        red = Math.Clamp((1 - (float)gameObject.HealthPercentage) * 2, 0, 1);
+                        green = Math.Clamp((float)gameObject.HealthPercentage * 2, 0, 1);
+                    }
+
                     DrawBar(
                         healthBoxRect.Value,
-                        new ColorRgbaF(0, 1, 0, 1),
+                        new ColorRgbaF(red, green, blue, 1),
                         (float)gameObject.HealthPercentage);
                 }
 
                 var yOffset = 0;
-                if (gameObject.Definition.KindOf.Get(ObjectKinds.Structure) && gameObject.IsBeingConstructed())
-                {
-                    yOffset += 4;
-                    var constructionProgressBoxRect = healthBoxRect.Value.WithY(healthBoxRect.Value.Y + yOffset);
-                    DrawBar(
-                        constructionProgressBoxRect,
-                        new ColorRgba(172, 255, 254, 255).ToColorRgbaF(),
-                        gameObject.BuildProgress);
-                }
-                else if (gameObject.ProductionUpdate != null)
+                // todo: this isn't shown in generals/zero hour
+                if (gameObject.ProductionUpdate != null)
                 {
                     yOffset += 4;
                     var productionBoxRect = healthBoxRect.Value.WithY(healthBoxRect.Value.Y + yOffset);


### PR DESCRIPTION
All behavior was tested against Zero Hour.

## Units
Health bars now change color as a unit is damaged. They go from `#00FF00` at full health to `#FFFF00` at 50% health and `#FF0000` at no health.

![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/529b9f89-4a04-4016-842f-d7b425809fd7)
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/3f413af1-2e1d-4f0f-9feb-7d69345d7b14)
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/30addd6a-0a46-4e57-b48e-e551ddb0f17b)
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/86fb6719-6f54-45d0-aefd-948ebe96ef3a)
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/bc2a6998-2c1e-43e9-a9d9-464f767bd0f5)

## Structures (under construction)
Health bars of under-construction structures are also changed, and now go from `#0000FF` at 0% health to `#00FFFF` at full health. The bar also shows health instead of construction progress. This means that if a structure is damaged while under construction, construction will complete before the bar reaches 100%. This is exactly how it behaves in Generals/Zero Hour. It also means a structure doesn't immediately have full health despite not being constructed at all - which of course makes sense, as in generals/zh scaffolds can be one-shot by basically anything that can damage them, and structures which haven't been constructed much are very easy to destroy.

![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/74fe4f2a-5ccb-4cbd-9f21-e0a55f6dc32d)
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/f1194301-a417-4511-b422-62e1e3d48c7c)
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/bc9bf143-c9eb-4d6a-bce1-92989a7a94ac)

## Production bar
What is the production bar for? It doesn't exist in generals, so I'm not clear what it's purpose is. Is it in later SAGE games? Should we put it under a game flag?
