### PR TITLE
Improve special power order generator

### DIFF
--- a/src/OpenSage.Game/Gui/CommandButtonCallback.cs
+++ b/src/OpenSage.Game/Gui/CommandButtonCallback.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Linq;
 using OpenSage.Gui.ControlBar;
+using OpenSage.Logic;
 using OpenSage.Logic.Object;
+using OpenSage.Logic.OrderGenerators;
 using OpenSage.Logic.Orders;
 using OpenSage.Mathematics;
 
@@ -112,17 +114,27 @@ namespace OpenSage.Gui
                         if (commandButton.Options != null)
                         {
                             var needsPos = commandButton.Options.Get(CommandButtonOption.NeedTargetPos);
-                            var needsObject = commandButton.Options.Get(CommandButtonOption.NeedTargetAllyObject)
-                                             || commandButton.Options.Get(CommandButtonOption.NeedTargetEnemyObject)
-                                             || commandButton.Options.Get(CommandButtonOption.NeedTargetNeutralObject);
+                            var needAlly = commandButton.Options.Get(CommandButtonOption.NeedTargetAllyObject);
+                            var needEnemy = commandButton.Options.Get(CommandButtonOption.NeedTargetEnemyObject);
+                            var needNeutral = commandButton.Options.Get(CommandButtonOption.NeedTargetNeutralObject);
+                            var needsObject = needAlly || needEnemy || needNeutral;
+
+                            var targetOptions = new BitArray<SpecialPowerTarget>();
+                            targetOptions.Set(SpecialPowerTarget.Location, needsPos);
+                            targetOptions.Set(SpecialPowerTarget.AllyObject, needAlly);
+                            targetOptions.Set(SpecialPowerTarget.EnemyObject, needEnemy);
+                            targetOptions.Set(SpecialPowerTarget.NeutralObject, needNeutral);
+
+                            var cursorInformation = new SpecialPowerCursorInformation(specialPower,
+                                targetOptions, commandButton.CursorName, commandButton.InvalidCursorName);
 
                             if (needsPos)
                             {
-                                game.OrderGenerator.StartSpecialPowerAtLocation(specialPower);
+                                game.OrderGenerator.StartSpecialPowerAtLocation(cursorInformation);
                             }
                             else if (needsObject)
                             {
-                                game.OrderGenerator.StartSpecialPowerAtObject(specialPower);
+                                game.OrderGenerator.StartSpecialPowerAtObject(cursorInformation);
                             }
                         }
                         else

--- a/src/OpenSage.Game/Logic/OrderGeneratorSystem.cs
+++ b/src/OpenSage.Game/Logic/OrderGeneratorSystem.cs
@@ -5,6 +5,7 @@ using OpenSage.Graphics.Rendering;
 using OpenSage.Input;
 using OpenSage.Logic.Object;
 using OpenSage.Logic.OrderGenerators;
+using OpenSage.Mathematics;
 
 namespace OpenSage.Logic
 {
@@ -120,21 +121,20 @@ namespace OpenSage.Logic
             return Game.Scene3D.Terrain.Intersect(ray);
         }
 
-        public void StartSpecialPowerAtLocation(SpecialPower specialPower)
+        public void StartSpecialPowerAtLocation(SpecialPowerCursorInformation cursorInformation)
         {
             var gameData = Game.AssetStore.GameData.Current;
 
-            ActiveGenerator = new SpecialPowerOrderGenerator(specialPower, gameData, Game.Scene3D.LocalPlayer,
-                    Game.Scene3D.GameContext, SpecialPowerTarget.Location, Game.Scene3D, Game.MapTime);
+            ActiveGenerator = new SpecialPowerOrderGenerator(cursorInformation, gameData, Game.Scene3D.LocalPlayer,
+                    Game.Scene3D.GameContext, SpecialPowerTargetType.Location, Game.Scene3D, Game.MapTime);
         }
 
-        public void StartSpecialPowerAtObject(SpecialPower specialPower)
+        public void StartSpecialPowerAtObject(SpecialPowerCursorInformation cursorInformation)
         {
             var gameData = Game.AssetStore.GameData.Current;
 
-            //TODO: pass the right target type
-            ActiveGenerator = new SpecialPowerOrderGenerator(specialPower, gameData, Game.Scene3D.LocalPlayer,
-                    Game.Scene3D.GameContext, SpecialPowerTarget.EnemyObject, Game.Scene3D, Game.MapTime);
+            ActiveGenerator = new SpecialPowerOrderGenerator(cursorInformation, gameData, Game.Scene3D.LocalPlayer,
+                    Game.Scene3D.GameContext, SpecialPowerTargetType.Object, Game.Scene3D, Game.MapTime);
         }
 
         public void StartConstructBuilding(ObjectDefinition buildingDefinition)

--- a/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
@@ -306,10 +306,13 @@ namespace OpenSage.Logic.Orders
                             var specialPowerLocation = order.Arguments[1].Value.Position;
 
                             var specialPower = _game.AssetStore.SpecialPowers.GetByInternalId(specialPowerDefinitionId);
-                            foreach (var unit in player.SelectedUnits)
+                            foreach (var unit in player.SelectedUnits) // todo: usa spy satellite is special power at location, but has nothing to do with selected objects
                             {
                                 unit.SpecialPowerAtLocation(specialPower, specialPowerLocation);
                             }
+
+                            _game.Audio.PlayAudioEvent(specialPower.InitiateSound?.Value);
+                            _game.Audio.PlayAudioEvent(specialPower.InitiateAtLocationSound?.Value); // todo: play this at location
                         }
                         break;
                     case OrderType.SpecialPower:

--- a/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
@@ -487,6 +487,7 @@ namespace OpenSage.Mods.Generals.Gui
                                 break;
                             case CommandType.SpecialPower:
                                 buttonControl.Visible = selectedUnit.Owner.SpecialPowerAvailable(commandButton.SpecialPower.Value);
+                                buttonControl.Enabled = true; // TODO: timer
                                 break;
                             case CommandType.ToggleOvercharge:
                                 buttonControl.IsSelected = selectedUnit.FindBehavior<OverchargeBehavior>().Enabled;


### PR DESCRIPTION
This expands upon the special power order generator to consider the owner of the target and use appropriately-defined cursors.

In the long-term, I'm not sure what the best course of action is here. It needs some way of identifying whether the target is valid (like the target of a cahs hack must be a supply center) but I haven't been able to find that defined anywhere in the inis. 