### PR TITLE
Change object owner when garrisoned

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Contain/HealContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/HealContain.cs
@@ -8,7 +8,7 @@ namespace OpenSage.Logic.Object
     {
         private readonly HealContainModuleData _moduleData;
 
-        public HealContain(GameObject gameObject, HealContainModuleData moduleData) : base(gameObject, moduleData)
+        internal HealContain(GameObject gameObject, GameContext gameContext, HealContainModuleData moduleData) : base(gameObject, gameContext, moduleData)
         {
             _moduleData = moduleData;
         }
@@ -63,7 +63,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new HealContain(gameObject, this);
+            return new HealContain(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
@@ -13,6 +13,7 @@ namespace OpenSage.Logic.Object
     {
         private readonly OpenContainModuleData _moduleData;
         protected GameObject GameObject { get; }
+        private protected GameContext GameContext { get; }
 
         private readonly List<uint> _containedObjectIds = new();
         private uint _unknownFrame1;
@@ -33,10 +34,11 @@ namespace OpenSage.Logic.Object
         protected const string ExitBoneStartName = "ExitStart";
         protected const string ExitBoneEndName = "ExitEnd";
 
-        protected OpenContainModule(GameObject gameObject, OpenContainModuleData moduleData)
+        private protected OpenContainModule(GameObject gameObject, GameContext gameContext, OpenContainModuleData moduleData)
         {
             _moduleData = moduleData;
             GameObject = gameObject;
+            GameContext = gameContext;
         }
 
         public bool CanAddUnit(GameObject unit)

--- a/src/OpenSage.Game/Logic/Object/Contain/OverlordContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OverlordContain.cs
@@ -6,8 +6,8 @@ namespace OpenSage.Logic.Object
     {
         private readonly OverlordContainModuleData _moduleData;
 
-        internal OverlordContain(GameObject gameObject, OverlordContainModuleData moduleData)
-            : base(gameObject, moduleData)
+        internal OverlordContain(GameObject gameObject, GameContext gameContext, OverlordContainModuleData moduleData)
+            : base(gameObject, gameContext, moduleData)
         {
             _moduleData = moduleData;
         }
@@ -50,7 +50,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new OverlordContain(gameObject, this);
+            return new OverlordContain(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
@@ -12,7 +12,7 @@ namespace OpenSage.Logic.Object
 
         private LogicFrame _nextEvacAllowedAfter; // unsure if this is correct, but seems plausible from testing?
 
-        internal TransportContain(GameObject gameObject, TransportContainModuleData moduleData): base(gameObject, moduleData)
+        internal TransportContain(GameObject gameObject, GameContext gameContext, TransportContainModuleData moduleData): base(gameObject, gameContext, moduleData)
         {
             _moduleData = moduleData;
 
@@ -311,7 +311,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new TransportContain(gameObject, this);
+            return new TransportContain(gameObject, context, this);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Contain/TunnelContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TunnelContain.cs
@@ -7,17 +7,15 @@ namespace OpenSage.Logic.Object
 {
     public sealed class TunnelContain : OpenContainModule
     {
-        public override int TotalSlots => GameObject.GameContext.Game.AssetStore.GameData.Current.MaxTunnelCapacity;
+        public override int TotalSlots => GameContext.Game.AssetStore.GameData.Current.MaxTunnelCapacity;
         public override IList<uint> ContainedObjectIds => GameObject.Owner.TunnelManager!.ContainedObjectIds;
 
-        private readonly GameContext _context;
         private readonly TunnelContainModuleData _moduleData;
         private bool _unknown1;
         private bool _unknown2;
 
-        internal TunnelContain(GameObject gameObject, GameContext context, TunnelContainModuleData moduleData) : base(gameObject, moduleData)
+        internal TunnelContain(GameObject gameObject, GameContext gameContext, TunnelContainModuleData moduleData) : base(gameObject, gameContext, moduleData)
         {
-            _context = context;
             _moduleData = moduleData;
             gameObject.Owner.TunnelManager?.TunnelIds.Add(gameObject.ID);
         }
@@ -30,7 +28,7 @@ namespace OpenSage.Logic.Object
             {
                 foreach (var objectId in ContainedObjectIds)
                 {
-                    _context.GameObjects.GetObjectById(objectId).Kill(DeathType.Crushed);
+                    GameObjectForId(objectId).Kill(DeathType.Crushed);
                 }
 
                 ContainedObjectIds.Clear();


### PR DESCRIPTION
It seems original owner is tracked via team, and as we aren't currently setting teams for players this behavior is currently worked by returning the object to plyrcivilian

Fixes #814 

![image](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/ecfdb736-13d7-4e0c-90cf-c0a0c19105c1)
