### PR TITLE
Remove unnecessary move order when constructing building

### DIFF
--- a/src/OpenSage.Game/Logic/OrderGenerators/ConstructBuildingOrderGenerator.cs
+++ b/src/OpenSage.Game/Logic/OrderGenerators/ConstructBuildingOrderGenerator.cs
@@ -100,11 +100,9 @@ namespace OpenSage.Logic.OrderGenerators
             scene.Audio.PlayAudioEvent(dozer, dozer.Definition.UnitSpecificSounds?["VoiceBuildResponse"]?.Value);
 
             var playerIdx = scene.GetPlayerIndex(player);
-            var moveOrder = Order.CreateMoveOrder(playerIdx, WorldPosition);
             var buildOrder = Order.CreateBuildObject(playerIdx, _definitionIndex, WorldPosition, _angle);
 
-            // TODO: Also send an order to builder to start building.
-            return OrderGeneratorResult.SuccessAndExit(new[] { moveOrder, buildOrder });
+            return OrderGeneratorResult.SuccessAndExit(new[] { buildOrder });
         }
 
         private bool IsValidPosition()


### PR DESCRIPTION
The unit already moves via the state machine order given when their build target is set. A manual move command is unnecessary and plays the VoiceMove audio queue, which we don't want in this case.