### PR TITLE
Hide SCRIPT_ONLY command buttons

### DIFF
--- a/src/OpenSage.Game/Gui/ControlBar/CommandButton.cs
+++ b/src/OpenSage.Game/Gui/ControlBar/CommandButton.cs
@@ -88,9 +88,9 @@ namespace OpenSage.Gui.ControlBar
         public LazyAssetReference<SpecialPower> SpecialPower { get; private set; }
         public LazyAssetReference<UpgradeTemplate> Upgrade { get; private set; }
         public LazyAssetReference<Science>[] Science { get; private set; }
-        public BitArray<CommandButtonOption> Options { get; private set; }
+        public BitArray<CommandButtonOption> Options { get; private set; } = new();
         public string TextLabel { get; private set; }
-        
+
         [AddedIn(SageGame.CncGeneralsZeroHour)]
         public string ConflictingLabel { get; private set; }
 

--- a/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
@@ -409,10 +409,11 @@ namespace OpenSage.Mods.Generals.Gui
                     if (commandSet != null && commandSet.Buttons.TryGetValue(i, out var commandButtonReference))
                     {
                         var commandButton = commandButtonReference.Value;
-                        if (commandButtonReference.Value.ButtonImage == null)
+                        if (commandButton.ButtonImage == null || commandButton.Options.Get(CommandButtonOption.ScriptOnly))
                         {
                             // in generals, the biohazard tech is only different from every other buildable command button in that there is no button image
                             // I suspect this could be the case for other units that didn't make the cut as well
+                            // ScriptOnly commands are used by the AI (such as for constructing the various combat cycle variants)
                             continue;
                         }
 
@@ -504,7 +505,7 @@ namespace OpenSage.Mods.Generals.Gui
                                 break;
                         }
 
-                        if (commandButton.Options?.Get(CommandButtonOption.NeedUpgrade) == true && buttonControl.Enabled)
+                        if (commandButton.Options.Get(CommandButtonOption.NeedUpgrade) && buttonControl.Enabled)
                         {
                             buttonControl.Enabled = selectedUnit.HasUpgrade(commandButton.Upgrade.Value);
                         }

--- a/src/OpenSage.Mods.Generals/Gui/GeneralsExpPointsCallbacks.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GeneralsExpPointsCallbacks.cs
@@ -32,9 +32,15 @@ namespace OpenSage.Mods.Generals.Gui
             for (int i = 0; i < commandSet.Buttons.Count; i++)
             {
                 var buttonControl = _window.Controls.FindControl($"GeneralsExpPoints.wnd:ButtonRank{rank}Number" + i) as Button;
-                if (commandSet != null && commandSet.Buttons.TryGetValue(i + 1, out var commandButtonReference))
+                if (commandSet.Buttons.TryGetValue(i + 1, out var commandButtonReference))
                 {
                     var commandButton = commandButtonReference.Value;
+
+                    if (commandButton.Options.Get(CommandButtonOption.ScriptOnly))
+                    {
+                        buttonControl.Hide();
+                        continue;
+                    }
 
                     CommandButtonUtils.SetCommandButton(buttonControl, commandButton, controlBar);
 


### PR DESCRIPTION
These are either sciences granted via other means (like the MOAB upgrade) or buttons used by the AI (like building the various GLA combat cycle variants)