### PR TITLE
Force evac and prevent access to a building when it is ReallyDamaged

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Contain/GarrisonContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/GarrisonContain.cs
@@ -20,6 +20,13 @@ namespace OpenSage.Logic.Object
             ModelConditionFlags.Set(ModelConditionFlag.Garrisoned, ContainedObjectIds.Count > 0);
         }
 
+        protected override bool HealthTooLowToHoldUnits()
+        {
+            return GameObject.IsKindOf(ObjectKinds.GarrisonableUntilDestroyed)
+                ? base.HealthTooLowToHoldUnits()
+                : GameObject.ModelConditionFlags.Get(ModelConditionFlag.ReallyDamaged);
+        }
+
         protected override BaseAudioEventInfo? GetEnterVoiceLine(UnitSpecificSounds sounds)
         {
             return sounds.VoiceGarrison?.Value;

--- a/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using FixedMath.NET;
 using ImGuiNET;
@@ -49,6 +49,7 @@ namespace OpenSage.Logic.Object
         public bool CanAddUnit(GameObject unit)
         {
             return unit != GameObject &&
+                   !HealthTooLowToHoldUnits() &&
                    _moduleData.ForbidInsideKindOf?.Intersects(unit.Definition.KindOf) != true &&
                    _moduleData.AllowInsideKindOf?.Intersects(unit.Definition.KindOf) == true &&
                    !GameObject.IsBeingConstructed() &&
@@ -107,11 +108,16 @@ namespace OpenSage.Logic.Object
             }
         }
 
+        protected virtual bool HealthTooLowToHoldUnits()
+        {
+            return GameObject.HealthPercentage <= Fix64.Zero;
+        }
+
         internal sealed override void Update(BehaviorUpdateContext context)
         {
             UpdateModuleSpecific(context);
 
-            if (GameObject.HealthPercentage == Fix64.Zero)
+            if (HealthTooLowToHoldUnits())
             {
                 foreach (var unitId in ContainedObjectIds.ToArray()) // we're modifying the collection, so we need a copy of it
                 {


### PR DESCRIPTION
Buildings without `GarrisonableUntilDestroyed` (i.e most garrisonable civilian buildings, but no garrisonable faction buildings) should have their contents evac'd when they reach the `ReallyDamaged` state, and should not be able to accept units in that state until repaired.