### PR TITLE
Add logic for HordeUpdate

### DIFF
--- a/src/OpenSage.Game/Client/Drawable.cs
+++ b/src/OpenSage.Game/Client/Drawable.cs
@@ -76,7 +76,7 @@ namespace OpenSage.Client
         private ColorFlashHelper _selectionFlashHelper;
         private ColorFlashHelper _scriptedFlashHelper;
 
-        private ObjectDecalType _objectDecalType;
+        public ObjectDecalType ObjectDecalType;
 
         private float _unknownFloat2;
         private float _unknownFloat3;
@@ -376,7 +376,7 @@ namespace OpenSage.Client
                 reader.PersistObject(_scriptedFlashHelper);
             }
 
-            reader.PersistEnum(ref _objectDecalType);
+            reader.PersistEnum(ref ObjectDecalType);
 
             var unknownFloat1 = 1.0f;
             reader.PersistSingle(ref unknownFloat1);
@@ -556,9 +556,11 @@ namespace OpenSage.Client
 
     public enum ObjectDecalType
     {
-        HordeInfantry = 1,
-        HordeVehicle = 3,
-        Crate = 5,
+        HordeInfantry = 1, // exhorde.dds
+        NationalismInfantry = 2, // exhorde_up.dds
+        HordeVehicle = 3, // exhordeb.dds
+        NationalismVehicle = 4, // exhordeb_up.dds
+        Crate = 5, // exjunkcrate.dds
         None = 6,
     }
 }

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -1292,6 +1292,16 @@ namespace OpenSage.Logic.Object
             _gameContext.AudioSystem.PlayAudioEvent(specialPower.InitiateAtLocationSound.Value);
         }
 
+        public void AddWeaponBonusType(WeaponBonusType bonusType)
+        {
+            _weaponBonusTypes |= (uint)bonusType;
+        }
+
+        public void RemoveWeaponBonusType(WeaponBonusType bonusType)
+        {
+            _weaponBonusTypes &= ~(uint)bonusType;
+        }
+
         public void Persist(StatePersister reader)
         {
             reader.PersistVersion(7);

--- a/src/OpenSage.Game/Logic/Object/Update/HordeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/HordeUpdate.cs
@@ -1,10 +1,92 @@
-﻿using OpenSage.Data.Ini;
+﻿using System.Linq;
+using ImGuiNET;
+using OpenSage.Client;
+using OpenSage.Data.Ini;
+using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
     public sealed class HordeUpdate : UpdateModule
     {
-        private bool _unknownBool;
+        private readonly GameObject _gameObject;
+        private readonly GameContext _context;
+        private readonly HordeUpdateModuleData _moduleData;
+
+        private bool _isInHorde;
+
+        protected override uint FramesBetweenUpdates => FramesForMs(_moduleData.UpdateRate);
+
+        internal HordeUpdate(GameObject gameObject, GameContext context, HordeUpdateModuleData moduleData)
+        {
+            _gameObject = gameObject;
+            _context = context;
+            _moduleData = moduleData;
+        }
+
+        private protected override void RunUpdate(BehaviorUpdateContext context)
+        {
+            var nearby = _context.Scene3D.Quadtree.FindNearby(_gameObject, _gameObject.Transform, _moduleData.Radius);
+            var nearbyInConstraints = nearby.Where(MatchesAlliance).Where(MatchesType).Select(o => o.FindBehavior<HordeUpdate>()).ToList();
+
+            if (nearbyInConstraints.Count >= _moduleData.Count - 1) // this list doesn't include us, but count does
+            {
+                foreach (var nearbyItem in nearbyInConstraints)
+                {
+                    // enable horde mode iff count succeeds
+                    nearbyItem.AddToHorde();
+                }
+                AddToHorde();
+            }
+            else if (_isInHorde)
+            {
+                // check if there are others who are in a horde near us
+                // I don't think this behavior is strictly correct, but it seems the simplest way to implement this logic in the spirit of the data names and descriptions
+                var nearbyRubOff = _context.Scene3D.Quadtree.FindNearby(_gameObject, _gameObject.Transform, _moduleData.RubOffRadius);
+                var nearbyRubOffInConstraints = nearbyRubOff.Where(MatchesAlliance).Where(MatchesType).Count(o => o.FindBehavior<HordeUpdate>() is { _isInHorde: true });
+                if (nearbyRubOffInConstraints < _moduleData.Count - 1) // this list doesn't include us, but count does
+                {
+                    RemoveFromHorde();
+                }
+            }
+        }
+
+        private void AddToHorde()
+        {
+            _isInHorde = true;
+            _gameObject.Drawable.ObjectDecalType = GameObjectDecalType;
+            _gameObject.AddWeaponBonusType(_moduleData.Action);
+        }
+
+        private void RemoveFromHorde()
+        {
+            _isInHorde = false;
+            _gameObject.Drawable.ObjectDecalType = ObjectDecalType.None;
+            _gameObject.RemoveWeaponBonusType(_moduleData.Action);
+        }
+
+        // todo: should this be hardcoded?
+        private UpgradeTemplate? NationalismUpgrade => _context.AssetLoadContext.AssetStore.Upgrades.GetLazyAssetReferenceByName("Upgrade_Nationalism")?.Value;
+
+        private bool HasNationalism => NationalismUpgrade != null && _gameObject.Owner.HasUpgrade(NationalismUpgrade);
+
+        private ObjectDecalType GameObjectDecalType => HasNationalism switch
+        {
+            true => _gameObject.IsKindOf(ObjectKinds.Infantry) ? ObjectDecalType.NationalismInfantry : ObjectDecalType.NationalismVehicle,
+            false => _gameObject.IsKindOf(ObjectKinds.Infantry) ? ObjectDecalType.HordeInfantry : ObjectDecalType.HordeVehicle,
+        };
+
+        private bool MatchesAlliance(GameObject gameObject)
+        {
+            return !_moduleData.AlliesOnly || gameObject.Owner == _gameObject.Owner || gameObject.Owner.Allies.Contains(_gameObject.Owner);
+        }
+
+        private bool MatchesType(GameObject gameObject)
+        {
+            return _moduleData.ExactMatch
+                ? gameObject.Definition == _gameObject.Definition // if the definitions match, then we have everything we need
+                : gameObject.FindBehavior<HordeUpdate>() != null && // otherwise, we need the horde update behavior
+                  gameObject.Definition.KindOf.Intersects(_moduleData.KindOf); // and the kindof needs to match
+        }
 
         internal override void Load(StatePersister reader)
         {
@@ -14,14 +96,20 @@ namespace OpenSage.Logic.Object
             base.Load(reader);
             reader.EndObject();
 
-            reader.PersistBoolean(ref _unknownBool);
+            reader.PersistBoolean(ref _isInHorde);
 
             reader.SkipUnknownBytes(1);
+        }
+
+        internal override void DrawInspector()
+        {
+            base.DrawInspector();
+            ImGui.LabelText("In horde", _isInHorde.ToString());
         }
     }
 
     /// <summary>
-    /// Hardcoded to apply the following textures to objects that are affected by this module: 
+    /// Hardcoded to apply the following textures to objects that are affected by this module:
     /// EXHorde, EXHorde_UP, EXHordeB, EXHordeB_UP.
     /// </summary>
     public sealed class HordeUpdateModuleData : UpdateModuleData
@@ -33,25 +121,49 @@ namespace OpenSage.Logic.Object
             { "RubOffRadius", (parser, x) => x.RubOffRadius = parser.ParseInteger() },
             { "UpdateRate", (parser, x) => x.UpdateRate = parser.ParseInteger() },
             { "Radius", (parser, x) => x.Radius = parser.ParseInteger() },
-            { "KindOf", (parser, x) => x.KindOf = parser.ParseEnum<ObjectKinds>() },
+            { "KindOf", (parser, x) => x.KindOf = parser.ParseEnumBitArray<ObjectKinds>() },
             { "AlliesOnly", (parser, x) => x.AlliesOnly = parser.ParseBoolean() },
             { "ExactMatch", (parser, x) => x.ExactMatch = parser.ParseBoolean() },
             { "Count", (parser, x) => x.Count = parser.ParseInteger() },
             { "Action", (parser, x) => x.Action = parser.ParseEnum<WeaponBonusType>() }
         };
 
+        /// <summary>
+        /// if I am this close to a real hordesman, I will get to be an honorary hordesman
+        /// </summary>
         public int RubOffRadius { get; private set; }
+        /// <summary>
+        /// how often to recheck horde status (msec)
+        /// </summary>
         public int UpdateRate { get; private set; }
+        /// <summary>
+        /// how close other units must be to us to count towards our horde-ness
+        /// </summary>
         public int Radius { get; private set; }
-        public ObjectKinds KindOf { get; private set; }
+        /// <summary>
+        /// what KindOf's must match to count towards horde-ness
+        /// </summary>
+        public BitArray<ObjectKinds> KindOf { get; private set; }
+        /// <summary>
+        /// do we only count allies towards horde status?
+        /// </summary>
         public bool AlliesOnly { get; private set; }
+        /// <summary>
+        /// do we only count units of our exact same type towards horde status? (overrides kindof)
+        /// </summary>
         public bool ExactMatch { get; private set; }
+        /// <summary>
+        /// how many units must be within Radius to grant us horde-ness
+        /// </summary>
         public int Count { get; private set; }
+        /// <summary>
+        /// when horde-ing, grant us the HORDE bonus
+        /// </summary>
         public WeaponBonusType Action { get; private set; }
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new HordeUpdate();
+            return new HordeUpdate(gameObject, context, this);
         }
     }
 }


### PR DESCRIPTION
I honestly wasn't sure of any other way to check for whether the player has the nationalism upgrade than to hardcode it. I don't see this defined as a parameter in GameData.ini or anywhere else. Should we create a game parameter for it? Do other games even use this UpdateBehavior, or is it specific to Generals/Zero Hour?