### PR TITLE
Parse time in ModuleData objects as LogicFrameSpans

### DIFF
--- a/src/OpenSage.Game/GameData.cs
+++ b/src/OpenSage.Game/GameData.cs
@@ -416,7 +416,7 @@ namespace OpenSage
             { "SellPercentage", (parser, x) => x.SellPercentage = parser.ParsePercentage() },
 
             { "BaseRegenHealthPercentPerSecond", (parser, x) => x.BaseRegenHealthPercentPerSecond = parser.ParsePercentage() },
-            { "BaseRegenDelay", (parser, x) => x.BaseRegenDelay = parser.ParseInteger() },
+            { "BaseRegenDelay", (parser, x) => x.BaseRegenDelay = parser.ParseTimeMillisecondsToLogicFrames() },
 
             { "SpecialPowerViewObject", (parser, x) => x.SpecialPowerViewObject = parser.ParseAssetReference() },
 
@@ -1160,7 +1160,7 @@ namespace OpenSage
         public Percentage SellPercentage { get; private set; }
 
         public Percentage BaseRegenHealthPercentPerSecond { get; private set; }
-        public int BaseRegenDelay { get; private set; }
+        public LogicFrameSpan BaseRegenDelay { get; private set; }
 
         public string SpecialPowerViewObject { get; private set; }
 
@@ -1557,7 +1557,7 @@ namespace OpenSage
 
     public sealed class WeaponBonus : Dictionary<WeaponBonusAttributeType, Percentage>
     {
-        
+
     }
 
     public enum WeaponBonusAttributeType

--- a/src/OpenSage.Game/Logic/AI/AIStates/HackInternetState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/HackInternetState.cs
@@ -1,14 +1,16 @@
-﻿namespace OpenSage.Logic.AI.AIStates
+﻿using OpenSage.Logic.Object;
+
+namespace OpenSage.Logic.AI.AIStates
 {
     internal sealed class HackInternetState : State
     {
-        public uint FramesUntilNextHack;
+        public LogicFrameSpan FramesUntilNextHack;
 
         public override void Persist(StatePersister reader)
         {
             reader.PersistVersion(1);
 
-            reader.PersistUInt32(ref FramesUntilNextHack);
+            reader.PersistLogicFrameSpan(ref FramesUntilNextHack);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/AI/AIStates/StartHackingInternetState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/StartHackingInternetState.cs
@@ -1,14 +1,16 @@
-﻿namespace OpenSage.Logic.AI.AIStates
+﻿using OpenSage.Logic.Object;
+
+namespace OpenSage.Logic.AI.AIStates
 {
     internal sealed class StartHackingInternetState : State
     {
-        public uint FramesUntilHackingBegins;
+        public LogicFrameSpan FramesUntilHackingBegins;
 
         public override void Persist(StatePersister reader)
         {
             reader.PersistVersion(1);
 
-            reader.PersistUInt32(ref FramesUntilHackingBegins);
+            reader.PersistLogicFrameSpan(ref FramesUntilHackingBegins);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/AI/AIStates/StopHackingInternetState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/StopHackingInternetState.cs
@@ -1,14 +1,16 @@
-﻿namespace OpenSage.Logic.AI.AIStates
+﻿using OpenSage.Logic.Object;
+
+namespace OpenSage.Logic.AI.AIStates
 {
     internal sealed class StopHackingInternetState : State
     {
-        public uint FramesUntilFinishedPacking;
+        public LogicFrameSpan FramesUntilFinishedPacking;
 
         public override void Persist(StatePersister reader)
         {
             reader.PersistVersion(1);
 
-            reader.PersistUInt32(ref FramesUntilFinishedPacking);
+            reader.PersistLogicFrameSpan(ref FramesUntilFinishedPacking);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
+++ b/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
@@ -13,11 +13,6 @@ namespace OpenSage.Logic.Object
 
         internal virtual void OnDamageStateChanged(BehaviorUpdateContext context, BodyDamageType fromDamage, BodyDamageType toDamage) { }
 
-        protected static uint FramesForMs(int ms)
-        {
-            return (uint)(Game.LogicFramesPerSecond * (ms / 1000f));
-        }
-
         internal override void Load(StatePersister reader)
         {
             reader.PersistVersion(1);
@@ -59,6 +54,7 @@ namespace OpenSage.Logic.Object
 
     public readonly struct LogicFrame
     {
+        public static readonly LogicFrame Zero = default;
         public static readonly LogicFrame MaxValue = new LogicFrame(uint.MaxValue);
 
         internal readonly uint Value;
@@ -127,6 +123,16 @@ namespace OpenSage.Logic.Object
             return new LogicFrameSpan(left.Value + 1);
         }
 
+        public static LogicFrameSpan operator -(LogicFrameSpan left, LogicFrameSpan right)
+        {
+            return new LogicFrameSpan(left.Value - right.Value);
+        }
+
+        public static LogicFrameSpan operator --(LogicFrameSpan left)
+        {
+            return new LogicFrameSpan(left.Value - 1);
+        }
+
         public static LogicFrameSpan operator *(LogicFrameSpan left, Percentage right)
         {
             return new LogicFrameSpan((uint)MathF.Ceiling(left.Value * (float)right));
@@ -150,6 +156,31 @@ namespace OpenSage.Logic.Object
         public static LogicFrameSpan operator /(LogicFrameSpan left, Percentage right)
         {
             return new LogicFrameSpan((uint)MathF.Ceiling(left.Value / (float)right));
+        }
+
+        public static bool operator ==(LogicFrameSpan left, LogicFrameSpan right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(LogicFrameSpan left, LogicFrameSpan right)
+        {
+            return !(left == right);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is LogicFrameSpan logicFrameSpan && Equals(logicFrameSpan);
+        }
+
+        private bool Equals(LogicFrameSpan other)
+        {
+            return Value == other.Value;
+        }
+
+        public override int GetHashCode()
+        {
+            return (int)Value;
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PropagandaTowerBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PropagandaTowerBehavior.cs
@@ -9,7 +9,7 @@ namespace OpenSage.Logic.Object
 {
     public sealed class PropagandaTowerBehavior : UpdateModule
     {
-        protected override uint FramesBetweenUpdates => FramesForMs(_moduleData.DelayBetweenUpdates);
+        protected override LogicFrameSpan FramesBetweenUpdates => _moduleData.DelayBetweenUpdates;
 
         private readonly GameObject _gameObject;
         private readonly PropagandaTowerBehaviorModuleData _moduleData;
@@ -140,7 +140,7 @@ namespace OpenSage.Logic.Object
         private static readonly IniParseTable<PropagandaTowerBehaviorModuleData> FieldParseTable = new IniParseTable<PropagandaTowerBehaviorModuleData>
         {
             { "Radius", (parser, x) => x.Radius = parser.ParseFloat() },
-            { "DelayBetweenUpdates", (parser, x) => x.DelayBetweenUpdates = parser.ParseInteger() },
+            { "DelayBetweenUpdates", (parser, x) => x.DelayBetweenUpdates = parser.ParseTimeMillisecondsToLogicFrames() },
             { "HealPercentEachSecond", (parser, x) => x.HealPercentEachSecond = parser.ParsePercentage() },
             { "PulseFX", (parser, x) => x.PulseFX = parser.ParseFXListReference() },
             { "UpgradeRequired", (parser, x) => x.UpgradeRequired = parser.ParseUpgradeReference() },
@@ -150,7 +150,7 @@ namespace OpenSage.Logic.Object
         };
 
         public float Radius { get; private set; }
-        public int DelayBetweenUpdates { get; private set; }
+        public LogicFrameSpan DelayBetweenUpdates { get; private set; }
         public Percentage HealPercentEachSecond { get; private set; }
         /// <summary>
         /// plays as often as DelayBetweenUpdates

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -191,7 +191,7 @@ namespace OpenSage.Logic.Object
         }
 
         private BitArray<DisabledType> _disabledTypes = new();
-        private readonly uint[] _disabledTypesFrames = new uint[9];
+        private readonly LogicFrame[] _disabledTypesFrames = new LogicFrame[9];
         public readonly ObjectVeterancyHelper VeterancyHelper;
         private uint _containerId;
         public uint ContainerId => _containerId;
@@ -1369,7 +1369,7 @@ namespace OpenSage.Logic.Object
         {
             _containerId = containerId;
             _containedFrame = _gameContext.GameLogic.CurrentFrame.Value;
-            const uint disabledUntilFrame = 0x3FFFFFFFu; // not sure why this is this way;
+            var disabledUntilFrame = new LogicFrame(0x3FFFFFFFu); // not sure why this is this way;
             Disable(DisabledType.Held, disabledUntilFrame);
             Hidden = true;
             SetSelectable(false);
@@ -1387,7 +1387,7 @@ namespace OpenSage.Logic.Object
             _status.Set(ObjectStatus.InsideGarrison, false);
         }
 
-        public void Disable(DisabledType type, uint frame)
+        public void Disable(DisabledType type, LogicFrame frame)
         {
             _disabledTypes.Set(type, true);
             _disabledTypesFrames[(int)type] = frame;
@@ -1396,7 +1396,7 @@ namespace OpenSage.Logic.Object
         public void UnDisable(DisabledType type)
         {
             _disabledTypes.Set(type, false);
-            _disabledTypesFrames[(int)type] = 0;
+            _disabledTypesFrames[(int)type] = LogicFrame.Zero;
         }
 
         private void CheckDisabledStates()
@@ -1404,7 +1404,7 @@ namespace OpenSage.Logic.Object
             for (var i = 0; i < _disabledTypesFrames.Length; i++)
             {
                 var disabledTypeFrame = _disabledTypesFrames[i];
-                if (disabledTypeFrame > 0 && disabledTypeFrame < _gameContext.GameLogic.CurrentFrame.Value)
+                if (disabledTypeFrame > LogicFrame.Zero && disabledTypeFrame < _gameContext.GameLogic.CurrentFrame)
                 {
                     UnDisable((DisabledType)i);
                 }
@@ -1508,9 +1508,9 @@ namespace OpenSage.Logic.Object
 
             reader.PersistArray(
                 _disabledTypesFrames,
-                static (StatePersister persister, ref uint item) =>
+                static (StatePersister persister, ref LogicFrame item) =>
                 {
-                    persister.PersistFrameValue(ref item);
+                    persister.PersistLogicFrameValue(ref item);
                 });
 
             reader.SkipUnknownBytes(8);

--- a/src/OpenSage.Game/Logic/Object/SpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower.cs
@@ -18,7 +18,7 @@ namespace OpenSage.Logic.Object
         private static readonly IniParseTable<SpecialPower> FieldParseTable = new()
         {
             { "Enum", (parser, x) => x.Type = parser.ParseEnum<SpecialPowerType>() },
-            { "ReloadTime", (parser, x) => x.ReloadTime = parser.ParseInteger() },
+            { "ReloadTime", (parser, x) => x.ReloadTime = parser.ParseTimeMillisecondsToLogicFrames() },
             { "RequiredScience", (parser, x) => x.RequiredSciences = new[] { parser.ParseScienceReference() } },
             { "PublicTimer", (parser, x) => x.PublicTimer = parser.ParseBoolean() },
             { "SharedSyncedTimer", (parser, x) => x.SharedSyncedTimer = parser.ParseBoolean() },
@@ -48,7 +48,7 @@ namespace OpenSage.Logic.Object
         /// <summary>
         /// The time for the special power to reload, in ms.
         /// </summary>
-        public int ReloadTime { get; private set; }
+        public LogicFrameSpan ReloadTime { get; private set; }
         public bool PublicTimer { get; private set; }
         public bool SharedSyncedTimer { get; private set; }
         public LazyAssetReference<BaseAudioEventInfo> InitiateSound { get; private set; }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialPower.cs
@@ -148,7 +148,7 @@ namespace OpenSage.Logic.Object
         {
             var specialPower = _moduleData.SpecialPower.Value;
             Context.AudioSystem.PlayAudioEvent(specialPower.InitiateSound?.Value);
-            Context.AudioSystem.PlayAudioEvent(position, specialPower.InitiateAtLocationSoun2.Value);
+            Context.AudioSystem.PlayAudioEvent(position, specialPower.InitiateAtLocationSound?.Value);
             ResetCountdown();
         }
 

--- a/src/OpenSage.Game/Logic/Object/Update/BaseRegenerateUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BaseRegenerateUpdate.cs
@@ -7,7 +7,7 @@ namespace OpenSage.Logic.Object
         private readonly GameObject _gameObject;
         private readonly GameContext _context;
 
-        protected override uint FramesBetweenUpdates => (uint)Game.LogicFramesPerSecond;
+        protected override LogicFrameSpan FramesBetweenUpdates => LogicFrameSpan.OneSecond;
 
         internal BaseRegenerateUpdate(GameObject gameObject, GameContext context)
         {
@@ -21,8 +21,8 @@ namespace OpenSage.Logic.Object
         /// </summary>
         public void RegisterDamage()
         {
-            var currentFrame = _gameObject.GameContext.GameLogic.CurrentFrame.Value;
-            NextUpdateFrame.Frame = currentFrame + FramesForMs(_context.AssetLoadContext.AssetStore.GameData.Current.BaseRegenDelay);
+            var currentFrame = _gameObject.GameContext.GameLogic.CurrentFrame;
+            NextUpdateFrame = new UpdateFrame(currentFrame + _context.AssetLoadContext.AssetStore.GameData.Current.BaseRegenDelay);
         }
 
         private protected override void RunUpdate(BehaviorUpdateContext context)

--- a/src/OpenSage.Game/Logic/Object/Update/HordeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/HordeUpdate.cs
@@ -14,7 +14,7 @@ namespace OpenSage.Logic.Object
 
         private bool _isInHorde;
 
-        protected override uint FramesBetweenUpdates => FramesForMs(_moduleData.UpdateRate);
+        protected override LogicFrameSpan FramesBetweenUpdates => _moduleData.UpdateRate;
 
         internal HordeUpdate(GameObject gameObject, GameContext context, HordeUpdateModuleData moduleData)
         {
@@ -119,7 +119,7 @@ namespace OpenSage.Logic.Object
         private static readonly IniParseTable<HordeUpdateModuleData> FieldParseTable = new IniParseTable<HordeUpdateModuleData>
         {
             { "RubOffRadius", (parser, x) => x.RubOffRadius = parser.ParseInteger() },
-            { "UpdateRate", (parser, x) => x.UpdateRate = parser.ParseInteger() },
+            { "UpdateRate", (parser, x) => x.UpdateRate = parser.ParseTimeMillisecondsToLogicFrames() },
             { "Radius", (parser, x) => x.Radius = parser.ParseInteger() },
             { "KindOf", (parser, x) => x.KindOf = parser.ParseEnumBitArray<ObjectKinds>() },
             { "AlliesOnly", (parser, x) => x.AlliesOnly = parser.ParseBoolean() },
@@ -135,7 +135,7 @@ namespace OpenSage.Logic.Object
         /// <summary>
         /// how often to recheck horde status (msec)
         /// </summary>
-        public int UpdateRate { get; private set; }
+        public LogicFrameSpan UpdateRate { get; private set; }
         /// <summary>
         /// how close other units must be to us to count towards our horde-ness
         /// </summary>

--- a/src/OpenSage.Game/Logic/Object/Update/RebuildHoleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RebuildHoleUpdate.cs
@@ -21,7 +21,7 @@ namespace OpenSage.Logic.Object
         private uint _structureId; // the structure that is being built
         private uint _originalStructureId; // the structure that was destroyed to create this hole
 
-        private uint _framesUntilConstructionBegins;
+        private LogicFrameSpan _framesUntilConstructionBegins;
 
         private string _workerObjectName; // the worker to spawn to build the structure
         private ObjectDefinition WorkerObjectDefinition => _context.Game.AssetStore.ObjectDefinitions.GetByName(_workerObjectName);
@@ -49,7 +49,7 @@ namespace OpenSage.Logic.Object
 
         private void ResetConstructionCounter()
         {
-            _framesUntilConstructionBegins = FramesForMs(_moduleData.WorkerRespawnDelay);
+            _framesUntilConstructionBegins = _moduleData.WorkerRespawnDelay;
         }
 
         // scaffolds have a status of 0001 0000 0000 0000 0000 0100 in sav file (0100 is under construction)
@@ -66,9 +66,9 @@ namespace OpenSage.Logic.Object
                 _gameObject.Heal(_healPercentagePerFrame);
             }
 
-            if (_framesUntilConstructionBegins > 0)
+            if (_framesUntilConstructionBegins != LogicFrameSpan.Zero)
             {
-                _framesUntilConstructionBegins -= 1;
+                _framesUntilConstructionBegins--;
                 return;
             }
 
@@ -164,7 +164,7 @@ namespace OpenSage.Logic.Object
             reader.PersistObjectID(ref _structureId);
             reader.PersistObjectID(ref _originalStructureId);
 
-            reader.PersistUInt32(ref _framesUntilConstructionBegins);
+            reader.PersistLogicFrameSpan(ref _framesUntilConstructionBegins);
 
             reader.PersistAsciiString(ref _workerObjectName);
             reader.PersistAsciiString(ref _structureObjectName);
@@ -195,13 +195,13 @@ namespace OpenSage.Logic.Object
         internal static readonly IniParseTable<RebuildHoleUpdateModuleData> BaseFieldParseTable = new IniParseTable<RebuildHoleUpdateModuleData>
         {
             { "WorkerObjectName", (parser, x) => x.WorkerObjectDefinition = parser.ParseObjectReference() },
-            { "WorkerRespawnDelay", (parser, x) => x.WorkerRespawnDelay = parser.ParseInteger() },
+            { "WorkerRespawnDelay", (parser, x) => x.WorkerRespawnDelay = parser.ParseTimeMillisecondsToLogicFrames() },
             { "HoleHealthRegen%PerSecond", (parser, x) => x.HoleHealthRegenPercentPerSecond = parser.ParsePercentage() }
         };
 
         public LazyAssetReference<ObjectDefinition> WorkerObjectDefinition { get; private set; }
 
-        public int WorkerRespawnDelay { get; private set; }
+        public LogicFrameSpan WorkerRespawnDelay { get; private set; }
 
         public Percentage HoleHealthRegenPercentPerSecond { get; private set; }
 

--- a/src/OpenSage.Game/Logic/Object/Update/StealthDetectorUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StealthDetectorUpdate.cs
@@ -1,4 +1,7 @@
-﻿using OpenSage.Data.Ini;
+﻿using OpenSage.Audio;
+using OpenSage.Content;
+using OpenSage.Data.Ini;
+using OpenSage.Graphics.ParticleSystems;
 
 namespace OpenSage.Logic.Object
 {
@@ -7,7 +10,7 @@ namespace OpenSage.Logic.Object
         private readonly StealthDetectorUpdateModuleData _moduleData;
         public bool Active;
 
-        protected override uint FramesBetweenUpdates => FramesForMs(_moduleData.DetectionRate);
+        protected override LogicFrameSpan FramesBetweenUpdates => _moduleData.DetectionRate;
 
         public StealthDetectorUpdate(StealthDetectorUpdateModuleData moduleData)
         {
@@ -46,18 +49,18 @@ namespace OpenSage.Logic.Object
 
         private static readonly IniParseTable<StealthDetectorUpdateModuleData> FieldParseTable = new IniParseTable<StealthDetectorUpdateModuleData>
         {
-            { "DetectionRate", (parser, x) => x.DetectionRate = parser.ParseInteger() },
+            { "DetectionRate", (parser, x) => x.DetectionRate = parser.ParseTimeMillisecondsToLogicFrames() },
             { "InitiallyDisabled", (parser, x) => x.InitiallyDisabled = parser.ParseBoolean() },
             { "DetectionRange", (parser, x) => x.DetectionRange = parser.ParseInteger() },
             { "CanDetectWhileGarrisoned", (parser, x) => x.CanDetectWhileGarrisoned = parser.ParseBoolean() },
             { "CanDetectWhileContained", (parser, x) => x.CanDetectWhileContained = parser.ParseBoolean() },
             { "ExtraRequiredKindOf", (parser, x) => x.ExtraRequiredKindOf = parser.ParseEnum<ObjectKinds>() },
-            { "PingSound", (parser, x) => x.PingSound = parser.ParseAssetReference() },
-            { "LoudPingSound", (parser, x) => x.LoudPingSound = parser.ParseAssetReference() },
-            { "IRParticleSysName", (parser, x) => x.IRParticleSysName = parser.ParseAssetReference() },
-            { "IRBrightParticleSysName", (parser, x) => x.IRBrightParticleSysName = parser.ParseAssetReference() },
-            { "IRGridParticleSysName", (parser, x) => x.IRGridParticleSysName = parser.ParseAssetReference() },
-            { "IRBeaconParticleSysName", (parser, x) => x.IRBeaconParticleSysName = parser.ParseAssetReference() },
+            { "PingSound", (parser, x) => x.PingSound = parser.ParseAudioEventReference() },
+            { "LoudPingSound", (parser, x) => x.LoudPingSound = parser.ParseAudioEventReference() },
+            { "IRParticleSysName", (parser, x) => x.IRParticleSysName = parser.ParseFXParticleSystemTemplateReference() },
+            { "IRBrightParticleSysName", (parser, x) => x.IRBrightParticleSysName = parser.ParseFXParticleSystemTemplateReference() },
+            { "IRGridParticleSysName", (parser, x) => x.IRGridParticleSysName = parser.ParseFXParticleSystemTemplateReference() },
+            { "IRBeaconParticleSysName", (parser, x) => x.IRBeaconParticleSysName = parser.ParseFXParticleSystemTemplateReference() },
             { "IRParticleSysBone", (parser, x) => x.IRParticleSysBone = parser.ParseBoneName() },
             { "CancelOneRingEffect", (parser, x) => x.CancelOneRingEffect = parser.ParseBoolean() },
             { "RequiredUpgrade", (parser, x) => x.RequiredUpgrade = parser.ParseAssetReference() },
@@ -66,7 +69,7 @@ namespace OpenSage.Logic.Object
         /// <summary>
         /// How often, in milliseconds, to scan for stealthed objects in sight range.
         /// </summary>
-        public int DetectionRate { get; private set; }
+        public LogicFrameSpan DetectionRate { get; private set; }
 
         public bool InitiallyDisabled { get; private set; }
 
@@ -78,12 +81,12 @@ namespace OpenSage.Logic.Object
 
         public ObjectKinds ExtraRequiredKindOf { get; private set; }
 
-        public string PingSound { get; private set; }
-        public string LoudPingSound { get; private set; }
-        public string IRParticleSysName { get; private set; }
-        public string IRBrightParticleSysName { get; private set; }
-        public string IRGridParticleSysName { get; private set; }
-        public string IRBeaconParticleSysName { get; private set; }
+        public LazyAssetReference<BaseAudioEventInfo> PingSound { get; private set; }
+        public LazyAssetReference<BaseAudioEventInfo> LoudPingSound { get; private set; }
+        public LazyAssetReference<FXParticleSystemTemplate> IRParticleSysName { get; private set; }
+        public LazyAssetReference<FXParticleSystemTemplate> IRBrightParticleSysName { get; private set; }
+        public LazyAssetReference<FXParticleSystemTemplate> IRGridParticleSysName { get; private set; }
+        public LazyAssetReference<FXParticleSystemTemplate> IRBeaconParticleSysName { get; private set; }
         public string IRParticleSysBone { get; private set; }
 
         [AddedIn(SageGame.Bfme)]

--- a/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
@@ -7,7 +7,7 @@ namespace OpenSage.Logic.Object
         // it's also possible this is _last_ update, not next update
         protected UpdateFrame NextUpdateFrame;
 
-        protected virtual uint FramesBetweenUpdates => 1;
+        protected virtual LogicFrameSpan FramesBetweenUpdates { get; } = new(1);
 
         private protected virtual void RunUpdate(BehaviorUpdateContext context) { }
 
@@ -19,7 +19,7 @@ namespace OpenSage.Logic.Object
                 return;
             }
 
-            NextUpdateFrame.Frame = context.LogicFrame.Value + FramesBetweenUpdates;
+            NextUpdateFrame = new UpdateFrame(context.LogicFrame + FramesBetweenUpdates);
             RunUpdate(context);
         }
 
@@ -37,6 +37,11 @@ namespace OpenSage.Logic.Object
         protected struct UpdateFrame
         {
             public uint RawValue;
+
+            public UpdateFrame(LogicFrame frame)
+            {
+                Frame = frame.Value;
+            }
 
             public uint Frame
             {

--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -1002,15 +1002,15 @@ namespace OpenSage.Logic
         }
     }
 
-    public sealed class SyncedSpecialPowerTimerCollection : Dictionary<SpecialPowerType, uint>, IPersistableObject
+    public sealed class SyncedSpecialPowerTimerCollection : Dictionary<SpecialPowerType, LogicFrame>, IPersistableObject
     {
         public void Persist(StatePersister persister)
         {
             persister.PersistDictionary(this,
-                static (StatePersister statePersister, ref SpecialPowerType specialPowerType, ref uint availableAtFrame) =>
+                static (StatePersister statePersister, ref SpecialPowerType specialPowerType, ref LogicFrame availableAtFrame) =>
                 {
                     statePersister.PersistEnum(ref specialPowerType);
-                    statePersister.PersistUInt32(ref availableAtFrame);
+                    statePersister.PersistLogicFrame(ref availableAtFrame);
                 }, "Dictionary");
         }
     }

--- a/src/OpenSage.Game/StatePersister.cs
+++ b/src/OpenSage.Game/StatePersister.cs
@@ -500,6 +500,20 @@ namespace OpenSage
             value = new LogicFrame(innerValue);
         }
 
+        public static void PersistLogicFrameSpan(this StatePersister persister, ref LogicFrameSpan value, [CallerArgumentExpression("value")] string name = "")
+        {
+            persister.PersistFieldName(name);
+
+            persister.PersistLogicFrameSpanValue(ref value);
+        }
+
+        public static void PersistLogicFrameSpanValue(this StatePersister persister, ref LogicFrameSpan value)
+        {
+            var innerValue = value.Value;
+            persister.PersistUInt32Value(ref innerValue);
+            value = new LogicFrameSpan(innerValue);
+        }
+
         public static void PersistMatrix4x3(this StatePersister persister, ref Matrix4x3 value, bool readVersion = true, [CallerArgumentExpression("value")] string name = "")
         {
             persister.BeginObject(name);


### PR DESCRIPTION
I've touched quite a few modules recently, and yet only even more recently discovered we had methods for parsing time as `LogicFrameSpan`s, and imo it makes a lot more sense to do things that way. This updates most of those modules to operate with `LogicFrameSpan`s instead.

Disclaimer - I haven't gone through and tested every module to verify it works. A quick smoke test of repairing and healing seems to indicate it works though.