### PR TITLE
Add more cursors and orders to UnitOrderGenerator

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
@@ -29,6 +29,7 @@ namespace OpenSage.Logic.Object
         public bool DrawPips => _moduleData.ShouldDrawPips;
         public virtual int TotalSlots => _moduleData.ContainMax;
         public int OccupiedSlots => ContainedObjectIds.Sum(id => SlotValueForUnit(GameObjectForId(id)));
+        public bool Full => OccupiedSlots >= TotalSlots;
 
         protected const string ExitBoneStartName = "ExitStart";
         protected const string ExitBoneEndName = "ExitEnd";

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -804,6 +804,11 @@ namespace OpenSage.Logic.Object
             return _behaviorCache!.TryGetValue(typeof(T), out var behaviors) ? behaviors.Cast<T>() : [];
         }
 
+        public bool HasBehavior<T>()
+        {
+            return FindBehavior<T>() != null;
+        }
+
         private void InstantiateBehaviorCache()
         {
             var cache = new Dictionary<Type, List<object>>();
@@ -1160,6 +1165,18 @@ namespace OpenSage.Logic.Object
             _upgrades.Remove(upgrade);
 
             // TODO: Set _triggered to false for all affected upgrade modules
+        }
+
+        public bool CanAttackObject(GameObject target)
+        {
+            return CanAttack && Definition.WeaponSets.Values.Any(t =>
+                t.Slots.Any(s => s?.Weapon.Value?.AntiMask.CanAttackObject(target) == true));
+        }
+
+        // todo: this probably is not correct
+        public bool IsAirborne(float groundDelta = 0.1f)
+        {
+            return Translation.Z - GameContext.Terrain.HeightMap.GetHeight(Translation.X, Translation.Y) > groundDelta;
         }
 
         internal void Kill(DeathType deathType)

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyAIUpdate.cs
@@ -34,6 +34,7 @@ namespace OpenSage.Logic.Object
         private SupplyWarehouseDockUpdate _currentSourceDockUpdate;
         protected LogicFrame _waitUntil;
         protected int _numBoxes;
+        public bool CarryingSupplies => _numBoxes > 0;
 
         public int SupplyWarehouseScanDistance => _moduleData.SupplyWarehouseScanDistance;
 

--- a/src/OpenSage.Game/Logic/Object/Weapon/WeaponTemplate.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/WeaponTemplate.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -585,7 +585,7 @@ namespace OpenSage.Logic.Object
         PerShot,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [IniEnum("PER_POSITION"), AddedIn(SageGame.Bfme)]
         PerPosition
@@ -676,7 +676,7 @@ namespace OpenSage.Logic.Object
 
         [IniEnum("STRUCTURES")]
         Structures = 1 << 0,
-        
+
         [IniEnum("WALLS")]
         Walls = 1 << 1,
 
@@ -735,5 +735,32 @@ namespace OpenSage.Logic.Object
         AntiParachute        = 1 << 7,
         AntiStructure        = 1 << 8,
         AntiAirborneMonster  = 1 << 9,
+    }
+
+    public static class WeaponAntiFlagsExtensions
+    {
+        public static bool CanAttackObject(this WeaponAntiFlags weapon, GameObject obj)
+        {
+            var kinds = obj.Definition.KindOf;
+
+            if ((weapon.HasFlag(WeaponAntiFlags.AntiProjectile) && obj.IsKindOf(ObjectKinds.Projectile)) ||
+                (weapon.HasFlag(WeaponAntiFlags.AntiSmallMissile) && obj.IsKindOf(ObjectKinds.SmallMissile)) ||
+                (weapon.HasFlag(WeaponAntiFlags.AntiBallisticMissile) && obj.IsKindOf(ObjectKinds.BallisticMissile)))
+            {
+                return true;
+            }
+
+            if (obj.IsAirborne())
+            {
+                return (weapon.HasFlag(WeaponAntiFlags.AntiAirborneVehicle) && obj.IsKindOf(ObjectKinds.Vehicle)) ||
+                       // unclear if this is correct
+                       (weapon.HasFlag(WeaponAntiFlags.AntiAirborneInfantry) && obj.IsKindOf(ObjectKinds.Infantry));
+            }
+
+            // this should handle when an aircraft is on the ground, since we previously checked if it was airborne
+            return (weapon.HasFlag(WeaponAntiFlags.AntiGround)) ||
+                   (weapon.HasFlag(WeaponAntiFlags.AntiMine) && obj.IsKindOf(ObjectKinds.Mine)) ||
+                   (weapon.HasFlag(WeaponAntiFlags.AntiStructure) && obj.IsKindOf(ObjectKinds.Structure));
+        }
     }
 }

--- a/src/OpenSage.Game/Logic/OrderGenerators/Cursors.cs
+++ b/src/OpenSage.Game/Logic/OrderGenerators/Cursors.cs
@@ -64,7 +64,7 @@ internal static class Cursors
     /// <summary>
     /// Gets the cursor that should be used for a given order. This does not work for special powers, which have their own cursors.
     /// </summary>
-    public static string? CursorForOrder(OrderType orderType)
+    public static string? CursorForOrder(OrderType? orderType)
     {
         return orderType switch
         {

--- a/src/OpenSage.Game/Logic/OrderGenerators/OrderGenerator.cs
+++ b/src/OpenSage.Game/Logic/OrderGenerators/OrderGenerator.cs
@@ -13,6 +13,7 @@ public abstract class OrderGenerator(Game game) : IOrderGenerator
 
     protected Vector3 WorldPosition { get; private set; }
     protected GameObject? WorldObject { get; private set; }
+    protected Game Game => game;
     protected Player? LocalPlayer => game.Scene3D.LocalPlayer;
     protected IReadOnlyCollection<GameObject>? SelectedUnits => LocalPlayer?.SelectedUnits;
 

--- a/src/OpenSage.Game/Logic/OrderGenerators/UnitOrderGenerator.cs
+++ b/src/OpenSage.Game/Logic/OrderGenerators/UnitOrderGenerator.cs
@@ -1,7 +1,11 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using FixedMath.NET;
 using OpenSage.Input;
 using OpenSage.Logic.Object;
 using OpenSage.Logic.Orders;
+using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.OrderGenerators
 {
@@ -9,121 +13,370 @@ namespace OpenSage.Logic.OrderGenerators
     {
         public override bool CanDrag => false;
 
-        public override string GetCursor(KeyModifiers keyModifiers)
+        private OrderType? _currentOrder = null;
+
+        public override string? GetCursor(KeyModifiers keyModifiers)
         {
-            if (LocalPlayer == null || SelectedUnits == null || SelectedUnits.Count == 0)
-            {
-                return WorldObject != null
-                    ? "Select" // TODO: Maybe shouldn't have this here.
-                    : "Arrow";
-            }
-
-            if (keyModifiers.HasFlag(KeyModifiers.Ctrl))
-            {
-                return WorldObject != null
-                    ? "ForceAttackObj"
-                    : "ForceAttackGround";
-            }
-
-            if (WorldObject != null)
-            {
-                // TODO: Should take allies into account.
-                if (WorldObject.Owner != LocalPlayer)
-                {
-                    if (SelectedUnits.Any(u => u.IsKindOf(ObjectKinds.Harvester)) &&
-                        WorldObject.IsKindOf(ObjectKinds.SupplySource))
-                    {
-                        // always take this order, even if the harvester is full
-                        return "EnterFriendly";
-                    }
-
-                    return "AttackObj";
-                }
-
-                if (WorldObject.Definition.KindOf.Get(ObjectKinds.Transport))
-                {
-                    // TODO: Check if transport is full.
-                    return "EnterFriendly";
-                }
-
-                if (SelectedUnits.Any(u => u.IsKindOf(ObjectKinds.Harvester)) &&
-                         SelectedUnits.Any(u => u.Supply > 0) &&
-                         LocalPlayer.SupplyManager.Contains(WorldObject))
-                {
-                    return "EnterFriendly";
-                }
-
-                return "Select";
-            }
-
-            return "Move";
+            _currentOrder = GetOrderTypeForState(keyModifiers);
+            return Cursors.CursorForOrder(_currentOrder);
         }
 
         public override OrderGeneratorResult TryActivate(Scene3D scene, KeyModifiers keyModifiers)
         {
-            if (scene.LocalPlayer.SelectedUnits.Count == 0)
+            var playerId = scene.GetPlayerIndex(scene.LocalPlayer);
+            var targetId = WorldObject?.ID ?? 0;
+
+            // TODO: handle hordes properly
+            var order = _currentOrder switch
             {
-                return OrderGeneratorResult.Inapplicable();
+                OrderType.SetSelection => Order.CreateSetSelection(playerId, targetId),
+                OrderType.SetRallyPoint => Order.CreateSetRallyPointOrder(playerId, SelectedUnits!.Select(u => u.ID).ToList(), WorldPosition),
+                OrderType.AttackObject => Order.CreateAttackObject(playerId, targetId, false),
+                OrderType.ForceAttackObject => Order.CreateAttackObject(playerId, targetId, true),
+                OrderType.ForceAttackGround => Order.CreateAttackGround(playerId, WorldPosition),
+                OrderType.ResumeBuild => Order.CreateResumeBuild(playerId, targetId),
+                OrderType.MoveTo => Order.CreateMoveOrder(playerId, WorldPosition),
+                OrderType.RepairVehicle => Order.CreateRepairVehicle(playerId, targetId),
+                OrderType.RepairStructure => Order.CreateRepairStructure(playerId, targetId),
+                OrderType.Enter => Order.CreateEnter(playerId, targetId),
+                OrderType.GatherDumpSupplies => Order.CreateSupplyGatherDump(playerId, targetId),
+                OrderType.AttackMove => throw new NotImplementedException(),
+                OrderType.AddWaypoint => throw new NotImplementedException(),
+                _ => null,
+            };
+
+            return order != null ? OrderGeneratorResult.SuccessAndContinue([ order ]) : OrderGeneratorResult.Inapplicable();
+        }
+
+        private OrderType? GetOrderTypeForState(KeyModifiers keyModifiers)
+        {
+            if (SelectedUnits is not null && (SelectedUnits.Count == 0 ||
+                                              SelectedUnits.All(u => u.Owner != LocalPlayer)))
+            {
+                return WorldObject != null ? OrderType.SetSelection : OrderType.Zero;
             }
 
-            Order order;
+            // the local player has selected unit(s), and they are the owner of those unit(s)
 
-            var unit = scene.LocalPlayer.SelectedUnits.Last();
+            if (keyModifiers.HasFlag(KeyModifiers.Alt))
+            {
+                return OrderType.AddWaypoint;
+            }
 
-            // TODO: Use ini files for this, don't hardcode it.
             if (keyModifiers.HasFlag(KeyModifiers.Ctrl))
             {
-                if (WorldObject != null)
-                {
-                    order = Order.CreateAttackObject(scene.GetPlayerIndex(scene.LocalPlayer), WorldObject.ID, true);
-                }
-                else
-                {
-                    order = Order.CreateAttackGround(scene.GetPlayerIndex(scene.LocalPlayer), WorldPosition);
-                }
+                return GetOrderForForceFire();
             }
-            else
+
+            // no modifier key has been applied
+            // SelectedUnits is player-owned
+
+            // TODO: verify a garrisoned civilian structure is in fact player-owned
+            if (SelectedUnitsIsStructure(out var s))
             {
-                if (WorldObject != null)
+                return GetCursorForStructureSelected(s);
+            }
+
+            // the selected object is a player-owned unit (not structure)
+            if (!TerrainUnderTargetIsRevealed())
+            {
+                // In Zero Hour, if terrain is under fog of war we always return the Move cursor, no matter what
+                // arguably we could improve upon this by looking at the terrain under the cursor, and ignoring any world objects
+                return OrderType.MoveTo;
+            }
+
+            // area is not under fog of war
+            if (!TryGetTarget(out var target))
+            {
+                return GetCursorForTerrainTarget();
+            }
+
+            // target is some game object
+            if (TargetIsEnemy(target))
+            {
+                return GetCursorForEnemyTarget(target);
+            }
+
+            if (GameObjectIsStructure(target))
+            {
+                if (SelectedUnits?.Any(u => u.Definition.KindOf.Get(ObjectKinds.Dozer)) == true)
                 {
-                    // TODO: Should take allies and neutrals (like supply depots) into account.
-                    if (WorldObject.Owner != LocalPlayer)
+                    if (target.IsBeingConstructed())
                     {
-                        if (unit.IsKindOf(ObjectKinds.Harvester) && WorldObject.IsKindOf(ObjectKinds.SupplySource))
+                        if (TargetIsPlayerOwned(target) && ObjectDoesNotHaveOriginalDozerAssigned(target))
                         {
-                            // always take this order, even if the harvester is full
-                            order = Order.CreateSupplyGatherDump(scene.GetPlayerIndex(scene.LocalPlayer), WorldObject.ID);
-                        }
-                        else
-                        {
-                            order = Order.CreateAttackObject(scene.GetPlayerIndex(scene.LocalPlayer), WorldObject.ID, false);
+                            return OrderType.ResumeBuild;
                         }
                     }
-                    else if (WorldObject.Definition.KindOf.Get(ObjectKinds.Transport))
+                    else if (target.HealthPercentage < Fix64.One)
                     {
-                        // SoundEnter
-                        // VoiceEnter
-                        // TODO: Also need to check TransportSlotCount, Slots, etc.
-                        order = Order.CreateEnter(scene.GetPlayerIndex(scene.LocalPlayer), WorldObject.ID);
-                    }
-                    else if (unit.IsKindOf(ObjectKinds.Harvester) && unit.Supply > 0 && scene.LocalPlayer.SupplyManager.Contains(WorldObject))
-                    {
-                        order = Order.CreateSupplyGatherDump(scene.GetPlayerIndex(scene.LocalPlayer), WorldObject.ID);
-                    }
-                    else
-                    {
-                        return OrderGeneratorResult.Inapplicable();
+                        return OrderType.RepairStructure; // has priority over units garrisoning structure
                     }
                 }
-                else
+
+                if (StructureCanHealAnySelectedUnit(target, out var orderType))
                 {
-                    // TODO: Check whether at least one of the selected units can actually be moved.
-                    // TODO: handle hordes properly
-                    order = Order.CreateMoveOrder(scene.GetPlayerIndex(scene.LocalPlayer), WorldPosition);
+                    return orderType;
+                }
+
+                if (SelectedUnits?.Any(u => u.Definition.KindOf.Get(ObjectKinds.Harvester)) == true)
+                {
+                    if (StructureHasSupplies(target) || // we can give an order to go pick up supplies even if our unit is full
+                        (StructureAcceptsSupplies(target) && SelectedUnits?.Any(u => u.FindBehavior<SupplyAIUpdate>()?.CarryingSupplies == true) == true)) // but we can't drop off supplies unless we already have some
+                    {
+                        return OrderType.GatherDumpSupplies;
+                    }
                 }
             }
 
-            return OrderGeneratorResult.SuccessAndContinue(new[] { order });
+            if (TargetIsEnterable(target))
+            {
+                return GetCursorForEnterableTarget(target);
+            }
+
+            return OrderType.SetSelection;
+        }
+
+
+        private OrderType? GetOrderForForceFire()
+        {
+            if (SelectedUnitsIsStructure(out var s) && s.CanAttack)
+            {
+                return GetCursorForForceAttackingStructure(s);
+            }
+
+            if (SelectedUnits?.All(u => u.CurrentWeapon == null) != false)
+            {
+                return null;  // if we have no units or if all our units have no weapons
+            }
+
+            if (WorldObject == null)
+            {
+                return OrderType.ForceAttackGround;
+            }
+
+            if (SelectedUnits is {Count: 1} && SelectedUnits.Single() == WorldObject)
+            {
+                // units can't force-attack themselves
+                return OrderType.SetSelection;
+            }
+
+            if (AnyUnitCanAttackTarget(WorldObject))
+            {
+                return OrderType.AttackObject;
+            }
+
+            return null;
+        }
+
+
+        /// <summary>
+        /// Checks if the most recent builder of the object still has said object as its build target.
+        /// </summary>
+        private bool ObjectDoesNotHaveOriginalDozerAssigned(GameObject gameObject)
+        {
+            var builderId = gameObject.BuiltByObjectID;
+            var builder = Game.Scene3D.GameObjects.GetObjectById(builderId);
+            return builder == null || builder.AIUpdate is IBuilderAIUpdate builderAiUpdate && builderAiUpdate.BuildTarget != gameObject;
+        }
+
+        private bool StructureCanHealAnySelectedUnit(GameObject structure, [NotNullWhen(true)] out OrderType? orderType)
+        {
+            orderType = null;
+            var allKinds = SelectedUnits?
+                .Where(u => u.Health < Fix64.One)
+                .Select(u => u.Definition.KindOf)
+                .Aggregate(new BitArray<ObjectKinds>(), (s, t) => s | t);
+
+            if (allKinds == null)
+            {
+                return false;
+            }
+
+            if (StructureCanHealVehicles(structure) && allKinds.Get(ObjectKinds.Vehicle) ||
+                StructureCanHealAircraft(structure) && allKinds.Get(ObjectKinds.Aircraft))
+            {
+                orderType = OrderType.RepairVehicle;
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool StructureCanHealVehicles(GameObject structure)
+        {
+            return TargetIsFriendly(structure) && structure.HasBehavior<RepairDockUpdate>();
+        }
+
+        private bool StructureCanHealAircraft(GameObject structure)
+        {
+            // todo: doesn't account for parking slots for fixed-wings and I'm not sure this is even correct for rotary-wings either
+            return TargetIsFriendly(structure) && structure.Definition.KindOf.Get(ObjectKinds.FSAirfield);
+        }
+
+        private OrderType? GetCursorForForceAttackingStructure(GameObject structure)
+        {
+            if (TargetIsInRangeOfStructure(structure))
+            {
+                return WorldObject is null ? OrderType.ForceAttackGround : OrderType.ForceAttackObject;
+            }
+
+            return null;
+        }
+
+        private bool TargetIsInRangeOfStructure(GameObject structure)
+        {
+            // TODO: check range of target, or range to ground position if target is null
+            return true;
+        }
+
+        private OrderType? GetCursorForStructureSelected(GameObject structure)
+        {
+            // the selected object is a player-owned structure
+            if (!TryGetTarget(out var structureTarget))
+            {
+                if (StructureHasRallyPointAbility(structure))
+                {
+                    return OrderType.SetRallyPoint;
+                }
+
+                return null;
+            }
+
+            // target exists
+            if (!TargetIsEnemy(structureTarget))
+            {
+                return OrderType.SetSelection;
+            }
+
+            // target is enemy
+            if (StructureCanAttackTarget(structureTarget))
+            {
+                return OrderType.AttackObject;
+            }
+
+            return null;
+        }
+
+        private OrderType? GetCursorForTerrainTarget()
+        {
+            return !TerrainUnderTargetIsImpassable() || AnySelectedUnitCanTraverseCliffs() ? OrderType.MoveTo : null;
+        }
+
+        private OrderType? GetCursorForEnemyTarget(GameObject target)
+        {
+            return AnyUnitCanAttackTarget(target) ? OrderType.AttackObject : null;
+        }
+
+        private OrderType GetCursorForEnterableTarget(GameObject target)
+        {
+            return AnySelectedUnitCanEnterTarget(target) ? OrderType.Enter : OrderType.SetSelection;
+        }
+
+        private bool SelectedUnitsIsStructure([NotNullWhen(true)] out GameObject structure)
+        {
+            structure = default;
+
+            if (SelectedUnits is not {Count: 1})
+            {
+                return false;
+            }
+
+            structure = SelectedUnits.SingleOrDefault(GameObjectIsStructure);
+
+            return structure is not null;
+        }
+
+        private static bool GameObjectIsStructure(GameObject obj)
+        {
+            return obj.Definition.KindOf.Get(ObjectKinds.Structure);
+        }
+
+        private static bool StructureHasRallyPointAbility(GameObject structure)
+        {
+            return structure.Definition.KindOf.Get(ObjectKinds.AutoRallyPoint);
+        }
+
+        private bool TryGetTarget(out GameObject target)
+        {
+            target = WorldObject;
+            return target is not null;
+        }
+
+        private bool StructureCanAttackTarget(GameObject target)
+        {
+            return TargetIsInRangeOfStructure(target) && AnyUnitCanAttackTarget(target);
+        }
+
+        private bool AnyUnitCanAttackTarget(GameObject target)
+        {
+            return SelectedUnits?.Any(unit => unit != target && unit.CanAttackObject(target)) == true;
+        }
+
+        private bool TargetIsEnemy(GameObject target)
+        {
+            return LocalPlayer?.Enemies.Contains(target.Owner) == true;
+        }
+
+        private bool TargetIsFriendly(GameObject target)
+        {
+            return LocalPlayer?.Allies.Contains(target.Owner) == true;
+        }
+
+        private bool TargetIsPlayerOwned(GameObject target)
+        {
+            return target.Owner == LocalPlayer;
+        }
+
+        // todo: update when fog of war is added
+        private bool TerrainUnderTargetIsRevealed()
+        {
+            return true;
+        }
+
+        private bool TerrainUnderTargetIsImpassable()
+        {
+            var mapCoords = Game.Scene3D.Terrain.HeightMap.GetTilePosition(WorldPosition);
+            if (!mapCoords.HasValue)
+            {
+                // we're outside of the map, so definitely impassable
+                return true;
+            }
+
+            var (x, y) = mapCoords.Value;
+            return Game.Scene3D.Terrain.Map.BlendTileData.Impassability[x, y];
+        }
+
+        private bool AnySelectedUnitCanTraverseCliffs()
+        {
+            return SelectedUnits?.Any(u =>
+                u.Definition.LocomotorSets.Values
+                    .SelectMany(t => t.Locomotors)
+                    .Select(l => l.Value)
+                    .Any(l => l.Surfaces.HasFlag(Surfaces.Cliff))) == true;
+        }
+
+        private static bool StructureHasSupplies(GameObject structure)
+        {
+            return structure.FindBehavior<SupplyWarehouseDockUpdate>()?.HasBoxes() == true;
+        }
+
+        private static bool StructureAcceptsSupplies(GameObject structure)
+        {
+            return structure.HasBehavior<SupplyCenterDockUpdate>();
+        }
+
+        // todo: what about upgrades like helix or overlord bunker? - check is triggered
+        private static bool TargetIsEnterable(GameObject target)
+        {
+            return target.FindBehavior<OpenContainModule>()?.Full == false;
+        }
+
+        private bool AnySelectedUnitCanEnterTarget(GameObject target)
+        {
+            var behavior = target.FindBehavior<OpenContainModule>();
+
+            return behavior != null && SelectedUnits?.Any(behavior.CanAddUnit) == true;
         }
     }
 }

--- a/src/OpenSage.Mathematics/BitArray512.cs
+++ b/src/OpenSage.Mathematics/BitArray512.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Numerics;
@@ -85,7 +85,7 @@ namespace OpenSage.Mathematics
                 else
                 {
                     *(pointer + offset) &= ~mask;
-                } 
+                }
             }
 
             // Mark cache as invalid.
@@ -225,6 +225,21 @@ namespace OpenSage.Mathematics
                 _a6 = _a6 & other._a6,
                 _a7 = _a7 & other._a7,
                 _setBits = -1
+            };
+        }
+
+        public BitArray512 Or(in BitArray512 other)
+        {
+            return new BitArray512(Math.Max(Length, other.Length)) {
+                _a0 = _a0 | other._a0,
+                _a1 = _a1 | other._a1,
+                _a2 = _a2 | other._a2,
+                _a3 = _a3 | other._a3,
+                _a4 = _a4 | other._a4,
+                _a5 = _a5 | other._a5,
+                _a6 = _a6 | other._a6,
+                _a7 = _a7 | other._a7,
+                _setBits = -1,
             };
         }
 

--- a/src/OpenSage.Mathematics/BitArray`1.cs
+++ b/src/OpenSage.Mathematics/BitArray`1.cs
@@ -60,6 +60,11 @@ namespace OpenSage.Mathematics
             }
         }
 
+        public BitArray(in BitArray512 bitArray)
+        {
+            _data = bitArray;
+        }
+
         public bool Get(int bit)
         {
             return _data.Get(bit);
@@ -116,6 +121,16 @@ namespace OpenSage.Mathematics
                     yield return (TEnum) (object) i;
                 }
             }
+        }
+
+        public static BitArray<TEnum> operator |(BitArray<TEnum> left, BitArray<TEnum> right)
+        {
+            return new BitArray<TEnum>(left._data.Or(right._data));
+        }
+
+        public static BitArray<TEnum> operator &(BitArray<TEnum> left, BitArray<TEnum> right)
+        {
+            return new BitArray<TEnum>(left._data.And(right._data));
         }
 
         public string DisplayName


### PR DESCRIPTION
Adds a majority of the general cursors which should apply to most games. I'm not yet sure where unit special power cursors will fit in to this model (which do appear even if the special power hasn't been explicitly selected, like for capturing a neutral building or for black lotus doing just about anything), but that's a problem for future charlie.