### PR TITLE
Fix GLATunnelNetwork GLAStingerSite SpawnBehavior

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
 
@@ -11,7 +12,8 @@ namespace OpenSage.Logic.Object
 
         private List<GameObject> _spawnedUnits;
         private bool _initial;
-        private IProductionExit _productionExit;
+        private IProductionExit? _productionExit;
+        private OpenContainModule? _openContain;
 
         private bool _unknownBool1;
         private string _templateName;
@@ -33,8 +35,6 @@ namespace OpenSage.Logic.Object
 
         private void SpawnUnit()
         {
-            _productionExit ??= _gameObject.FindBehavior<IProductionExit>();
-
             var spawnedObject = _gameObject.GameContext.GameLogic.CreateObject(_moduleData.SpawnTemplate.Value, _gameObject.Owner);
             _spawnedUnits.Add(spawnedObject);
 
@@ -44,9 +44,25 @@ namespace OpenSage.Logic.Object
                 slavedUpdate.Master = _gameObject;
             }
 
+            if (!TryTransformViaProductionExit(spawnedObject) &&
+                !TryTransformViaOpenContainer(spawnedObject))
+            {
+                throw new Exception("Unable to set spawn point for spawned unit");
+            }
+        }
+
+        private bool TryTransformViaProductionExit(GameObject spawnedObject)
+        {
+            _productionExit ??= _gameObject.FindBehavior<IProductionExit>();
+
+            if (_productionExit == null)
+            {
+                return false;
+            }
+
             if (_productionExit != null)
             {
-                spawnedObject.SetTranslation(_gameObject.ToWorldspace(_productionExit.GetUnitCreatePoint()));
+                spawnedObject.SetTranslation(_productionExit.GetUnitCreatePoint());
 
                 var rallyPoint = _productionExit.GetNaturalRallyPoint();
                 if (rallyPoint.HasValue)
@@ -60,6 +76,41 @@ namespace OpenSage.Logic.Object
             {
                 ProductionUpdate.HandleHarvesterUnitCreation(_gameObject, spawnedObject);
             }
+
+            return true;
+        }
+
+        // GLATunnelNetwork has no production exit behavior - it's explicitly commented out, saying "... we don't appear to need it for the spawns because they use OpenContain instead"
+        private bool TryTransformViaOpenContainer(GameObject spawnedObject)
+        {
+            _openContain ??= _gameObject.FindBehavior<OpenContainModule>();
+
+            if (_openContain == null)
+            {
+                return false;
+            }
+
+            // spawn at container output
+            var (exitStart, exitEnd) = _openContain.DefaultExitPath;
+
+            if (exitStart.HasValue && exitEnd.HasValue)
+            {
+                spawnedObject.SetTranslation(_gameObject.ToWorldspace(exitStart.Value));
+                spawnedObject.AIUpdate.AddTargetPoint(_gameObject.ToWorldspace(exitEnd.Value));
+            }
+            else
+            {
+                spawnedObject.SetTranslation(_gameObject.Translation);
+            }
+
+            // move to rally point
+            var rallyPoint = _gameObject.RallyPoint;
+            if (rallyPoint.HasValue)
+            {
+                spawnedObject.AIUpdate?.AddTargetPoint(rallyPoint.Value);
+            }
+
+            return true;
         }
 
         public void SpawnInitial()

--- a/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using FixedMath.NET;
 using ImGuiNET;
 using OpenSage.Audio;
@@ -28,6 +29,9 @@ namespace OpenSage.Logic.Object
         public bool DrawPips => _moduleData.ShouldDrawPips;
         public virtual int TotalSlots => _moduleData.ContainMax;
         public int OccupiedSlots => ContainedObjectIds.Sum(id => SlotValueForUnit(GameObjectForId(id)));
+
+        protected const string ExitBoneStartName = "ExitStart";
+        protected const string ExitBoneEndName = "ExitEnd";
 
         protected OpenContainModule(GameObject gameObject, OpenContainModuleData moduleData)
         {
@@ -72,6 +76,10 @@ namespace OpenSage.Logic.Object
                 GameObject.GameContext.AudioSystem.PlayAudioEvent(unit, GetEnterVoiceLine(unit.Definition.UnitSpecificSounds));
             }
         }
+
+        public (Vector3? Start, Vector3? End) DefaultExitPath => (
+            GameObject.Drawable.FindBone(ExitBoneStartName).bone?.Transform.Translation,
+            GameObject.Drawable.FindBone(ExitBoneEndName).bone?.Transform.Translation);
 
         protected virtual BaseAudioEventInfo? GetEnterVoiceLine(UnitSpecificSounds sounds)
         {

--- a/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
@@ -48,8 +48,8 @@ namespace OpenSage.Logic.Object
         {
             if (_moduleData.NumberOfExitPaths > 0)
             {
-                var startBoneName = "ExitStart";
-                var endBoneName = "ExitEnd";
+                var startBoneName = ExitBoneStartName;
+                var endBoneName = ExitBoneEndName;
 
                 // from the inis:
                 // Set 0 to not use ExitStart/ExitEnd, set higher than 1 to use ExitStart01-nn/ExitEnd01-nn


### PR DESCRIPTION
Previously, units were spawning at map 0,0 (in the case of the tunnel network) or somewhere along the map edge (in the case of the stinger site).

It appears the issue with the tunnel network was that the productionexitbehavior was specifically commented out in inis with a comment that it falls back to opencontain, so I've implemented support for that here (including following the exit bones and rally points).

For the stinger site, it seems like `_productionExit.GetUnitCreatePoint()` was already in world space, and we transformed it _again_ resulting in some weird coordinates.

@Tarcontar looks like you wrote a lot of this code initially (if a while ago) so I wouldn't mind your eyes on it.