### PR TITLE
Fix units created at supply points spawning at wrong coords

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
@@ -62,7 +62,7 @@ namespace OpenSage.Logic.Object
 
             if (_productionExit != null)
             {
-                spawnedObject.SetTranslation(_productionExit.GetUnitCreatePoint());
+                spawnedObject.SetTranslation(_gameObject.ToWorldspace(_productionExit.GetUnitCreatePoint()));
 
                 var rallyPoint = _productionExit.GetNaturalRallyPoint();
                 if (rallyPoint.HasValue)

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SpawnPointProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SpawnPointProductionExitUpdate.cs
@@ -36,7 +36,7 @@ namespace OpenSage.Logic.Object
 
             _nextIndex++;
 
-            return modelInstance.AbsoluteBoneTransforms[bone.Index].Translation;
+            return modelInstance.RelativeBoneTransforms[bone.Index].Translation;
         }
 
         private (ModelInstance, ModelBone) FindBone(int index)


### PR DESCRIPTION
Honestly I should have dug a little bit deeper in #823. The issue was right there in `SpawnPointProductionExitUpdate` - everything else used model-relative coordinates, while this used world coordinates for some reason. `GetUnitCreatePoint()` is only called in two places, and both expect relative coordinates. This reverts the change in #823 that switched `TryTransformViaProductionExit()` to expecting world coordinates, as no other spawn behavior outputs that, and fixes the real underlying bug in `SpawnPointProductionExitUpdate` as mentioned above.

Tested in Generals with the GLA, and now units from supply centers, war factories, barracks, stinger sites, and tunnel networks all spawn in the correct place.