### PR TITLE
Fix W3dModelDraw not disposing its particle systems correctly

### DIFF
--- a/src/OpenSage.Game/Client/Drawable.cs
+++ b/src/OpenSage.Game/Client/Drawable.cs
@@ -20,6 +20,8 @@ namespace OpenSage.Client
             module.Tag = tag;
             _drawModules.Add(module);
             _tagToModuleLookup.Add(tag, module);
+
+            AddDisposable(module);
         }
 
         private void AddClientUpdateModule(string tag, ClientUpdateModule module)
@@ -367,11 +369,6 @@ namespace OpenSage.Client
                 _shownSubObjects[subObject] = true;
             }
             _hiddenSubObjects.Remove(subObject);
-        }
-
-        public new void Dispose()
-        {
-            Destroy();
         }
 
         internal void Destroy()

--- a/src/OpenSage.Game/Client/Drawable.cs
+++ b/src/OpenSage.Game/Client/Drawable.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -367,6 +367,11 @@ namespace OpenSage.Client
                 _shownSubObjects[subObject] = true;
             }
             _hiddenSubObjects.Remove(subObject);
+        }
+
+        public new void Dispose()
+        {
+            Destroy();
         }
 
         internal void Destroy()

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -366,6 +366,11 @@ namespace OpenSage.Logic.Object
             _activeModelDrawConditionState?.Model?.DrawInspector();
         }
 
+        public override void Dispose()
+        {
+            _activeModelDrawConditionState?.Dispose();
+        }
+
         internal override void Load(StatePersister reader)
         {
             reader.PersistVersion(2);
@@ -428,6 +433,11 @@ namespace OpenSage.Logic.Object
         }
 
         public bool StillActive() => Model.AnimationInstances.Any(x => x.IsPlaying);
+
+        public new void Dispose()
+        {
+            Deactivate();
+        }
 
         public void Deactivate()
         {

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -366,11 +366,6 @@ namespace OpenSage.Logic.Object
             _activeModelDrawConditionState?.Model?.DrawInspector();
         }
 
-        public override void Dispose()
-        {
-            _activeModelDrawConditionState?.Dispose();
-        }
-
         internal override void Load(StatePersister reader)
         {
             reader.PersistVersion(2);
@@ -430,14 +425,11 @@ namespace OpenSage.Logic.Object
 
             _particleSystems = particleSystems;
             _context = context;
+
+            AddDisposeAction(() => Deactivate());
         }
 
         public bool StillActive() => Model.AnimationInstances.Any(x => x.IsPlaying);
-
-        public new void Dispose()
-        {
-            Deactivate();
-        }
 
         public void Deactivate()
         {

--- a/src/OpenSage.Game/ModuleBase.cs
+++ b/src/OpenSage.Game/ModuleBase.cs
@@ -15,5 +15,7 @@
         }
 
         internal virtual void DrawInspector() { }
+
+        public virtual void Dispose() { }
     }
 }

--- a/src/OpenSage.Game/ModuleBase.cs
+++ b/src/OpenSage.Game/ModuleBase.cs
@@ -15,7 +15,5 @@
         }
 
         internal virtual void DrawInspector() { }
-
-        public virtual void Dispose() { }
     }
 }


### PR DESCRIPTION
Particle systems now no longer remain after the DrawModule (or Drawable) gets disposed

closes #686