### PR TITLE
Revert "Merge pull request #838 from charliefoxtwo/feature/gameobject-iteration-cache"

### DIFF
--- a/src/OpenSage.Game/Logic/GameLogic.cs
+++ b/src/OpenSage.Game/Logic/GameLogic.cs
@@ -31,18 +31,12 @@ namespace OpenSage.Logic
 
         internal uint NextObjectId = 1;
 
-        // as _objectsToIterate is already a copy in case the collection is updated, this persists the copy in case we iterate mid-update
-        private uint _objectsToIterateFrameCache;
         private readonly List<GameObject> _objectsToIterate = new();
         // TODO: This allocates memory. Don't do this.
         public IEnumerable<GameObject> Objects
         {
             get
             {
-                if (_objectsToIterateFrameCache == CurrentFrame.Value)
-                {
-                    return _objectsToIterate;
-                }
                 // TODO: We can't return _objects directly because it's possible for new objects to be added
                 // during iteration. We should instead create new objects in a pending list, like we do for
                 // removed objects.
@@ -54,8 +48,6 @@ namespace OpenSage.Logic
                         _objectsToIterate.Add(gameObject);
                     }
                 }
-
-                _objectsToIterateFrameCache = _currentFrame.Value;
                 return _objectsToIterate;
             }
         }

--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -417,15 +417,7 @@ namespace OpenSage.Logic
                 case UpgradeStatus.Completed:
                     _upgradesInProgress.Remove(template);
                     UpgradesCompleted.Add(template);
-                    // TODO: make this more efficient?
-                    foreach (var gameObject in _game.Scene3D.GameContext.GameObjects.Items)
-                    {
-                        if (gameObject.Owner != this)
-                        {
-                            continue;
-                        }
-                        gameObject.UpdateUpgradeableModules();
-                    }
+                    // TODO: Iterate all game objects owned by this player and call their UpdateUpgradeableModules methods.
                     break;
             }
 


### PR DESCRIPTION
This reverts commit bb67296974d883f9a35c7fbb0f303631125a5ce6, reversing changes made to a57b79ce9a01879ab5921e2a457f5539a55cd048.

I found I was getting the following exception when selling or canceling building structures. Reverting this commit seems to fix the issue. Unfortunately this means player upgrades don't get applied properly, but I guess that just means we'll have to find a different, less hacky way to iterate over those objects.
```
System.Runtime.InteropServices.SEHException (0x80004005): External component has thrown an exception.
   at Vortice.Direct3D11.ID3D11DeviceContext.Map(ID3D11Resource resource, Int32 subresource, MapMode mapType, MapFlags mapFlags, MappedSubresource& mappedResource)
   at Vortice.Direct3D11.ID3D11DeviceContext.Map(ID3D11Resource resource, Int32 subresource, MapMode mode, MapFlags flags)
   at Veldrid.D3D11.D3D11CommandList.UpdateBufferCore(DeviceBuffer buffer, UInt32 bufferOffsetInBytes, IntPtr source, UInt32 sizeInBytes)
   at Veldrid.CommandList.UpdateBuffer(DeviceBuffer buffer, UInt32 bufferOffsetInBytes, IntPtr source, UInt32 sizeInBytes)
   at Veldrid.CommandList.UpdateBuffer[T](DeviceBuffer buffer, UInt32 bufferOffsetInBytes, T& source)
   at OpenSage.Graphics.ConstantBuffer`1.Update(CommandList commandList) in X:\OpenSAGE\src\OpenSage.Game\Graphics\ConstantBuffer`1.cs:line 27
   at OpenSage.Graphics.ModelMeshInstance.OnBeforeRender(CommandList cl, RenderItem& renderItem) in X:\OpenSAGE\src\OpenSage.Game\Graphics\ModelMeshInstance.cs:line 95
   at OpenSage.Graphics.ModelMeshPartInstance.OnBeforeRender(CommandList cl, RenderItem& renderItem) in X:\OpenSAGE\src\OpenSage.Game\Graphics\ModelMeshInstance.cs:line 49
   at OpenSage.Graphics.ModelMeshPartInstance.<.ctor>b__5_1(CommandList cl, RenderItem& renderItem) in X:\OpenSAGE\src\OpenSage.Game\Graphics\ModelMeshInstance.cs:line 41
   at OpenSage.Graphics.Rendering.RenderPipeline.DoRenderPass(RenderContext context, CommandList commandList, RenderBucket bucket, BoundingFrustum cameraFrustum, ResourceSet forwardPassResourceSet, Nullable`1& clippingPlane1, Nullable`1& clippingPlane2) in X:\OpenSAGE\src\OpenSage.Game\Graphics\Rendering\RenderPipeline.cs:line 383
   at OpenSage.Graphics.Rendering.RenderPipeline.<>c__DisplayClass38_0.<Render3DScene>b__0(Framebuffer framebuffer, BoundingFrustum lightBoundingFrustum) in X:\OpenSAGE\src\OpenSage.Game\Graphics\Rendering\RenderPipeline.cs:line 203
   at OpenSage.Graphics.Rendering.Shadows.ShadowMapRenderer.RenderShadowMap(Scene3D scene, GraphicsDevice graphicsDevice, CommandList commandList, Action`2 drawSceneCallback) in X:\OpenSAGE\src\OpenSage.Game\Graphics\Rendering\Shadows\ShadowMapRenderer.cs:line 83
   at OpenSage.Graphics.Rendering.RenderPipeline.Render3DScene(CommandList commandList, Scene3D scene, RenderContext context) in X:\OpenSAGE\src\OpenSage.Game\Graphics\Rendering\RenderPipeline.cs:line 188
   at OpenSage.Graphics.Rendering.RenderPipeline.Execute(RenderContext context) in X:\OpenSAGE\src\OpenSage.Game\Graphics\Rendering\RenderPipeline.cs:line 125
   at OpenSage.Graphics.GraphicsSystem.Draw(TimeInterval& gameTime) in X:\OpenSAGE\src\OpenSage.Game\Graphics\GraphicsSystem.cs:line 36
   at OpenSage.Game.Render() in X:\OpenSAGE\src\OpenSage.Game\Game.cs:line 885
   at OpenSage.Diagnostics.GameView.DrawOverride(Boolean& isGameViewFocused) in X:\OpenSAGE\src\OpenSage.Game\Diagnostics\GameView.cs:line 45
   at OpenSage.Diagnostics.DiagnosticView.Draw(Boolean& isGameViewFocused) in X:\OpenSAGE\src\OpenSage.Game\Diagnostics\DiagnosticView.cs:line 53
   at OpenSage.Diagnostics.MainView.Draw(Boolean& isGameViewFocused) in X:\OpenSAGE\src\OpenSage.Game\Diagnostics\MainView.cs:line 306
   at OpenSage.Diagnostics.DeveloperModeView.Tick() in X:\OpenSAGE\src\OpenSage.Game\Diagnostics\DeveloperModeView.cs:line 83
   at OpenSage.Launcher.Program.Run(Options opts) in X:\OpenSAGE\src\OpenSage.Launcher\Program.cs:line 251
   at OpenSage.Launcher.Program.<>c.<Main>b__1_0(Options opts) in X:\OpenSAGE\src\OpenSage.Launcher\Program.cs:line 67
   at CommandLine.ParserResultExtensions.WithParsed[T](ParserResult`1 result, Action`1 action)
   at OpenSage.Launcher.Program.Main(String[] args) in X:\OpenSAGE\src\OpenSage.Launcher\Program.cs:line 66
```