### PR TITLE
Implement AutoDepositUpdate persistence and generals/zh moduledata

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Collide/MoneyCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/MoneyCrateCollide.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.FileFormats;
 
@@ -36,18 +37,15 @@ namespace OpenSage.Logic.Object
         }
     }
 
-    public struct BoostUpgrade
+    public readonly record struct BoostUpgrade(LazyAssetReference<UpgradeTemplate> UpgradeType, int Boost)
     {
         internal static BoostUpgrade Parse(IniParser parser)
         {
             return new BoostUpgrade
             {
-                UpgradeType = parser.ParseAttribute("UpgradeType", () => parser.ParseAssetReference()),
-                Boost = parser.ParseAttributeInteger("Boost")
+                UpgradeType = parser.ParseAttribute("UpgradeType", parser.ParseUpgradeReference),
+                Boost = parser.ParseAttributeInteger("Boost"),
             };
         }
-
-        public string UpgradeType;
-        public int Boost;
     }
 }

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -1421,6 +1421,11 @@ namespace OpenSage.Logic.Object
 
         internal void GainExperience(int experience)
         {
+            if (!Definition.IsTrainable)
+            {
+                return;
+            }
+
             VeterancyHelper.GainExperience(experience);
         }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
@@ -7,35 +7,62 @@ namespace OpenSage.Logic.Object
 {
     internal sealed class AutoDepositUpdate : UpdateModule
     {
-        GameObject _gameObject;
-        AutoDepositUpdateModuleData _moduleData;
+        private readonly GameObject _gameObject;
+        private readonly GameContext _context;
+        private readonly AutoDepositUpdateModuleData _moduleData;
 
-        private LogicFrame _waitUntil;
-
-        private uint _unknownFrame;
-        private bool _unknownBool1;
-        private bool _unknownBool2;
+        private LogicFrame _nextAwardFrame;
+        private bool _shouldGrantInitialCaptureBonus = true; // this always starts as true, even if there is no capture bonus
+        private bool _unknownBool2 = true;
 
         internal AutoDepositUpdate(GameObject gameObject, GameContext context, AutoDepositUpdateModuleData moduleData)
         {
             _moduleData = moduleData;
             _gameObject = gameObject;
+            _context = context;
         }
 
         internal override void Update(BehaviorUpdateContext context)
         {
-            if (_gameObject.IsBeingConstructed() || (context.LogicFrame < _waitUntil))
+            if (_gameObject.IsBeingConstructed())
             {
                 return;
             }
 
-            _waitUntil = context.LogicFrame + _moduleData.DepositTiming;
-            var amount = (uint) (_moduleData.DepositAmount * _gameObject.ProductionModifier);
-            _gameObject.Owner.BankAccount.Deposit(amount);
-            _gameObject.ActiveCashEvent = new CashEvent((int)amount, _gameObject.Owner.Color, new Vector3(0, 0, 10));
-            if (!_moduleData.GiveNoXP)
+            // this bonus happens on capture, regardless of the award frame timing
+            if (_shouldGrantInitialCaptureBonus && _moduleData.InitialCaptureBonus != 0 && _gameObject.Owner != _context.Game.PlayerManager.GetCivilianPlayer())
             {
-                _gameObject.GainExperience((int)amount);
+                _shouldGrantInitialCaptureBonus = false;
+                _gameObject.ActiveCashEvent = new CashEvent(_moduleData.InitialCaptureBonus, _gameObject.Owner.Color, new Vector3(0, 0, 10));
+
+                // It doesn't appear capture bonus and actual money ever intersect, but just in case...
+                if (_moduleData.ActualMoney)
+                {
+                    _gameObject.Owner.BankAccount.Deposit((uint)_moduleData.InitialCaptureBonus);
+                }
+            }
+
+            if (context.LogicFrame < _nextAwardFrame)
+            {
+                return;
+            }
+
+            _nextAwardFrame = context.LogicFrame + _moduleData.DepositTiming;
+            var amount = (uint) (_moduleData.DepositAmount * _gameObject.ProductionModifier);
+
+            if (_moduleData.UpgradedBoost.HasValue && _gameObject.HasUpgrade(_moduleData.UpgradedBoost.Value.UpgradeType.Value))
+            {
+                amount += (uint)(amount * (_moduleData.UpgradedBoost.Value.Boost / 100f));
+            }
+
+            _gameObject.ActiveCashEvent = new CashEvent((int)amount, _gameObject.Owner.Color, new Vector3(0, 0, 10));
+            if (_moduleData.ActualMoney)
+            {
+                _gameObject.Owner.BankAccount.Deposit(amount);
+                if (!_moduleData.GiveNoXP)
+                {
+                    _gameObject.GainExperience((int)amount);
+                }
             }
         }
 
@@ -47,8 +74,8 @@ namespace OpenSage.Logic.Object
             base.Load(reader);
             reader.EndObject();
 
-            reader.PersistFrame(ref _unknownFrame);
-            reader.PersistBoolean(ref _unknownBool1);
+            reader.PersistLogicFrame(ref _nextAwardFrame);
+            reader.PersistBoolean(ref _shouldGrantInitialCaptureBonus);
             reader.PersistBoolean(ref _unknownBool2);
         }
     }
@@ -86,11 +113,17 @@ namespace OpenSage.Logic.Object
         /// </summary>
         public int InitialCaptureBonus { get; private set; }
 
+        /// <summary>
+        /// Whether to actually award money or just make it appear to others that money has been awarded.
+        /// </summary>
         [AddedIn(SageGame.CncGeneralsZeroHour)]
-        public bool ActualMoney { get; private set; }
+        public bool ActualMoney { get; private set; } = true;
 
+        /// <summary>
+        /// Bonus cash percentage to add to the <see cref="DepositAmount"/> contingent upon the upgrade being researched.
+        /// </summary>
         [AddedIn(SageGame.CncGeneralsZeroHour)]
-        public BoostUpgrade UpgradedBoost { get; private set; }
+        public BoostUpgrade? UpgradedBoost { get; private set; }
 
         [AddedIn(SageGame.Bfme)]
         public string Upgrade { get; private set; }

--- a/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
@@ -29,19 +29,6 @@ namespace OpenSage.Logic.Object
                 return;
             }
 
-            // this bonus happens on capture, regardless of the award frame timing
-            if (_shouldGrantInitialCaptureBonus && _moduleData.InitialCaptureBonus != 0 && _gameObject.Owner != _context.Game.PlayerManager.GetCivilianPlayer())
-            {
-                _shouldGrantInitialCaptureBonus = false;
-                _gameObject.ActiveCashEvent = new CashEvent(_moduleData.InitialCaptureBonus, _gameObject.Owner.Color, new Vector3(0, 0, 10));
-
-                // It doesn't appear capture bonus and actual money ever intersect, but just in case...
-                if (_moduleData.ActualMoney)
-                {
-                    _gameObject.Owner.BankAccount.Deposit((uint)_moduleData.InitialCaptureBonus);
-                }
-            }
-
             if (context.LogicFrame < _nextAwardFrame)
             {
                 return;
@@ -55,7 +42,7 @@ namespace OpenSage.Logic.Object
                 amount += (uint)(amount * (_moduleData.UpgradedBoost.Value.Boost / 100f));
             }
 
-            _gameObject.ActiveCashEvent = new CashEvent((int)amount, _gameObject.Owner.Color, new Vector3(0, 0, 10));
+            GenerateAutoDepositCashEvent((int)amount);
             if (_moduleData.ActualMoney)
             {
                 _gameObject.Owner.BankAccount.Deposit(amount);
@@ -64,6 +51,26 @@ namespace OpenSage.Logic.Object
                     _gameObject.GainExperience((int)amount);
                 }
             }
+        }
+
+        public void GrantCaptureBonus()
+        {
+            if (_shouldGrantInitialCaptureBonus && _moduleData.InitialCaptureBonus != 0)
+            {
+                _shouldGrantInitialCaptureBonus = false;
+                GenerateAutoDepositCashEvent(_moduleData.InitialCaptureBonus);
+
+                // It doesn't appear capture bonus and actual money ever intersect, but just in case...
+                if (_moduleData.ActualMoney)
+                {
+                    _gameObject.Owner.BankAccount.Deposit((uint)_moduleData.InitialCaptureBonus);
+                }
+            }
+        }
+
+        private void GenerateAutoDepositCashEvent(int amount)
+        {
+            _gameObject.ActiveCashEvent = new CashEvent(amount, _gameObject.Owner.Color, new Vector3(0, 0, 10));
         }
 
         internal override void Load(StatePersister reader)


### PR DESCRIPTION
This ties the next deposit frame to a persisted field, and implements a few more of the moduledata properties. I'm still not sure what that second persisted bool is for... it was always `true` in my testing.