### PR TITLE
Add ammo pips

### DIFF
--- a/src/OpenSage.Game/Client/Drawable.cs
+++ b/src/OpenSage.Game/Client/Drawable.cs
@@ -171,6 +171,7 @@ namespace OpenSage.Client
         {
             if (_animationMap.Remove(animationType))
             {
+                // todo: this can result in a lot of allocations
                 _animations = _animations.Where(a => a.AnimationType != animationType).ToList();
             }
         }

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -152,6 +152,7 @@ namespace OpenSage.Logic.Object
 
         internal BitArray<WeaponSetConditions> WeaponSetConditions;
         private readonly WeaponSet _weaponSet;
+        public WeaponSet ActiveWeaponSet => _weaponSet;
 
         public readonly ObjectDefinition Definition;
 

--- a/src/OpenSage.Game/Logic/Object/Weapon/Weapon.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/Weapon.cs
@@ -3,7 +3,7 @@ using ImGuiNET;
 
 namespace OpenSage.Logic.Object
 {
-    internal sealed class Weapon : IPersistableObject
+    public sealed class Weapon : IPersistableObject
     {
         private readonly ModelConditionFlag _usingFlag;
 
@@ -37,7 +37,7 @@ namespace OpenSage.Logic.Object
             internal set => _currentRounds = value;
         }
 
-        public WeaponTarget CurrentTarget { get; private set; }
+        internal WeaponTarget CurrentTarget { get; private set; }
 
         private Vector3? CurrentTargetPosition => CurrentTarget?.TargetPosition;
 
@@ -94,7 +94,7 @@ namespace OpenSage.Logic.Object
             CurrentRounds = Template.ClipSize;
         }
 
-        public void SetTarget(WeaponTarget target)
+        internal void SetTarget(WeaponTarget target)
         {
             if (CurrentTarget == target)
             {

--- a/src/OpenSage.Game/Logic/Object/Weapon/WeaponSet.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/WeaponSet.cs
@@ -1,4 +1,5 @@
-﻿using OpenSage.Mathematics;
+﻿using System.Collections.Generic;
+using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
@@ -16,6 +17,7 @@ namespace OpenSage.Logic.Object
         private bool _unknown4;
 
         internal Weapon CurrentWeapon => _weapons[(int) _currentWeaponSlot];
+        public IEnumerable<Weapon> Weapons => _weapons;
 
         internal WeaponSet(GameObject gameObject)
         {

--- a/src/OpenSage.Mathematics/SizeF.cs
+++ b/src/OpenSage.Mathematics/SizeF.cs
@@ -59,5 +59,10 @@ namespace OpenSage.Mathematics
         {
             return !(f1 == f2);
         }
+
+        public static SizeF operator *(SizeF size, float multiplier)
+        {
+            return new SizeF(size.Width * multiplier, size.Height * multiplier);
+        }
     }
 }


### PR DESCRIPTION
Pips show for weapons which have them enabled, and only when the unit is selected (notice the raptor is not selected, and so no pips are shown).

This new pip placement is objectively worse than a previous version of this PR, though I'll argue it surfaces the real issue which is that our health bars aren't positioned correctly. There's also the manner of the `PipScreenOffset` parameters, which I don't quite understand how to implement.

```ini
AmmoPipScreenOffset = X:-1.0 Y:0.0        ; note that this is a multiplier to boundingspheresize, NOT an absolute offset
ContainerPipScreenOffset = X:1.0 Y:0.0    ; note that this is a multiplier to boundingspheresize, NOT an absolute offset
```

### OpenSAGE
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/c57f56e2-41c5-419b-b37d-24a97e2f7986)

### Vanilla generals
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/d97c18ca-633e-46c2-88af-545bf679c7ee)

