### PR TITLE
Move construction management to DozerAndWorkerState

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
@@ -72,7 +72,7 @@ namespace OpenSage.Logic.Object
                     if (!instant)
                     {
                         baseObject.PrepareConstruction();
-                        baseObject.Construct();
+                        baseObject.SetIsBeingConstructed();
                         baseObject.BuildProgress = 0.0f;
                     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -186,7 +186,18 @@ namespace OpenSage.Logic.Object
         {
         }
 
-        internal void Stop()
+        /// <summary>
+        /// Ceases all behavior by the unit, like when the stop button is pressed.
+        /// </summary>
+        internal virtual void Stop()
+        {
+            StopMovingOnly();
+        }
+
+        /// <summary>
+        /// Stops moving, but does not clear any additional state machine behavior that might be running (e.g. construction, supply gathering, etc)
+        /// </summary>
+        private void StopMovingOnly()
         {
             GameObject.ModelConditionFlags.Set(ModelConditionFlag.Moving, false);
             _waypointEnumerator?.Dispose();
@@ -216,7 +227,7 @@ namespace OpenSage.Logic.Object
             else
             {
                 ArrivedAtDestination();
-                Stop();
+                StopMovingOnly();
             }
         }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAndWorkerState.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAndWorkerState.cs
@@ -1,0 +1,269 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using OpenSage.Logic.AI;
+
+namespace OpenSage.Logic.Object;
+
+internal sealed class DozerAndWorkerState
+{
+    public GameObject? BuildTarget => TryGetBuildTarget(out var buildTarget) ? buildTarget : null;
+    public GameObject? RepairTarget => TryGetRepairTarget(out var repairTarget) ? repairTarget : null;
+
+    private readonly GameObject _gameObject;
+    private readonly GameContext _context;
+    private readonly IBuilderAIUpdateData _moduleData;
+
+    private readonly DozerTarget[] _dozerTargets = new DozerTarget[3];
+    private readonly WorkerAIUpdateStateMachine1 _stateMachine = new();
+    private int _unknown2;
+    private readonly DozerSomething2[] _unknownList2 = new DozerSomething2[9]; // these seem to be in groups of 3, one group for each target
+    private int _unknown4;
+
+    public DozerAndWorkerState(GameObject gameObject, GameContext context, IBuilderAIUpdateData moduleData)
+    {
+        _gameObject = gameObject;
+        _context = context;
+        _moduleData = moduleData;
+    }
+
+    // todo: This is really state _machine_ behavior, and should be moved there when we better understand the fields
+    public void Update(BehaviorUpdateContext updateContext)
+    {
+        if (TryGetBuildTarget(out var buildTarget))
+        {
+            UpdateBuildTarget(buildTarget);
+        }
+        else if (TryGetRepairTarget(out var repairTarget))
+        {
+            UpdateRepairTarget(repairTarget, updateContext);
+        }
+    }
+
+    public void ArrivedAtDestination()
+    {
+        if (BuildTarget != null || RepairTarget != null)
+        {
+            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.ActivelyConstructing, true);
+        }
+    }
+
+    private void UpdateBuildTarget(GameObject buildTarget)
+    {
+        if (!buildTarget.IsUnderActiveConstruction() && buildTarget.CollidesWith(_gameObject))
+        {
+            buildTarget.SetIsBeingConstructed();
+        }
+        else if (_gameObject.ModelConditionFlags.Get(ModelConditionFlag.ActivelyConstructing))
+        {
+            // advance construction
+            buildTarget.AdvanceConstruction();
+
+            if (buildTarget is { BuildProgress: >= 1 })
+            {
+                ClearDozerTasks();
+                _context.AudioSystem.PlayAudioEvent(_gameObject, _gameObject.Definition.VoiceTaskComplete.Value);
+            }
+        }
+    }
+
+    private void UpdateRepairTarget(GameObject repairTarget, BehaviorUpdateContext updateContext)
+    {
+        if (repairTarget.IsFullHealth)
+        {
+            ClearDozerTasks();
+            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.ActivelyConstructing, false);
+        }
+        else if (repairTarget.HealedEndFrame <= updateContext.LogicFrame.Value)
+        {
+            // advance repair progress
+            repairTarget.HealedByObjectId = _gameObject.ID;
+            repairTarget.Heal(_moduleData.RepairHealthPercentPerSecond);
+            repairTarget.HealedEndFrame = (updateContext.LogicFrame + LogicFrameSpan.OneSecond).Value;
+        }
+    }
+
+    public void ClearDozerTasks()
+    {
+        ClearBuildTarget();
+        ClearRepairTarget();
+    }
+
+    private bool TryGetBuildTarget([NotNullWhen(true)] out GameObject? gameObject)
+    {
+        var id = _dozerTargets[0].ObjectId;
+        if (id > 0)
+        {
+            gameObject = _context.GameObjects.GetObjectById(id);
+            return true;
+        }
+
+        gameObject = null;
+        return false;
+    }
+
+    public void SetBuildTarget(GameObject buildTarget, uint currentFrame)
+    {
+        _dozerTargets[0] = new DozerTarget { ObjectId = buildTarget.ID, OrderFrame = currentFrame };
+        // these are both set to the unit currently (or most recently) constructing the object
+        buildTarget.CreatedByObjectID =  _gameObject.ID;
+        buildTarget.BuiltByObjectID = _gameObject.ID;
+    }
+
+    private void ClearBuildTarget()
+    {
+        _gameObject.ModelConditionFlags.Set(ModelConditionFlag.ActivelyConstructing, false);
+        _dozerTargets[0] = new DozerTarget();
+    }
+
+    private bool TryGetRepairTarget([NotNullWhen(true)] out GameObject? gameObject)
+    {
+        var id = _dozerTargets[1].ObjectId;
+        if (id > 0)
+        {
+            gameObject = _context.GameObjects.GetObjectById(id);
+            return true;
+        }
+
+        gameObject = null;
+        return false;
+    }
+
+    public void SetRepairTarget(GameObject repairTarget, uint currentFrame)
+    {
+        repairTarget.HealedByObjectId = _gameObject.ID;
+        _dozerTargets[1] = new DozerTarget { ObjectId = repairTarget.ID, OrderFrame = currentFrame };
+    }
+
+    private void ClearRepairTarget()
+    {
+        if (TryGetRepairTarget(out var repairTarget))
+        {
+            repairTarget.HealedByObjectId = 0;
+            repairTarget.HealedEndFrame = 0;
+        }
+        _dozerTargets[1] = new DozerTarget();
+    }
+
+    public void Persist(StatePersister reader)
+    {
+        reader.PersistArrayWithUInt32Length(
+            _dozerTargets,
+            static (StatePersister persister, ref DozerTarget item) =>
+            {
+                persister.PersistObjectValue(ref item);
+            });
+
+        reader.PersistObject(_stateMachine);
+        reader.PersistInt32(ref _unknown2);
+
+        var unknown3 = 3;
+        reader.PersistInt32(ref unknown3);
+        if (unknown3 != 0 && unknown3 != 3 && unknown3 != 257)
+        {
+            throw new InvalidStateException();
+        }
+
+        reader.PersistArray(
+            _unknownList2,
+            static (StatePersister persister, ref DozerSomething2 item) =>
+            {
+                persister.PersistObjectValue(ref item);
+            });
+
+        reader.PersistInt32(ref _unknown4);
+    }
+
+    private struct DozerTarget : IPersistableObject
+    {
+        public uint ObjectId;
+        public uint OrderFrame;
+
+        public void Persist(StatePersister persister)
+        {
+            persister.PersistObjectID(ref ObjectId);
+            persister.PersistUInt32(ref OrderFrame);
+        }
+    }
+
+    private struct DozerSomething2 : IPersistableObject
+    {
+        public bool UnknownBool; // potentially whether the related dozertarget is active (assuming 3 DozerSomething2 for each DozerTarget)
+        public Vector3 UnknownPos;
+
+        public void Persist(StatePersister persister)
+        {
+            persister.PersistBoolean(ref UnknownBool);
+            persister.PersistVector3(ref UnknownPos);
+        }
+    }
+
+    private sealed class WorkerAIUpdateStateMachine1 : StateMachineBase
+    {
+        public WorkerAIUpdateStateMachine1()
+        {
+            AddState(0, new WorkerUnknown0State());
+            AddState(1, new WorkerUnknown1State());
+            AddState(2, new WorkerUnknown2State());
+        }
+
+        public override void Persist(StatePersister reader)
+        {
+            reader.PersistVersion(1);
+
+            reader.BeginObject("Base");
+            base.Persist(reader);
+            reader.EndObject();
+        }
+
+        private sealed class WorkerUnknown0State : State
+        {
+            private int _unknown1;
+            private int _unknown2;
+            private bool _unknown3;
+
+            public override void Persist(StatePersister reader)
+            {
+                reader.PersistVersion(1);
+
+                reader.PersistInt32(ref _unknown1);
+                reader.PersistInt32(ref _unknown2);
+                reader.PersistBoolean(ref _unknown3);
+            }
+        }
+
+        private sealed class WorkerUnknown1State : State
+        {
+            public override void Persist(StatePersister reader)
+            {
+                reader.PersistVersion(1);
+
+                reader.SkipUnknownBytes(4);
+
+                var unknown2 = 1;
+                reader.PersistInt32(ref unknown2);
+                if (unknown2 != 1)
+                {
+                    throw new InvalidStateException();
+                }
+
+                reader.SkipUnknownBytes(1);
+            }
+        }
+
+        private sealed class WorkerUnknown2State : State
+        {
+            private int _unknown1;
+            private int _unknown2;
+            private bool _unknown3;
+
+            public override void Persist(StatePersister reader)
+            {
+                reader.PersistVersion(1);
+
+                reader.PersistInt32(ref _unknown1);
+                reader.PersistInt32(ref _unknown2);
+                reader.PersistBoolean(ref _unknown3);
+            }
+        }
+    }
+}

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/IBuilderAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/IBuilderAIUpdate.cs
@@ -1,15 +1,16 @@
-﻿namespace OpenSage.Logic.Object
+﻿namespace OpenSage.Logic.Object;
+
+/// <summary>
+/// Should be implemented by any class which inherits <see cref="AIUpdate"/> and is used by a <see cref="ObjectKinds.Dozer"/> unit.
+/// </summary>
+/// <remarks>
+/// This interface is implemented by <see cref="DozerAIUpdate"/> and <see cref="WorkerAIUpdate"/>, since the GLA
+/// worker is also a supply unit.
+/// </remarks>
+public interface IBuilderAIUpdate
 {
-    /// <summary>
-    /// Should be implemented by any class which inherits <see cref="AIUpdate"/> and is used by a <see cref="ObjectKinds.Dozer"/> unit.
-    /// </summary>
-    /// <remarks>
-    /// This interface is implemented by <see cref="DozerAIUpdate"/> and <see cref="WorkerAIUpdate"/>, since the GLA
-    /// worker is also a supply unit.
-    /// </remarks>
-    public interface IBuilderAIUpdate
-    {
-        void SetBuildTarget(GameObject gameObject);
-        bool HasBuildTarget { get; }
-    }
+    void SetBuildTarget(GameObject gameObject);
+    void SetRepairTarget(GameObject gameObject);
+    GameObject? BuildTarget { get; }
+    GameObject? RepairTarget { get; }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/IBuilderAIUpdateData.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/IBuilderAIUpdateData.cs
@@ -1,0 +1,17 @@
+﻿using OpenSage.Mathematics;
+
+namespace OpenSage.Logic.Object;
+
+/// <summary>
+/// Should be implemented by any module data class which inherits <see cref="AIUpdateModuleData"/> and is used by a <see cref="ObjectKinds.Dozer"/> unit.
+/// </summary>
+/// <remarks>
+/// This interface is implemented by <see cref="DozerAIUpdateModuleData"/> and <see cref="WorkerAIUpdateModuleData"/>, since the GLA
+/// worker is also a supply unit.
+/// </remarks>
+public interface IBuilderAIUpdateData
+{
+    public Percentage RepairHealthPercentPerSecond { get; }
+    public LogicFrameSpan BoredTime { get; }
+    public int BoredRange { get; }
+}

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
@@ -8,21 +8,37 @@ namespace OpenSage.Logic.Object
 {
     public class WorkerAIUpdate : SupplyAIUpdate, IBuilderAIUpdate
     {
-        public bool HasBuildTarget => _buildTarget != null;
+        public GameObject? BuildTarget => _state.BuildTarget;
+        public GameObject? RepairTarget => _state.RepairTarget;
 
-        private WorkerAIUpdateModuleData _moduleData;
-        private GameObject _buildTarget;
+        private readonly GameContext _context;
+        private readonly WorkerAIUpdateModuleData _moduleData;
 
-        private readonly DozerAndWorkerState _state = new();
+        private readonly DozerAndWorkerState _state;
 
         private readonly WorkerAIUpdateStateMachine2 _stateMachine2 = new();
         private uint _unknownObjectId;
         private int _unknown5;
+        private int _unknown6;
         private readonly WorkerAIUpdateStateMachine3 _stateMachine3 = new();
 
-        internal WorkerAIUpdate(GameObject gameObject, WorkerAIUpdateModuleData moduleData) : base(gameObject, moduleData)
+        internal WorkerAIUpdate(GameObject gameObject, GameContext context, WorkerAIUpdateModuleData moduleData) : base(gameObject, moduleData)
         {
+            _context = context;
             _moduleData = moduleData;
+            _state = new DozerAndWorkerState(gameObject, context, moduleData);
+        }
+
+        internal override void Stop()
+        {
+            _state.ClearDozerTasks();
+            // todo: stop supply gathering?
+            base.Stop();
+        }
+
+        protected override void ArrivedAtDestination()
+        {
+            _state.ArrivedAtDestination();
         }
 
         #region Dozer stuff
@@ -32,36 +48,33 @@ namespace OpenSage.Logic.Object
             // note that the order here is important, as SetTargetPoint will clear any existing buildTarget
             // TODO: target should not be directly on the building, but rather a point along the foundation perimeter
             SetTargetPoint(gameObject.Translation);
-            CurrentSupplyTarget = null;
-            SupplyGatherState = SupplyGatherStates.Default;
-            _buildTarget = gameObject;
+            _state.SetBuildTarget(gameObject, _context.GameLogic.CurrentFrame.Value);
+            ResetSupplyState();
+        }
+
+        public void SetRepairTarget(GameObject gameObject)
+        {
+            // note that the order here is important, as SetTargetPoint will clear any existing repairTarget
+            SetTargetPoint(gameObject.Translation);
+            _state.SetRepairTarget(gameObject, _context.GameLogic.CurrentFrame.Value);
+            ResetSupplyState();
         }
 
         internal override void SetTargetPoint(Vector3 targetPoint)
         {
+            _state.ClearDozerTasks();
             base.SetTargetPoint(targetPoint);
-            GameObject.ModelConditionFlags.Set(ModelConditionFlag.ActivelyConstructing, false);
-            _buildTarget?.PauseConstruction();
-            ClearBuildTarget();
-        }
-
-        protected override void ArrivedAtDestination()
-        {
-            base.ArrivedAtDestination();
-
-            if (_buildTarget is not null)
-            {
-                _buildTarget.Construct();
-                GameObject.ModelConditionFlags.Set(ModelConditionFlag.ActivelyConstructing, true);
-            }
-        }
-
-        private void ClearBuildTarget()
-        {
-            _buildTarget = null;
         }
 
         #endregion
+
+        #region Supply Stuff
+
+        private void ResetSupplyState()
+        {
+            CurrentSupplyTarget = null;
+            SupplyGatherState = SupplyGatherStates.Default;
+        }
 
         internal override void ClearConditionFlags()
         {
@@ -164,38 +177,25 @@ namespace OpenSage.Logic.Object
             GameObject.ModelConditionFlags.Set(ModelConditionFlag.HarvestAction, false);
         }
 
+        #endregion
+
         internal override void Update(BehaviorUpdateContext context)
         {
             base.Update(context);
+            _state.Update(context);
 
-            if (_buildTarget?.ModelConditionFlags.Get(ModelConditionFlag.DestroyedWhilstBeingConstructed) == true)
-            {
-                ClearBuildTarget();
-                Stop();
-                return;
-            }
+            var isMoving = GameObject.ModelConditionFlags.Get(ModelConditionFlag.Moving);
 
-            if (_buildTarget != null && _buildTarget.BuildProgress >= 1)
+            switch (SupplyGatherState)
             {
-                ClearBuildTarget();
-                GameObject.ModelConditionFlags.Set(ModelConditionFlag.ActivelyConstructing, false);
-                GameObject.GameContext.AudioSystem.PlayAudioEvent(GameObject, GameObject.Definition.VoiceTaskComplete.Value);
-            }
-            else
-            {
-                var isMoving = GameObject.ModelConditionFlags.Get(ModelConditionFlag.Moving);
-
-                switch (SupplyGatherState)
-                {
-                    case SupplyGatherStates.Default:
-                        if (!isMoving)
-                        {
-                            SupplyGatherState = SupplyGatherStateToResume;
-                            break;
-                        }
-                        _waitUntil = context.LogicFrame + _moduleData.BoredTime;
+                case SupplyGatherStates.Default:
+                    if (!isMoving)
+                    {
+                        SupplyGatherState = SupplyGatherStateToResume;
                         break;
-                }
+                    }
+                    _waitUntil = context.LogicFrame + _moduleData.BoredTime;
+                    break;
             }
         }
 
@@ -213,7 +213,7 @@ namespace OpenSage.Logic.Object
             reader.PersistObjectID(ref _unknownObjectId);
             reader.PersistInt32(ref _unknown5);
 
-            reader.SkipUnknownBytes(1);
+            reader.PersistInt32(ref _unknown6); // was 1 when worker was carrying supplies, wandering around cc with no supply stash available
 
             reader.PersistObject(_stateMachine3);
         }
@@ -249,59 +249,6 @@ namespace OpenSage.Logic.Object
                 {
                     // No version?
                 }
-            }
-        }
-    }
-
-    internal sealed class WorkerAIUpdateStateMachine1 : StateMachineBase
-    {
-        public WorkerAIUpdateStateMachine1()
-        {
-            AddState(0, new WorkerUnknown0State());
-            AddState(1, new WorkerUnknown1State());
-        }
-
-        public override void Persist(StatePersister reader)
-        {
-            reader.PersistVersion(1);
-
-            reader.BeginObject("Base");
-            base.Persist(reader);
-            reader.EndObject();
-        }
-
-        private sealed class WorkerUnknown0State : State
-        {
-            private int _unknown1;
-            private int _unknown2;
-            private bool _unknown3;
-
-            public override void Persist(StatePersister reader)
-            {
-                reader.PersistVersion(1);
-
-                reader.PersistInt32(ref _unknown1);
-                reader.PersistInt32(ref _unknown2);
-                reader.PersistBoolean(ref _unknown3);
-            }
-        }
-
-        private sealed class WorkerUnknown1State : State
-        {
-            public override void Persist(StatePersister reader)
-            {
-                reader.PersistVersion(1);
-
-                reader.SkipUnknownBytes(4);
-
-                var unknown2 = 1;
-                reader.PersistInt32(ref unknown2);
-                if (unknown2 != 1)
-                {
-                    throw new InvalidStateException();
-                }
-
-                reader.SkipUnknownBytes(1);
             }
         }
     }
@@ -372,7 +319,7 @@ namespace OpenSage.Logic.Object
     /// VoiceTaskComplete within UnitSpecificSounds section of the object.
     /// Requires Kindof = DOZER.
     /// </summary>
-    public sealed class WorkerAIUpdateModuleData : SupplyAIUpdateModuleData
+    public sealed class WorkerAIUpdateModuleData : SupplyAIUpdateModuleData, IBuilderAIUpdateData
     {
         internal new static WorkerAIUpdateModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
 
@@ -410,7 +357,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new WorkerAIUpdate(gameObject, this);
+            return new WorkerAIUpdate(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
@@ -411,7 +411,7 @@ namespace OpenSage.Mods.Generals.Gui
                         {
                             // Disable the button when the unit is not produceable
                             case CommandType.DozerConstruct:
-                                var isBuilding = selectedUnit.IsKindOf(ObjectKinds.Dozer) && (selectedUnit.AIUpdate as IBuilderAIUpdate)?.HasBuildTarget == true; // todo: can we remove this cast in the future?
+                                var isBuilding = selectedUnit.IsKindOf(ObjectKinds.Dozer) && selectedUnit.AIUpdate is IBuilderAIUpdate { BuildTarget: not null };
                                 buttonControl.Enabled = selectedUnit.CanConstructUnit(objectDefinition) && !isBuilding;
                                 buttonControl.Show();
                                 break;


### PR DESCRIPTION
Also fixes flags which were being set correctly, and scaffolds behavior for repairing buildings.

This has slight consequences in that now no model is shown when a scaffold is placed and construction has not yet begun, but that's actually more correct - previously we were showing the scaffolding model which was incorrect. We should just be showing the fence model, which we weren't before and still aren't now (see #795)