### PR TITLE
Document Generals special powers

### DIFF
--- a/src/OpenSage.Game/Logic/Object/SpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower.cs
@@ -1,4 +1,5 @@
-﻿using OpenSage.Audio;
+﻿using System;
+using OpenSage.Audio;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.Mathematics;
@@ -111,53 +112,92 @@ namespace OpenSage.Logic.Object
 
     public enum SpecialPowerType
     {
+        /// <summary>
+        /// USA fuel-air bomb science ability.
+        /// </summary>
         [IniEnum("SPECIAL_DAISY_CUTTER")]
-        DaisyCutter,
+        FuelAirBomb = 2,
 
+        /// <summary>
+        /// USA paradrop infantry science ability.
+        /// </summary>
         [IniEnum("SPECIAL_PARADROP_AMERICA")]
-        ParadropAmerica,
+        ParadropAmerica = 3,
 
+        /// <summary>
+        /// China carpet bomb science ability.
+        /// </summary>
         [IniEnum("SPECIAL_CARPET_BOMB")]
         CarpetBomb,
 
+        /// <summary>
+        /// China cluster mines science ability.
+        /// </summary>
         [IniEnum("SPECIAL_CLUSTER_MINES")]
-        ClusterMines,
+        ClusterMines = 5,
 
+        /// <summary>
+        /// China EMP bomb science ability.
+        /// </summary>
         [IniEnum("SPECIAL_EMP_PULSE")]
-        EmpPulse,
+        EmpPulse = 6,
 
         [IniEnum("SPECIAL_CRATE_DROP")]
         CrateDrop,
 
+        /// <summary>
+        /// USA A-10 Thunderbolt strike science ability.
+        /// </summary>
         [IniEnum("SPECIAL_A10_THUNDERBOLT_STRIKE")]
-        A10ThunderboltStrike,
+        A10ThunderboltStrike = 8,
 
         [IniEnum("SPECIAL_NAPALM_STRIKE")]
         NapalmStrike,
 
+        /// <summary>
+        /// China nuclear missile superweapon launch.
+        /// </summary>
         [IniEnum("SPECIAL_NEUTRON_MISSILE")]
-        NeutronMissile,
+        NuclearMissile = 10,
 
         [IniEnum("SPECIAL_DETONATE_DIRTY_NUKE")]
         DetonateDirtyNuke,
 
+        /// <summary>
+        /// GLA SCUD storm superweapon launch.
+        /// </summary>
         [IniEnum("SPECIAL_SCUD_STORM")]
-        ScudStorm,
+        ScudStorm = 12,
 
+        /// <summary>
+        /// China artillery barrage science ability.
+        /// </summary>
         [IniEnum("SPECIAL_ARTILLERY_BARRAGE")]
-        ArtilleryBarrage,
+        ArtilleryBarrage = 13,
 
+        /// <summary>
+        /// China cash hack science ability.
+        /// </summary>
         [IniEnum("SPECIAL_CASH_HACK")]
-        CashHack,
+        CashHack = 14,
 
+        /// <summary>
+        /// USA spy satellite command center ability.
+        /// </summary>
         [IniEnum("SPECIAL_SPY_SATELLITE")]
         SpySatellite = 15,
 
+        /// <summary>
+        /// USA spy drone science ability.
+        /// </summary>
         [IniEnum("SPECIAL_SPY_DRONE")]
         SpyDrone = 16,
 
+        /// <summary>
+        /// GLA radar van scan ability.
+        /// </summary>
         [IniEnum("SPECIAL_RADAR_VAN_SCAN")]
-        RadarVanScan,
+        RadarVanScan = 17,
 
         [IniEnum("SPECIAL_DEFECTOR")]
         Defector,
@@ -165,60 +205,121 @@ namespace OpenSage.Logic.Object
         [IniEnum("SPECIAL_TERROR_CELL")]
         TerrorCell,
 
+        /// <summary>
+        /// GLA rebel ambush science ability.
+        /// </summary>
         [IniEnum("SPECIAL_AMBUSH")]
-        Ambush,
+        Ambush = 20,
 
         [IniEnum("SPECIAL_BLACK_MARKET_NUKE")]
         BlackMarketNuke,
 
+        /// <summary>
+        /// GLA anthrax bomb science ability.
+        /// </summary>
         [IniEnum("SPECIAL_ANTHRAX_BOMB")]
         AnthraxBomb,
 
+        /// <summary>
+        /// USA Missile Defender laser-lock ability.
+        /// </summary>
         [IniEnum("SPECIAL_MISSILE_DEFENDER_LASER_GUIDED_MISSILES")]
-        MissileDefenderLaserGuidedMissiles,
+        MissileDefenderLaserGuidedMissiles = 23,
 
+        /// <summary>
+        /// China Tank Hunter TNT ability.
+        /// </summary>
         [IniEnum("SPECIAL_TANKHUNTER_TNT_ATTACK")]
-        TankHunterTntAttack,
+        TankHunterTntAttack = 24,
 
+        /// <summary>
+        /// USA Colonel Burton remote demo charge ability (plus detonation).
+        /// </summary>
         [IniEnum("SPECIAL_REMOTE_CHARGES")]
         RemoteCharges = 25,
 
+        /// <summary>
+        /// USA Colonel Burton timed demo charge ability.
+        /// </summary>
         [IniEnum("SPECIAL_TIMED_CHARGES")]
         TimedCharges = 26,
 
+        /// <summary>
+        /// China Hacker disable building ability.
+        /// </summary>
         [IniEnum("SPECIAL_HACKER_DISABLE_BUILDING")]
-        HackerDisableBuilding,
+        HackerDisableBuilding = 27,
 
-        [IniEnum("SPECIAL_INFANTRY_CAPTURE_BUILDING")]
-        InfantryCaptureBuilding,
-
+        /// <summary>
+        /// China Black Lotus capture building ability.
+        /// </summary>
         [IniEnum("SPECIAL_BLACKLOTUS_CAPTURE_BUILDING")]
-        BlackLotusCaptureBuilding,
+        BlackLotusCaptureBuilding = 28,
 
+        /// <summary>
+        /// Infantry capture building ability.
+        /// </summary>
+        /// <remarks>
+        /// 29 for usa, 30 for china, 31 for gla (enum string is the same)
+        /// todo: figure out how to handle this
+        /// </remarks>
+        [IniEnum("SPECIAL_INFANTRY_CAPTURE_BUILDING")]
+        InfantryCaptureBuilding = 29,
+
+        /// <summary>
+        /// China Black Lotus disable vehicle ability.
+        /// </summary>
         [IniEnum("SPECIAL_BLACKLOTUS_DISABLE_VEHICLE_HACK")]
-        BlackLotusDisableVehicleHack,
+        BlackLotusDisableVehicleHack = 32,
 
+        /// <summary>
+        /// China Black Lotus cash hack ability.
+        /// </summary>
         [IniEnum("SPECIAL_BLACKLOTUS_STEAL_CASH_HACK")]
-        BlackLotusStealCashHack,
+        BlackLotusStealCashHack = 33,
 
+        /// <summary>
+        /// USA Detention Center intelligence ability.
+        /// </summary>
         [IniEnum("SPECIAL_CIA_INTELLIGENCE")]
         CiaIntelligence = 34,
 
+        /// <summary>
+        /// All-faction emergency repair science ability.
+        /// </summary>
         [IniEnum("SPECIAL_REPAIR_VEHICLES")]
-        RepairVehicles,
+        RepairVehicles = 35,
 
+        /// <summary>
+        /// GLA Bomb Truck disguise as vehicle ability.
+        /// </summary>
         [IniEnum("SPECIAL_DISGUISE_AS_VEHICLE")]
-        DisguiseAsVehicle,
+        DisguiseAsVehicle = 36,
 
+        /// <summary>
+        /// USA Particle Cannon superweapon launch.
+        /// </summary>
+        /// <remarks>
+        /// Uses <see cref="OrderType.DirectParticleCannon"/> to guide.
+        /// </remarks>
         [IniEnum("SPECIAL_PARTICLE_UPLINK_CANNON")]
         ParticleUplinkCannon = 37,
 
         [IniEnum("SPECIAL_CASH_BOUNTY")]
         CashBounty,
 
+        /// <summary>
+        /// USA Strategy center Bombardment/Hold the Line/Search and Destroy abilities.
+        /// </summary>
+        /// <remarks>
+        /// Uses flags to set plan type.
+        /// </remarks>
         [IniEnum("SPECIAL_CHANGE_BATTLE_PLANS")]
         ChangeBattlePlans = 41,
 
+        /// <summary>
+        /// USA Ambulance clean up toxins ability.
+        /// </summary>
         [IniEnum("SPECIAL_CLEANUP_AREA")]
         CleanupArea = 42,
 
@@ -714,5 +815,27 @@ namespace OpenSage.Logic.Object
 
         [IniEnum("RESPECT_RECHARGE_TIME_DISCOUNT")]
         RespectRechargeTimeDiscount,
+    }
+
+    // todo: these entries are very similar to CommandButtonOrderType. Perhaps in the future CommandButtonOrderType should be reordered as the ordinal values don't appear to be used?
+    [Flags]
+    public enum SpecialPowerOrderFlags
+    {
+        NeedTargetEnemyObject       = 1 << 0,
+        NeedTargetNeutralObject     = 1 << 1,
+        NeedTargetAllyObject        = 1 << 2,
+        Unknown1                    = 1 << 3,
+        Unknown2                    = 1 << 4,
+        NeedTargetPosition          = 1 << 5,
+        NeedUpgrade                 = 1 << 6,
+        NeedSpecialPowerScience     = 1 << 7,
+        OkForMultiSelect            = 1 << 8,
+        ContextModeCommand          = 1 << 9,
+        CheckLike                   = 1 << 10,
+        Unknown3                    = 1 << 11,
+        Unknown4                    = 1 << 12,
+        OptionOne                   = 1 << 13,
+        OptionTwo                   = 1 << 14,
+        OptionThree                 = 1 << 15,
     }
 }

--- a/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
@@ -302,10 +302,13 @@ namespace OpenSage.Logic.Orders
                         break;
                     case OrderType.SpecialPowerAtLocation:
                         {
-                            var specialPowerDefinitionId = order.Arguments[0].Value.Integer;
+                            var specialPowerDefinitionId = (SpecialPowerType) order.Arguments[0].Value.Integer;
                             var specialPowerLocation = order.Arguments[1].Value.Position;
+                            var unknownObjectId = order.Arguments[2].Value.ObjectId;
+                            var commandFlags = (SpecialPowerOrderFlags) order.Arguments[3].Value.Integer;
+                            var commandCenterSource = order.Arguments[4].Value.ObjectId;
 
-                            var specialPower = _game.AssetStore.SpecialPowers.GetByInternalId(specialPowerDefinitionId);
+                            var specialPower = _game.AssetStore.SpecialPowers.GetByInternalId((int)specialPowerDefinitionId); // todo: using the internal id is likely incorrect - these items have specific values that don't line up with how they are loaded
                             foreach (var unit in player.SelectedUnits) // todo: usa spy satellite is special power at location, but has nothing to do with selected objects
                             {
                                 unit.SpecialPowerAtLocation(specialPower, specialPowerLocation);
@@ -315,8 +318,22 @@ namespace OpenSage.Logic.Orders
                             _game.Audio.PlayAudioEvent(specialPower.InitiateAtLocationSound?.Value); // todo: play this at location
                         }
                         break;
+
                     case OrderType.SpecialPower:
+                        {
+                            var specialPowerDefinitionId = (SpecialPowerType) order.Arguments[0].Value.Integer;
+                            var commandFlags = (SpecialPowerOrderFlags) order.Arguments[1].Value.Integer;
+                            var commandCenterSource = order.Arguments[2].Value.ObjectId;
+                        }
+                        throw new NotImplementedException();
+
                     case OrderType.SpecialPowerAtObject:
+                        {
+                            var specialPowerDefinitionId = (SpecialPowerType) order.Arguments[0].Value.Integer;
+                            var targetId = order.Arguments[1].Value.ObjectId;
+                            var commandFlags = (SpecialPowerOrderFlags) order.Arguments[2].Value.Integer;
+                            var commandCenterSource = order.Arguments[3].Value.ObjectId;
+                        }
                         throw new NotImplementedException();
 
                     case OrderType.EndGame:

--- a/src/OpenSage.Game/Logic/Orders/OrderType.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderType.cs
@@ -32,21 +32,9 @@
         SelectGroup8 = 1024,
         SelectGroup9 = 1025,
 
-        // the leading integer for these special power arguments seems to correspond to SpecialPowerType
-        // burton detonate demo charge      SpecialPower(Integer:25, Integer:256, ObjectId:0)
-        // detention center intelligence    SpecialPower(Integer:34, Integer:0, ObjectId:0)
-        // strategy center bombardment      SpecialPower(Integer:41, Integer:9216, ObjectId:0)
-        // strategy center hold the line    SpecialPower(Integer:41, Integer:17408, ObjectId:0)
-        // strategy center search & destroy SpecialPower(Integer:41, Integer:33792, ObjectId:0)
-        SpecialPower = 1040,
-        // spy satellite             SpecialPowerAtLocation(Integer:15, Position:<304.26398, 409.33313, 10>, ObjectId:0, Integer:544, ObjectId:0)
-        // spy drone                 SpecialPowerAtLocation(Integer:16, Position:<825.8123, 606.12665, 10>, ObjectId:0, Integer:928, ObjectId:4) // last object id could be command center source?
-        // particle cannon           SpecialPowerAtLocation(Integer:37, Position:<442.46735, 318.8226, 10>, ObjectId:0, Integer:672, ObjectId:0)
-        // ambulance cleanup area    SpecialPowerAtLocation(Integer:42, Position:<443.1347, 219.59857, 10>, ObjectId:0, Integer:288, ObjectId:0)
-        SpecialPowerAtLocation = 1041,
-        // burton remote demo charge SpecialPowerAtObject(Integer:25, ObjectId:2, Integer:771, ObjectId:0) // first object id is target
-        // burton timed demo charge  SpecialPowerAtObject(Integer:26, ObjectId:3, Integer:259, ObjectId:0) // first object id is target
-        SpecialPowerAtObject = 1042, // Integer:29, ObjectId:199, Integer:323, ObjectId:0
+        SpecialPower = 1040, // Integer:25, Integer:256, ObjectId:0 // SpecialPowerType, SpecialPowerOrderFlags, source command center?
+        SpecialPowerAtLocation = 1041, // Integer:35, Position:<1105.9589, 728.7699, 18.75>, ObjectId:2816, Integer:672, ObjectId:657 // SpecialPowerType, location, unknown, SpecialPowerOrderFlags, source command center?
+        SpecialPowerAtObject = 1042, // Integer:14, ObjectId:674, Integer:643, ObjectId:657 // SpecialPowerType, target object, SpecialPowerOrderFlags, source command center?
         SetRallyPoint = 1043,
         PurchaseScience = 1044,
         BeginUpgrade = 1045, //encountered while adding landmines to power plant: ObjectId:671,Integer:1604 (mines is Upgrades[13]), also when upgrading usa power plant (ObjectId:673,Integer:1593), (ObjectId:671,Integer:1593), also for flashbangs in the barracks (ObjectId:678,Integer:1594)
@@ -100,7 +88,7 @@
         // dragon tank fire wall Integer:1, Position:<530.40765, 607.319, 9.9999695>, Integer:2147483647, ObjectId:0  // secondary weapon is fire wall
         // comanche rocket pods  Integer:2, Position:<373.81445, 256.29944, 10>, Integer:2147483647, ObjectId:0       // tertiary weapon is rocket pods
         UseWeapon = 1038,
-        Unknown1039 = 1039,
+        SnipeVehicle = 1039, // Integer:1, ObjectId:6, Integer:2147483647 // first integer argument could be because sniper is secondary weapon (similar to useweapon above)
         Unknown1050 = 1050,
 
         Unknown1055 = 1055,
@@ -110,7 +98,7 @@
         RepairVehicle = 1062, // ObjectId:3 includes vehicles returning to war factory for repair and helicopters landing and airfields for repair
         Unknown1063 = 1063,
         RepairStructure = 1064, // ObjectId:4 when a dozer is ordered to repair a structure
-        Enter = 1066,
+        Enter = 1066, // used for entering friendly vehicles and for hijacking vehicles
         GatherDumpSupplies = 1067, // used for both gathering from a supply source and dumping supplies
 
         AttackMove = 1069, // Position:<1343.561, 378.53568, 18.75>
@@ -120,7 +108,7 @@
         Unknown1073 = 1073,
         StopMoving = 1074,
         Scatter = 1075, // no arguments
-        Unknown1076 = 1076,
+        HackInternet = 1076, // no arguments
         Cheer = 1077, // no arguments
 
         SelectWeapon = 1079, // Integer:1 // e.g. USA Ranger, 1 for flashbang 0 for machine gun

--- a/src/OpenSage.Game/Logic/Orders/SpecialPowerArguments.md
+++ b/src/OpenSage.Game/Logic/Orders/SpecialPowerArguments.md
@@ -1,0 +1,71 @@
+﻿- the leading integer for these special power arguments seems to correspond to SpecialPowerType
+- the second integer argument seems to be some sort of bitflags similar to commandbuttonoption
+- last object id could be command center source?
+
+## Integer argument flags
+enemy vs neutral needs verification - no special powers in generals only have one of them in isolation
+```
+1         0000 0000 0000 0001  NEED_TARGET_ENEMY_OBJECT
+2         0000 0000 0000 0010  NEED_TARGET_NEUTRAL_OBJECT
+4         0000 0000 0000 0100  NEED_TARGET_ALLY_OBJECT
+8         0000 0000 0000 1000  ?????
+16        0000 0000 0001 0000  ?????
+32        0000 0000 0010 0000  NEED_TARGET_POS
+64        0000 0000 0100 0000  NEED_UPGRADE
+128       0000 0000 1000 0000  NEED_SPECIAL_POWER_SCIENCE
+256       0000 0001 0000 0000  OK_FOR_MULTI_SELECT
+512       0000 0010 0000 0000  CONTEXTMODE_COMMAND
+1024      0000 0100 0000 0000  CHECK_LIKE
+2048      0000 1000 0000 0000  ?????
+4096      0001 0000 0000 0000  ?????
+8192      0010 0000 0000 0000  OPTION_ONE
+16384     0100 0000 0000 0000  OPTION_TWO
+32768     1000 0000 0000 0000  OPTION_THREE
+```
+
+## `SpecialPower`
+```
+burton detonate demo charge      SpecialPower(Integer:25, Integer:256, ObjectId:0)   // 0000 0001 0000 0000
+detention center intelligence    SpecialPower(Integer:34, Integer:0, ObjectId:0)     // 0000 0000 0000 0000
+strategy center bombardment      SpecialPower(Integer:41, Integer:9216, ObjectId:0)  // 0010 0100 0000 0000
+strategy center hold the line    SpecialPower(Integer:41, Integer:17408, ObjectId:0) // 0100 0100 0000 0000
+strategy center search & destroy SpecialPower(Integer:41, Integer:33792, ObjectId:0) // 1000 0100 0000 0000
+```
+
+## `SpecialPowerAtLocation`
+unclear what first object id is
+```
+fuel air bomb             SpecialPowerAtLocation(Integer:2, Position:<1217.1951, 1874.8988, 18.75>, ObjectId:0, Integer:672, ObjectId:657)     // 0000 0010 1010 0000
+paradrop                  SpecialPowerAtLocation(Integer:3, Position:<1128.1514, 705.649, 18.74997>, ObjectId:0, Integer:672, ObjectId:657)    // 0000 0010 1010 0000
+cluster mines             SpecialPowerAtLocation(Integer:5, Position:<1346.773, 2096.985, 18.75>, ObjectId:1243, Integer:672, ObjectId:657)    // 0000 0010 1010 0000
+emp bomb                  SpecialPowerAtLocation(Integer:6, Position:<1603.1487, 1894.5223, 18.75>, ObjectId:3661, Integer:672, ObjectId:657)  // 0000 0010 1010 0000
+a10                       SpecialPowerAtLocation(Integer:8, Position:<1795.539, 1420.2986, 110>, ObjectId:0, Integer:672, ObjectId:657)        // 0000 0010 1010 0000
+nuclear missile           SpecialPowerAtLocation(Integer:10, Position:<668.3643, 241.7229, 10>, ObjectId:5, Integer:672, ObjectId:0)           // 0000 0010 1010 0000
+scud storm                SpecialPowerAtLocation(Integer:12, Position:<1432.6141, 1948.8225, 18.75>, ObjectId:0, Integer:544, ObjectId:0)      // 0000 0010 0010 0000
+artillery barrage         SpecialPowerAtLocation(Integer:13, Position:<1490.2301, 2075.6533, 18.75>, ObjectId:2794, Integer:672, ObjectId:657) // 0000 0010 1010 0000
+spy satellite             SpecialPowerAtLocation(Integer:15, Position:<304.26398, 409.33313, 10>, ObjectId:0, Integer:544, ObjectId:0)         // 0000 0010 0010 0000
+spy drone                 SpecialPowerAtLocation(Integer:16, Position:<825.8123, 606.12665, 10>, ObjectId:0, Integer:928, ObjectId:4)          // 0000 0011 1010 0000
+radar van scan            SpecialPowerAtLocation(Integer:17, Position:<1508.3314, 1920.3726, 18.75>, ObjectId:0, Integer:864, ObjectId:0)      // 0000 0011 0110 0000
+rebel ambush              SpecialPowerAtLocation(Integer:20, Position:<1734.9331, 1322.1748, 110>, ObjectId:0, Integer:672, ObjectId:657)      // 0000 0010 1010 0000
+repair                    SpecialPowerAtLocation(Integer:35, Position:<1105.9589, 728.7699, 18.75>, ObjectId:2816, Integer:672, ObjectId:657)  // 0000 0010 1010 0000
+particle cannon           SpecialPowerAtLocation(Integer:37, Position:<442.46735, 318.8226, 10>, ObjectId:0, Integer:672, ObjectId:0)          // 0000 0010 1010 0000
+ambulance cleanup area    SpecialPowerAtLocation(Integer:42, Position:<443.1347, 219.59857, 10>, ObjectId:0, Integer:288, ObjectId:0)          // 0000 0001 0010 0000
+```
+
+## `SpecialPowerAtObject`
+first object id seems to be target
+```
+cash hack                 SpecialPowerAtObject(Integer:14, ObjectId:674, Integer:643, ObjectId:657)  // 0000 0010 1000 0011
+missile laser lock        SpecialPowerAtObject(Integer:23, ObjectId:700, Integer:771, ObjectId:0)    // 0000 0011 0000 0011
+tank hunter tnt           SpecialPowerAtObject(Integer:24, ObjectId:6, Integer:259, ObjectId:0)      // 0000 0001 0000 0011
+burton remote demo charge SpecialPowerAtObject(Integer:25, ObjectId:2, Integer:771, ObjectId:0)      // 0000 0011 0000 0011
+burton timed demo charge  SpecialPowerAtObject(Integer:26, ObjectId:3, Integer:259, ObjectId:0)      // 0000 0001 0000 0011
+hacker disable building   SpecialPowerAtObject(Integer:27, ObjectId:8, Integer:259, ObjectId:0)      // 0000 0001 0000 0011
+lotus capture building    SpecialPowerAtObject(Integer:28, ObjectId:8, Integer:259, ObjectId:0)      // 0000 0001 0000 0011
+usa ranger capture        SpecialPowerAtObject(Integer:29, ObjectId:8, Integer:323, ObjectId:0)      // 0000 0001 0100 0011
+china red guard capture   SpecialPowerAtObject(Integer:30, ObjectId:8, Integer:323, ObjectId:0)      // 0000 0001 0100 0011
+gla rebel capture         SpecialPowerAtObject(Integer:31, ObjectId:8, Integer:323, ObjectId:0)      // 0000 0001 0100 0011
+lotus disable vehicle     SpecialPowerAtObject(Integer:32, ObjectId:6, Integer:259, ObjectId:0)      // 0000 0001 0000 0011
+lotus cash hack           SpecialPowerAtObject(Integer:33, ObjectId:674, Integer:259, ObjectId:0)    // 0000 0001 0000 0011
+bomb truck disguise       SpecialPowerAtObject(Integer:36, ObjectId:1176, Integer:263, ObjectId:0)   // 0000 0001 0000 0111
+```


### PR DESCRIPTION
I went through and tested pretty much every special power that can be used in non-campaign play in generals (ok I accidentally killed the AI before testing the anthrax bomb and didn't want to go back and do it again). In doing so I was able to gain a bit more insight into how the special power orders work, so I figured I'd document as much.

In the future I'm _guessing_ we'll want to combine `SpecialPowerOrderFlags` and `CommandButtonOptions` since they _seem_ to be identical - the only difference is the order, but the ordinal values don't seem to matter for `CommandButtonOptions` so they could likely be reordered to suit this, but more testing would be required. It would definitely make generating orders from GeneralsControlBar way easier if we could pass the options straight through instead of translating them (which is not implemented in this PR).

I'm still not clear what the first object id in SpecialPowerAtLocation is. Maybe the nearest object, or object under the cursor? I don't know if that matters for any of the location-based special powers.