### PR TITLE
Use BuildUpClockColor overlay for purchased upgrades

### DIFF
--- a/src/OpenSage.Game/Gui/Wnd/Controls/Button.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Controls/Button.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using OpenSage.Data.Wnd;
 using OpenSage.Gui.Wnd.Images;
 using OpenSage.Mathematics;
@@ -48,7 +48,7 @@ namespace OpenSage.Gui.Wnd.Controls
             {
                 PushedOverlayImage.Draw(drawingContext, ClientRectangle);
             }
-            else if (IsMouseOver && HoverOverlayImage != null)
+            else if (Enabled && IsMouseOver && HoverOverlayImage != null)
             {
                 HoverOverlayImage.Draw(drawingContext, ClientRectangle);
             }

--- a/src/OpenSage.Game/Gui/Wnd/Controls/Control.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Controls/Control.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using OpenSage.Gui.Wnd.Images;
 using OpenSage.Mathematics;
@@ -204,6 +204,10 @@ namespace OpenSage.Gui.Wnd.Controls
         // TODO: Move these into better Animation classes.
         public ColorRgbaF? BackgroundColorOverride { get; set; }
         public ColorRgbaF? OverlayColor { get; set; }
+        /// <summary>
+        /// Used for construction in progress overlay.
+        /// </summary>
+        public float OverlayRadialPercentage { get; set; }
 
         public float Opacity { get; set; } = 1;
 
@@ -387,7 +391,10 @@ namespace OpenSage.Gui.Wnd.Controls
 
             if (!Enabled)
             {
-                image = DisabledBackgroundImage ?? image;
+                if (OverlayColor == null)
+                {
+                    image = DisabledBackgroundImage ?? image;
+                }
             }
             else if (IsMouseOver)
             {
@@ -439,9 +446,11 @@ namespace OpenSage.Gui.Wnd.Controls
             var overlayColor = OverlayColor.Value;
             overlayColor = overlayColor.WithA(overlayColor.A * TextOpacity);
 
-            drawingContext.FillRectangle(
+            // Draw radial progress indicator.
+            drawingContext.FillRectangleRadial360(
                 ClientRectangle,
-                overlayColor);
+                overlayColor,
+                OverlayRadialPercentage);
         }
 
         protected void DrawText(DrawingContext2D drawingContext, TextAlignment textAlignment)
@@ -479,7 +488,12 @@ namespace OpenSage.Gui.Wnd.Controls
 
         public void DefaultInput(Control control, WndWindowMessage message, ControlCallbackContext context)
         {
-            if (!Enabled) return;
+            if (!Enabled)
+            {
+                IsMouseOver = false;
+                IsMouseDown = false;
+                return;
+            }
 
             switch (message.MessageType)
             {

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -775,7 +775,7 @@ namespace OpenSage.Logic.Object
                 : _upgrades.Contains(upgrade);
         }
 
-        private bool HasEnqueuedUpgrade(UpgradeTemplate upgrade)
+        public bool HasEnqueuedUpgrade(UpgradeTemplate upgrade)
         {
             return upgrade.Type == UpgradeType.Player
                 ? Owner.HasEnqueuedUpgrade(upgrade)

--- a/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
@@ -381,6 +381,7 @@ namespace OpenSage.Mods.Generals.Gui
 
                         var objectDefinition = commandButton.Object?.Value;
 
+                        buttonControl.OverlayColor = null;
                         switch (commandButton.Command)
                         {
                             // Disable the button when the unit is not produceable
@@ -398,8 +399,16 @@ namespace OpenSage.Mods.Generals.Gui
                             // Disable the button when the object already has it etc.
                             case CommandType.PlayerUpgrade:
                             case CommandType.ObjectUpgrade:
-                                // todo: button should still have some color (not full color), but be disabled in the event it has already been purchased
-                                buttonControl.Enabled = selectedUnit.CanEnqueueUpgrade(commandButton.Upgrade.Value);
+                                var canEnqueueUpgrade = selectedUnit.CanEnqueueUpgrade(commandButton.Upgrade.Value);
+                                buttonControl.Enabled = canEnqueueUpgrade;
+
+                                if (!canEnqueueUpgrade)
+                                {
+                                    var hasPurchasedUpgrade = selectedUnit.HasUpgrade(commandButton.Upgrade.Value) ||
+                                                              selectedUnit.HasEnqueuedUpgrade(commandButton.Upgrade.Value);
+                                    buttonControl.OverlayColor = hasPurchasedUpgrade ? controlBar._scheme.BuildUpClockColor.ToColorRgbaF() : null;
+                                }
+
                                 buttonControl.Show();
                                 break;
                             case CommandType.SpecialPower:
@@ -492,13 +501,9 @@ namespace OpenSage.Mods.Generals.Gui
                             {
                                 queueButton.DrawCallback = (control, drawingContext) =>
                                 {
+                                    queueButton.OverlayColor = controlBar._scheme.BuildUpClockColor.ToColorRgbaF();
+                                    queueButton.OverlayRadialPercentage = job.Progress;
                                     queueButton.DefaultDraw(control, drawingContext);
-
-                                    // Draw radial progress indicator.
-                                    drawingContext.FillRectangleRadial360(
-                                        control.ClientRectangle,
-                                        controlBar._scheme.BuildUpClockColor.ToColorRgbaF(),
-                                        job.Progress);
                                 };
 
                                 if (job.Type == ProductionJobType.Unit)


### PR DESCRIPTION
In this screenshot, the flashbang upgrade has already been purchased, and the capture upgrade is queued. As such, both are disabled, but are _not_ grayscale.
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/686a1080-ab33-493f-a9f6-5eab54723c4c)
