### PR TITLE
Allow iteration of gameobjects while iterating gameobjects 🤮

### DIFF
--- a/src/OpenSage.Game/Logic/GameLogic.cs
+++ b/src/OpenSage.Game/Logic/GameLogic.cs
@@ -28,12 +28,18 @@ namespace OpenSage.Logic
 
         internal uint NextObjectId = 1;
 
+        // as _objectsToIterate is already a copy in case the collection is updated, this persists the copy in case we iterate mid-update
+        private uint _objectsToIterateFrameCache;
         private readonly List<GameObject> _objectsToIterate = new();
         // TODO: This allocates memory. Don't do this.
         public IEnumerable<GameObject> Objects
         {
             get
             {
+                if (_objectsToIterateFrameCache == CurrentFrame.Value)
+                {
+                    return _objectsToIterate;
+                }
                 // TODO: We can't return _objects directly because it's possible for new objects to be added
                 // during iteration. We should instead create new objects in a pending list, like we do for
                 // removed objects.
@@ -45,6 +51,8 @@ namespace OpenSage.Logic
                         _objectsToIterate.Add(gameObject);
                     }
                 }
+
+                _objectsToIterateFrameCache = _currentFrame.Value;
                 return _objectsToIterate;
             }
         }

--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -419,7 +419,15 @@ namespace OpenSage.Logic
                 case UpgradeStatus.Completed:
                     _upgradesInProgress.Remove(template);
                     UpgradesCompleted.Add(template);
-                    // TODO: Iterate all game objects owned by this player and call their UpdateUpgradeableModules methods.
+                    // TODO: make this more efficient?
+                    foreach (var gameObject in _game.Scene3D.GameContext.GameObjects.Items)
+                    {
+                        if (gameObject.Owner != this)
+                        {
+                            continue;
+                        }
+                        gameObject.UpdateUpgradeableModules();
+                    }
                     break;
             }
 


### PR DESCRIPTION
On the plus side, I don't think this breaks existing behavior and given there are definitely multiple places where we iterate over gameobjects this surely saves us _some_ cycles.

This does allow for player upgrades to be processed, which is needed for some special powers in #837 (namely capture building and radar van scan). I'm very open to other ways of accomplishing this.