### PR TITLE
Set Garrisoned/Loaded flags on drawable

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Contain/GarrisonContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/GarrisonContain.cs
@@ -17,7 +17,9 @@ namespace OpenSage.Logic.Object
 
         private protected override void UpdateModuleSpecific(BehaviorUpdateContext context)
         {
-            ModelConditionFlags.Set(ModelConditionFlag.Garrisoned, ContainedObjectIds.Count > 0);
+            var isGarrisoned = ContainedObjectIds.Count > 0;
+            ModelConditionFlags.Set(ModelConditionFlag.Garrisoned, isGarrisoned);
+            GameObject.ModelConditionFlags.Set(ModelConditionFlag.Garrisoned, isGarrisoned);
         }
 
         protected override BaseAudioEventInfo? GetEnterVoiceLine(UnitSpecificSounds sounds)

--- a/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
@@ -38,7 +38,10 @@ namespace OpenSage.Logic.Object
             {
                 HealUnits(100_000 / _moduleData.HealthRegenPercentPerSecond); // (100% / regenpercentpersecond) * 1000ms
             }
-            ModelConditionFlags.Set(ModelConditionFlag.Loaded, ContainedObjectIds.Count > 0);
+
+            var isLoaded = ContainedObjectIds.Count > 0;
+            ModelConditionFlags.Set(ModelConditionFlag.Loaded, isLoaded);
+            GameObject.ModelConditionFlags.Set(ModelConditionFlag.Loaded, isLoaded);
         }
 
         protected override bool TryAssignExitPath(GameObject unit)


### PR DESCRIPTION
Missed this in a previous PR. Devious. The flags are set on both the module and the drawable. I'm not sure why.