### PR TITLE
Refactor order generation

### DIFF
--- a/src/OpenSage.Game/Logic/OrderGeneratorInputHandler.cs
+++ b/src/OpenSage.Game/Logic/OrderGeneratorInputHandler.cs
@@ -26,6 +26,8 @@ namespace OpenSage.Logic
         public void Update()
         {
             _priority = HandlingPriority.OrderGeneratorPriority;
+
+            _orderGeneratorSystem.UpdatePosition(_mousePosition.ToVector2());
         }
 
         public override InputMessageResult HandleMessage(InputMessage message)
@@ -41,7 +43,6 @@ namespace OpenSage.Logic
                     else
                     {
                         _mousePosition = message.Value.MousePosition;
-                        _orderGeneratorSystem.UpdatePosition(_mousePosition.ToVector2());
                     }
                     break;
 

--- a/src/OpenSage.Game/Logic/OrderGeneratorSystem.cs
+++ b/src/OpenSage.Game/Logic/OrderGeneratorSystem.cs
@@ -5,7 +5,6 @@ using OpenSage.Graphics.Rendering;
 using OpenSage.Input;
 using OpenSage.Logic.Object;
 using OpenSage.Logic.OrderGenerators;
-using OpenSage.Mathematics;
 
 namespace OpenSage.Logic
 {
@@ -163,7 +162,7 @@ namespace OpenSage.Logic
 
         public void SetRallyPoint()
         {
-            ActiveGenerator = new RallyPointOrderGenerator();
+            ActiveGenerator = new RallyPointOrderGenerator(Game);
         }
 
         public void CancelOrderGenerator()

--- a/src/OpenSage.Game/Logic/OrderGenerators/ConstructBuildingOrderGenerator.cs
+++ b/src/OpenSage.Game/Logic/OrderGenerators/ConstructBuildingOrderGenerator.cs
@@ -14,7 +14,7 @@ namespace OpenSage.Logic.OrderGenerators
     // 1. Builder dies
     // 2. We lose access to the building
     // 3. Player right-clicks
-    public sealed class ConstructBuildingOrderGenerator : IOrderGenerator, IDisposable
+    public sealed class ConstructBuildingOrderGenerator : OrderGenerator, IDisposable
     {
         private readonly ObjectDefinition _buildingDefinition;
         private readonly int _definitionIndex;
@@ -26,7 +26,7 @@ namespace OpenSage.Logic.OrderGenerators
         private float _angle;
         private Vector3 _position;
 
-        public bool CanDrag { get; } = true;
+        public override bool CanDrag => true;
 
         internal ConstructBuildingOrderGenerator(
             ObjectDefinition buildingDefinition,
@@ -34,7 +34,7 @@ namespace OpenSage.Logic.OrderGenerators
             GameData config,
             Player player,
             GameContext gameContext,
-            Scene3D scene)
+            Scene3D scene) : base(gameContext.Game)
         {
             _buildingDefinition = buildingDefinition;
             _definitionIndex = definitionIndex;
@@ -59,7 +59,7 @@ namespace OpenSage.Logic.OrderGenerators
             UpdateValidity();
         }
 
-        public void BuildRenderList(RenderList renderList, Camera camera, in TimeInterval gameTime)
+        public override void BuildRenderList(RenderList renderList, Camera camera, in TimeInterval gameTime)
         {
             // TODO: Draw arrow (locater02.w3d) to visualise rotation angle.
 
@@ -67,7 +67,7 @@ namespace OpenSage.Logic.OrderGenerators
             _previewObject.BuildRenderList(renderList, camera, gameTime);
         }
 
-        public OrderGeneratorResult TryActivate(Scene3D scene, KeyModifiers keyModifiers)
+        public override OrderGeneratorResult TryActivate(Scene3D scene, KeyModifiers keyModifiers)
         {
             if (scene.Game.SageGame == SageGame.Bfme)
             {
@@ -126,9 +126,9 @@ namespace OpenSage.Logic.OrderGenerators
                 _scene.LocalPlayer.Enemies.Contains(u.Owner));
         }
 
-        public void UpdatePosition(Vector2 mousePosition, Vector3 worldPosition)
+        public override void UpdatePosition(Vector2 mousePosition, Vector3 worldPosition)
         {
-            _position = worldPosition;
+            base.UpdatePosition(mousePosition, worldPosition);
 
             UpdatePreviewObjectPosition();
             UpdateValidity();
@@ -141,7 +141,7 @@ namespace OpenSage.Logic.OrderGenerators
             _previewObject.BuildProgress = 1.0f;
         }
 
-        public void UpdateDrag(Vector3 position)
+        public override void UpdateDrag(Vector3 position)
         {
             // Calculate angle from building position to current unprojected mouse position.
             var direction = position.Vector2XY() - _position.Vector2XY();
@@ -162,7 +162,7 @@ namespace OpenSage.Logic.OrderGenerators
         }
 
         // Use radial cursor.
-        public string GetCursor(KeyModifiers keyModifiers) => null;
+        public override string GetCursor(KeyModifiers keyModifiers) => null;
 
         public void Dispose()
         {

--- a/src/OpenSage.Game/Logic/OrderGenerators/Cursors.cs
+++ b/src/OpenSage.Game/Logic/OrderGenerators/Cursors.cs
@@ -1,0 +1,89 @@
+﻿using OpenSage.Logic.Orders;
+
+namespace OpenSage.Logic.OrderGenerators;
+
+// these are all of the cursors listed in the Mouse.ini files
+internal static class Cursors
+{
+    // generals
+    private const string Normal = "Normal"; // standard cursor // bfme ini comment: ; "Normal" is not quite correct, as it shouldn't ever be used.  Just seems to be a spare entry. :P - MDC
+    private const string Arrow = "Arrow"; // also standard cursor
+    private const string Scroll = "Scroll"; // prefix for sccscroll0-7 - used when right-click scrolling
+    private const string Target = "Target"; // todo: what is this?
+    private const string Move = "Move"; // unit move to location
+    private const string AttackMove = "AttackMove"; // attack move ability
+    private const string AttackObj = "AttackObj"; // attack an object
+    private const string ForceAttackObj = "ForceAttackObj"; // force attack an object
+    private const string ForceAttackGround = "ForceAttackGround"; // force attack the ground
+    private const string Select = "Select"; // select a unit
+    private const string GenericInvalid = "GenericInvalid"; // invalid cursor when no other cursor applies?
+    private const string EnterFriendly = "EnterFriendly"; // garrison building, enter transport, etc
+    private const string EnterAggressive = "EnterAggressive"; // combat drop
+    private const string CaptureBuilding = "CaptureBuilding"; // ranger/rebel/red guard capture
+    private const string SnipeVehicle = "SnipeVehicle"; // kell snipe vehicle
+    private const string FireBomb = "FireBomb"; // "hidden" special power in generals
+    private const string Defector = "Defector"; // "hidden" special power in generals
+    private const string LaserGuidedMissiles = "LaserGuidedMissiles"; // usa missile defender ability
+    private const string TankHunterTntAttack = "TankHunterTNTAttack"; // china tank hunter ability
+    private const string StabAttack = "StabAttack"; // colonel burton ability
+    private const string Hack = "Hack"; // black lotus/hacker ability
+    private const string StabAttackInvalid = "StabAttackInvalid"; // colonel burton ability (invalid)
+    private const string PlaceRemoteCharge = "PlaceRemoteCharge"; // colonel burton ability
+    private const string PlaceTimedCharge = "PlaceTimedCharge"; // colonel burton ability
+    private const string PlaceChargeInvalid = "PlaceChargeInvalid"; // colonel burton ability (invalid)
+    private const string SetRallyPoint = "SetRallyPoint"; // set a rally point for a building
+    private const string Dock = "Dock"; // todo: what is this? uses Enter cursor icon
+    private const string GetRepaired = "GetRepaired"; // send vehicle back to war factory to repair
+    private const string GetHealed = "GetHealed"; // todo: what is this?
+    private const string DoRepair = "DoRepair"; // dozer repair structure
+    private const string ResumeConstruction = "ResumeConstruction"; // dozer resume construction of incomplete structure
+    private const string FireFlame = "FireFlame"; // dragon tank ability
+    private const string PlaceBeacon = "PlaceBeacon"; // place beacon in multiplayer game
+    private const string DisguiseAsVehicle = "DisguiseAsVehicle"; // bomb truck ability
+    private const string Waypoint = "Waypoint"; // add new pathing waypoint
+    private const string OutRange = "OutRange"; // todo: what is this?
+    private const string ParticleUplinkCannon = "ParticleUplinkCannon"; // particle cannon ability
+
+    // bfme
+    private const string Axe = "Axe";
+    private const string EvilAbilityObj = "EvilAbilityObj";
+    private const string LightPointParticle = "LightPointParticle";
+    private const string LivingWorldZoom = "LivingWorldZoom";
+    private const string WeaponUpgrade = "WeaponUpgrade";
+    private const string ArmorUpgrade = "ArmorUpgrade";
+    private const string JoinHorde = "JoinHorde";
+    private const string Beam = "Beam";
+    private const string Bombard = "Bombard";
+    private const string PickUp = "PickUp";
+
+    // bfme2
+    private const string SendToDeath = "SendToDeath";
+    private const string DeliverRing = "DeliverRing";
+    private const string Patrol = "Patrol";
+
+    /// <summary>
+    /// Gets the cursor that should be used for a given order. This does not work for special powers, which have their own cursors.
+    /// </summary>
+    public static string? CursorForOrder(OrderType orderType)
+    {
+        return orderType switch
+        {
+            OrderType.Zero => Arrow,
+            OrderType.SetSelection => Select,
+            OrderType.SetRallyPoint => SetRallyPoint,
+            OrderType.AttackObject => AttackObj,
+            OrderType.ForceAttackObject => ForceAttackObj,
+            OrderType.ForceAttackGround => ForceAttackGround,
+            OrderType.RepairVehicle => GetRepaired,
+            OrderType.ResumeBuild => ResumeConstruction,
+            OrderType.RepairStructure => DoRepair,
+            OrderType.Enter => EnterFriendly,
+            OrderType.GatherDumpSupplies => EnterFriendly,
+            OrderType.MoveTo => Move,
+            OrderType.AttackMove => AttackMove,
+            OrderType.AddWaypoint => Waypoint,
+            OrderType.DirectParticleCannon => ParticleUplinkCannon,
+            _ => GenericInvalid,
+        };
+    }
+}

--- a/src/OpenSage.Game/Logic/OrderGenerators/OrderGenerator.cs
+++ b/src/OpenSage.Game/Logic/OrderGenerators/OrderGenerator.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.Numerics;
+using OpenSage.Graphics.Cameras;
+using OpenSage.Graphics.Rendering;
+using OpenSage.Input;
+using OpenSage.Logic.Object;
+
+namespace OpenSage.Logic.OrderGenerators;
+
+public abstract class OrderGenerator(Game game) : IOrderGenerator
+{
+    public abstract bool CanDrag { get; }
+
+    protected Vector3 WorldPosition { get; private set; }
+    protected GameObject? WorldObject { get; private set; }
+    protected Player? LocalPlayer => game.Scene3D.LocalPlayer;
+    protected IReadOnlyCollection<GameObject>? SelectedUnits => LocalPlayer?.SelectedUnits;
+
+    public abstract OrderGeneratorResult TryActivate(Scene3D scene, KeyModifiers keyModifiers);
+    public abstract string? GetCursor(KeyModifiers keyModifiers);
+
+    public virtual void BuildRenderList(RenderList renderList, Camera camera, in TimeInterval gameTime) { }
+    public virtual void UpdateDrag(Vector3 position) { }
+
+    public virtual void UpdatePosition(Vector2 mousePosition, Vector3 worldPosition)
+    {
+        WorldPosition = worldPosition;
+        WorldObject = game.Selection.FindClosestObject(mousePosition);
+    }
+}

--- a/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
@@ -69,6 +69,7 @@ namespace OpenSage.Logic.Orders
                     case OrderType.MoveTo:
                         {
                             var targetPosition = order.Arguments[0].Value.Position;
+                            GameObject? lastUnit = null;
                             foreach (var unit in player.SelectedUnits)
                             {
                                 unit.AIUpdate?.SetTargetPoint(targetPosition);
@@ -79,7 +80,11 @@ namespace OpenSage.Logic.Orders
                                 {
                                     _game.Audio.PlayAudioEvent(unit, sound);
                                 }
+
+                                lastUnit = unit;
                             }
+
+                            lastUnit?.OnLocalMove(_game.Audio);
                         }
                         break;
                     case OrderType.BuildObject:
@@ -294,6 +299,8 @@ namespace OpenSage.Logic.Orders
                                     .ToArray();
                                 _game.Selection.SetRallyPointForSelectedObjects(player, objIds, new Vector3());
                             }
+
+                            _game.Audio.PlayAudioEvent("RallyPointSet");
                         }
                         catch (Exception e)
                         {

--- a/src/OpenSage.Game/Logic/SelectionSystem.cs
+++ b/src/OpenSage.Game/Logic/SelectionSystem.cs
@@ -139,7 +139,7 @@ namespace OpenSage.Logic
             {
                 if (CanSetRallyPoint(objects))
                 {
-                    Game.OrderGenerator.ActiveGenerator = new RallyPointOrderGenerator();
+                    Game.OrderGenerator.ActiveGenerator = new RallyPointOrderGenerator(Game);
                 }
                 else
                 {


### PR DESCRIPTION
Moves audio playing to order processor, and gives the order processor state so that the logic for what cursor to show and what order to give doesn't need to be duplicated.

I've updated the RallyPointOrderGenerator in this PR as a proof of concept. I have a good bit of UnitOrderGenerator locally as well if this is an architecture we're ok to move forward with.

Requires #830 for CI build to pass