### PR TITLE
Apply Hover and Pushed overlay images to production queue

### DIFF
--- a/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
@@ -361,10 +361,8 @@ namespace OpenSage.Mods.Generals.Gui
             {
                 for (var i = 1; i < 100; i++) // Generals has 12 buttons and Zero Hour has 14, but there's no need to set those values as the limit in the code
                 {
-                    var buttonControl = controlBar._commandWindow.Controls.FindControl($"ControlBar.wnd:ButtonCommand{i:D2}") as Button;
-
                     // the amount of ButtonCommand children in ControlBar.wnd defines how many buttons the game will have in-game
-                    if (controlBar._commandWindow.Controls.FindControl($"ControlBar.wnd:ButtonCommand{i:D2}") == null)
+                    if (controlBar._commandWindow.Controls.FindControl($"ControlBar.wnd:ButtonCommand{i:D2}") is not Button buttonControl)
                         break;
 
                     if (commandSet != null && commandSet.Buttons.TryGetValue(i, out var commandButtonReference))
@@ -475,13 +473,14 @@ namespace OpenSage.Mods.Generals.Gui
 
                     for (var pos = 0; pos < PRODUCTION_QUEUE_SIZE; pos++)
                     {
-                        var queueButton = productionQueueWindow.Controls.FindControl($"ControlBar.wnd:ButtonQueue0{pos + 1}");
-
-                        if (queueButton == null)
+                        if (productionQueueWindow.Controls.FindControl($"ControlBar.wnd:ButtonQueue0{pos + 1}") is not Button queueButton)
                         {
                             _logger.Warn($"Could not find the right control (ControlBar.wnd:ButtonQueue0{pos + 1})");
                             continue;
                         }
+
+                        queueButton.HoverOverlayImage = controlBar.CommandButtonHover;
+                        queueButton.PushedOverlayImage = controlBar.CommandButtonPush;
 
                         Image img = null;
                         Image overlayImage = null;


### PR DESCRIPTION
## Hover
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/c577d464-8176-4b62-bcf4-c518b16d9fa4)

## Pushed
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/b19d95cc-371e-4e2c-87bd-f76151773730)
