### PR TITLE
Make env var paths take precedence over registry paths

### DIFF
--- a/src/OpenSage.Game/Data/InstallationLocator.cs
+++ b/src/OpenSage.Game/Data/InstallationLocator.cs
@@ -85,7 +85,7 @@ namespace OpenSage.Data
                 return new GameInstallation[]{};
             }
 
-            var installations = new GameInstallation[]{new GameInstallation(game, path)};
+            var installations = new GameInstallation[]{new GameInstallation(game, path, game.BaseGame != null ? FindInstallations(game.BaseGame).First() : null )};
 
             return installations;
         }
@@ -136,12 +136,12 @@ namespace OpenSage.Data
     {
         public static IEnumerable<IInstallationLocator> GetAllForPlatform()
         {
+            yield return new EnvironmentInstallationLocator();
+
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             {
                 yield return new RegistryInstallationLocator();
             }
-
-            yield return new EnvironmentInstallationLocator();
         }
 
         public static IEnumerable<GameInstallation> FindAllInstallations(IGameDefinition game)


### PR DESCRIPTION
I was playing around with getting zero hour sav parsing to work, and was encountering issues that made it clear OpenSAGE wasn't respecting the environment variable paths for the game installs I had set. I dug into this, and it looks like we prioritized registry key installs over environment variable installs. To me, this seems backwards - if the environment variables are set, they should be considered an override of the registry paths. This moves the environment variable paths up to be considered before the registry key paths. It also fixes the base game not being loaded when using an environment variable path.