### PR TITLE
Adjust uneven terrain around objects being built

### DIFF
--- a/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectDefinition.cs
@@ -1267,6 +1267,7 @@ namespace OpenSage.Logic.Object
         }
 
         private GeometryShape _currentGeometryShape;
+        public GeometryShape CurrentGeometryShape => _currentGeometryShape;
 
         internal void ParseGeometry(IniParser parser)
         {


### PR DESCRIPTION
Generals will lower any terrain around an object higher than the centerpoint of the object being placed. It will not raise terrain that is lower than the centerpoint. Adding support for that could be a nice improvement in the future, but would require adjusting things like roads as well.

Roads in Generals currently always render behind structures, regardless of elevation. This is not the case in OpenSAGE, so that still looks a bit wonky currently.

This also removes any scenery (such as shrubbery, rubble, signposts, etc) from the build area.

Generals:
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/9327677c-8b9c-4148-b34f-a4da39023cdd)

OpenSAGE:
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/01ab64af-8c57-4a24-8a60-d18e859af2dd)

Here's an example of where one might build a barracks, with the terrain around it being adjusted (circled red for clarity):
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/f0834968-ed5f-420d-ae09-59ab1fce7053)

Here's a more contrived example as we don't currently check that the terrain variation is within allowable limits (I'm working on that separately, but the computation is currently a bit expensive to run every frame):
![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/05ade4a9-2370-42b8-83cf-07525fef8efb)
