### PR TITLE
Select proper ModelConditionState when building structures

### DIFF
--- a/src/OpenSage.Game.Tests/Logic/Draw/W3dModelDrawTests.cs
+++ b/src/OpenSage.Game.Tests/Logic/Draw/W3dModelDrawTests.cs
@@ -1,0 +1,112 @@
+﻿using System.Collections.Generic;
+using OpenSage.Logic.Object;
+using OpenSage.Mathematics;
+using Xunit;
+
+namespace OpenSage.Tests.Logic.Draw;
+
+public class W3dModelDrawTests
+{
+    [Theory]
+    [InlineData(new[] { ModelConditionFlag.AwaitingConstruction })]
+    [InlineData(new[] { ModelConditionFlag.Sold, ModelConditionFlag.Night, ModelConditionFlag.Snow, ModelConditionFlag.ReallyDamaged })]
+    [InlineData(new[] { ModelConditionFlag.Damaged, ModelConditionFlag.Snow })]
+    [InlineData(new[] { ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed, ModelConditionFlag.Night, ModelConditionFlag.Snow, ModelConditionFlag.ReallyDamaged })]
+    public void FindBestFittingConditionState_TestExactMatch(ModelConditionFlag[] providedFlags)
+    {
+        var flags = new BitArray<ModelConditionFlag>(providedFlags);
+        var bestConditionState = W3dModelDraw.FindBestFittingConditionState(ModelConditionStates(), flags);
+        Assert.Contains(bestConditionState.ConditionFlags, f => f.CountIntersectionBits(flags) == flags.NumBitsSet); // .equals wasn't working?
+    }
+
+    [Theory]
+    [InlineData(new[] { ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed }, new[] { ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.Garrisoned })] // we can DEFINITELY have extra flags - I'm not sure if this is the result that would be returned though
+    [InlineData(new[] { ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed }, new[] { ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed })]
+    [InlineData(new[] { ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed, ModelConditionFlag.Night, ModelConditionFlag.Snow, ModelConditionFlag.Damaged }, new[] { ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed, ModelConditionFlag.Night, ModelConditionFlag.Snow, ModelConditionFlag.Damaged })]
+    [InlineData(new[] { ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed, ModelConditionFlag.Night }, new[] { ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed, ModelConditionFlag.Night })]
+    public void FindBestFittingConditionState_TestPartialMatch(ModelConditionFlag[] expectedFlags, ModelConditionFlag[] providedFlags)
+    {
+        var flags = new BitArray<ModelConditionFlag>(providedFlags);
+        var expected = new BitArray<ModelConditionFlag>(expectedFlags);
+        var bestConditionState = W3dModelDraw.FindBestFittingConditionState(ModelConditionStates(), flags);
+        Assert.Contains(bestConditionState.ConditionFlags, f => f.CountIntersectionBits(expected) == expected.NumBitsSet); // .equals wasn't working?
+    }
+
+    /// <summary>
+    /// Example model condition states take from usa AmericaBarracks ModuleTag_01
+    /// </summary>
+    /// <returns></returns>
+    private static List<ModelConditionState> ModelConditionStates()
+    {
+        return [
+            CreateModelConditionState(ModelConditionFlag.None),
+            CreateModelConditionState(ModelConditionFlag.Damaged),
+            CreateModelConditionState(ModelConditionFlag.ReallyDamaged, ModelConditionFlag.Rubble),
+            CreateModelConditionState(ModelConditionFlag.Night),
+            CreateModelConditionState(ModelConditionFlag.Damaged, ModelConditionFlag.Night),
+            CreateModelConditionState(ModelConditionFlag.ReallyDamaged, ModelConditionFlag.Rubble, ModelConditionFlag.Night),
+            CreateModelConditionState(ModelConditionFlag.Snow),
+            CreateModelConditionState(ModelConditionFlag.Damaged, ModelConditionFlag.Snow),
+            CreateModelConditionState(ModelConditionFlag.ReallyDamaged, ModelConditionFlag.Rubble, ModelConditionFlag.Snow),
+            CreateModelConditionState(ModelConditionFlag.Snow, ModelConditionFlag.Night),
+            CreateModelConditionState(ModelConditionFlag.Damaged, ModelConditionFlag.Snow, ModelConditionFlag.Night),
+            CreateModelConditionState(ModelConditionFlag.ReallyDamaged, ModelConditionFlag.Rubble, ModelConditionFlag.Snow, ModelConditionFlag.Night),
+            CreateModelConditionState(ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed),
+            CreateModelConditionState(ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed, ModelConditionFlag.Damaged),
+            CreateModelConditionState(ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed, ModelConditionFlag.ReallyDamaged),
+            CreateModelConditionState(ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed, ModelConditionFlag.Night),
+            CreateModelConditionState(ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed, ModelConditionFlag.Night, ModelConditionFlag.Damaged),
+            CreateModelConditionState(ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed, ModelConditionFlag.Night, ModelConditionFlag.ReallyDamaged),
+            CreateModelConditionState(ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed, ModelConditionFlag.Snow),
+            CreateModelConditionState(ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed, ModelConditionFlag.Snow, ModelConditionFlag.Damaged),
+            CreateModelConditionState(ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed, ModelConditionFlag.Snow, ModelConditionFlag.ReallyDamaged),
+            CreateModelConditionState(ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed, ModelConditionFlag.Night, ModelConditionFlag.Snow),
+            CreateModelConditionState(ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed, ModelConditionFlag.Night, ModelConditionFlag.Snow, ModelConditionFlag.Damaged),
+            CreateModelConditionState(ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.PartiallyConstructed, ModelConditionFlag.ActivelyBeingConstructed, ModelConditionFlag.Night, ModelConditionFlag.Snow, ModelConditionFlag.ReallyDamaged),
+            CreateModelConditionState( // aliased
+                [ModelConditionFlag.AwaitingConstruction],
+                [ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.Damaged],
+                [ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.ReallyDamaged],
+                [ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.Night],
+                [ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.Night, ModelConditionFlag.Damaged],
+                [ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.Night, ModelConditionFlag.ReallyDamaged],
+                [ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.Snow],
+                [ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.Snow, ModelConditionFlag.Damaged],
+                [ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.Snow, ModelConditionFlag.ReallyDamaged],
+                [ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.Night, ModelConditionFlag.Snow],
+                [ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.Night, ModelConditionFlag.Snow, ModelConditionFlag.Damaged],
+                [ModelConditionFlag.AwaitingConstruction, ModelConditionFlag.Night, ModelConditionFlag.Snow, ModelConditionFlag.ReallyDamaged],
+                [ModelConditionFlag.Sold],
+                [ModelConditionFlag.Sold, ModelConditionFlag.Damaged],
+                [ModelConditionFlag.Sold, ModelConditionFlag.ReallyDamaged],
+                [ModelConditionFlag.Sold, ModelConditionFlag.Night],
+                [ModelConditionFlag.Sold, ModelConditionFlag.Night, ModelConditionFlag.Damaged],
+                [ModelConditionFlag.Sold, ModelConditionFlag.Night, ModelConditionFlag.ReallyDamaged],
+                [ModelConditionFlag.Sold, ModelConditionFlag.Snow],
+                [ModelConditionFlag.Sold, ModelConditionFlag.Snow, ModelConditionFlag.Damaged],
+                [ModelConditionFlag.Sold, ModelConditionFlag.Snow, ModelConditionFlag.ReallyDamaged],
+                [ModelConditionFlag.Sold, ModelConditionFlag.Night, ModelConditionFlag.Snow],
+                [ModelConditionFlag.Sold, ModelConditionFlag.Night, ModelConditionFlag.Snow, ModelConditionFlag.Damaged],
+                [ModelConditionFlag.Sold, ModelConditionFlag.Night, ModelConditionFlag.Snow, ModelConditionFlag.ReallyDamaged]
+            ),
+        ];
+    }
+
+    private static ModelConditionState CreateModelConditionState(params ModelConditionFlag[] flags)
+    {
+        var model = new ModelConditionState();
+        model.ConditionFlags.Add(new BitArray<ModelConditionFlag>(flags));
+        return model;
+    }
+
+    private static ModelConditionState CreateModelConditionState(params ModelConditionFlag[][] flagsAndAliases)
+    {
+        var model = new ModelConditionState();
+        foreach (var flagSet in flagsAndAliases)
+        {
+            model.ConditionFlags.Add(new BitArray<ModelConditionFlag>(flagSet));
+        }
+
+        return model;
+    }
+}

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -918,9 +918,14 @@ namespace OpenSage.Logic.Object
                     _gameContext.AudioSystem.PlayAudioEvent(Definition.SoundOnReallyDamaged.Value);
                 }
 
-                ModelConditionFlags.Set(ModelConditionFlag.ReallyDamaged, true);
+                if (!IsBeingConstructed())
+                {
+                    // prevents damaged flags from being set while the building is being constructed - generals has models for this it seems, but they're not implemented as far as I can tell?
+                    ModelConditionFlags.Set(ModelConditionFlag.ReallyDamaged, true);
+                    _bodyDamageType = BodyDamageType.ReallyDamaged;
+                }
+
                 ModelConditionFlags.Set(ModelConditionFlag.Damaged, false);
-                _bodyDamageType = BodyDamageType.ReallyDamaged;
             }
             else if (takingDamage && healthPercentage < (Fix64) GameContext.AssetLoadContext.AssetStore.GameData.Current.UnitDamagedThreshold)
             {
@@ -929,9 +934,12 @@ namespace OpenSage.Logic.Object
                     _gameContext.AudioSystem.PlayAudioEvent(Definition.SoundOnDamaged.Value);
                 }
 
+                if (!IsBeingConstructed())
+                {
+                    ModelConditionFlags.Set(ModelConditionFlag.Damaged, true);
+                    _bodyDamageType = BodyDamageType.Damaged;
+                }
                 ModelConditionFlags.Set(ModelConditionFlag.ReallyDamaged, false);
-                ModelConditionFlags.Set(ModelConditionFlag.Damaged, true);
-                _bodyDamageType = BodyDamageType.Damaged;
             }
             else
             {


### PR DESCRIPTION
This at least fixes the ModelConditionState selection issue mentioned in #795. However, it does not correct the animations or transitions. The transitions never play, and it seems either all drawables will rise from the ground or none of them will, rather than only the drawable with `ADJUST_HEIGHT_BY_CONSTRUCTION_PERCENT` set.