### PR TITLE
Fix NPE when running Sav2Json tool

### DIFF
--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -532,7 +532,7 @@ namespace OpenSage
                 OrderGenerator = AddDisposable(new OrderGeneratorSystem(this));
 
                 Panel.ClientSizeChanged += OnPanelSizeChanged;
-                Panel.EnsureFrame(window.ClientBounds);
+                Panel.EnsureFrame(window?.ClientBounds ?? new Mathematics.Rectangle(0, 0, 1, 1)); // fallback set for sav2json tool
 
                 GameSystems.ForEach(gs => gs.Initialize());
 


### PR DESCRIPTION
A bit of a hack, but it does get the sav2json tool working (though it still crashes upon completion of writing the json file, but at least it's able to write the json file).

This cropped up with one of the recent library upgrades.