### PR TITLE
Fixed MappedImageUtility::CreateTexture to handle block compression properly

### DIFF
--- a/src/OpenSage.Game/Data/Utilities/Extensions/PixelFormatExtensions.cs
+++ b/src/OpenSage.Game/Data/Utilities/Extensions/PixelFormatExtensions.cs
@@ -1,0 +1,39 @@
+﻿using Veldrid;
+
+namespace OpenSage.Data.Utilities.Extensions
+{
+    internal static class PixelFormatExtensions
+    {
+        public static bool IsBlockCompressed(this PixelFormat format)
+        {
+            switch (format)
+            {
+                case PixelFormat.BC1_Rgb_UNorm:
+                case PixelFormat.BC1_Rgba_UNorm:
+                case PixelFormat.BC1_Rgba_UNorm_SRgb:
+                case PixelFormat.BC1_Rgb_UNorm_SRgb:
+                case PixelFormat.BC2_UNorm:
+                case PixelFormat.BC2_UNorm_SRgb:
+                case PixelFormat.BC3_UNorm:
+                case PixelFormat.BC3_UNorm_SRgb:
+                case PixelFormat.BC4_UNorm:
+                case PixelFormat.BC4_SNorm:
+                case PixelFormat.BC5_UNorm:
+                case PixelFormat.BC5_SNorm:
+                    return true;
+            }
+
+            return false;
+        }
+
+        public static uint GetBlockDivisor(this PixelFormat format)
+        {
+            if(format.IsBlockCompressed())
+            {
+                return 4;
+            }
+
+            return 1;
+        }
+    }
+}

--- a/src/OpenSage.Game/Gui/Wnd/Images/MappedImageUtility.cs
+++ b/src/OpenSage.Game/Gui/Wnd/Images/MappedImageUtility.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using OpenSage.Content;
+using OpenSage.Data.Utilities.Extensions;
 using OpenSage.Graphics;
 using OpenSage.Mathematics;
 using Veldrid;
@@ -19,8 +20,22 @@ namespace OpenSage.Gui.Wnd.Images
             var graphicsDevice = loadContext.GraphicsDevice;
 
             var src = mappedImage.Coords;
+
+            var left = (uint)src.Left;
+            var top = (uint)src.Top;    
             var width = (uint) src.Width;
             var height = (uint) src.Height;
+
+            var format = mappedImage.Texture.Value.Texture.Format;
+            if(format.IsBlockCompressed())
+            {
+                var blockDivisor = format.GetBlockDivisor();
+
+                left = MathUtility.GetClosestDivisible(left, blockDivisor);
+                top = MathUtility.GetClosestDivisible(top, blockDivisor);
+                width = MathUtility.GetClosestDivisible(width, blockDivisor);
+                height = MathUtility.GetClosestDivisible(height, blockDivisor);
+            }
 
             var imageTexture = graphicsDevice.ResourceFactory.CreateTexture(
                 TextureDescription.Texture2D(
@@ -28,7 +43,7 @@ namespace OpenSage.Gui.Wnd.Images
                     height,
                     1,
                     1,
-                    PixelFormat.R8_G8_B8_A8_UNorm,
+                    format,
                     TextureUsage.Sampled));
 
             imageTexture.Name = "WndImage";
@@ -38,7 +53,7 @@ namespace OpenSage.Gui.Wnd.Images
             commandList.Begin();
 
             commandList.CopyTexture(
-                mappedImage.Texture.Value, (uint) src.Left, (uint) src.Top, 0, 0, 0,    // Source
+                mappedImage.Texture.Value, left, top, 0, 0, 0,    // Source
                 imageTexture, 0, 0, 0, 0, 0, width, height, 1, 1);                      // Destination
 
             commandList.End();

--- a/src/OpenSage.Mathematics/MathUtility.cs
+++ b/src/OpenSage.Mathematics/MathUtility.cs
@@ -69,5 +69,16 @@ namespace OpenSage.Mathematics
 
             return value;
         }
+
+        public static uint GetClosestDivisible(uint value, uint divisor)
+        {
+            var remainder = value % divisor;
+            if(remainder >= divisor / 2)
+            {
+                return value + (divisor - remainder);
+            }
+
+            return value - remainder;
+        }
     }
 }


### PR DESCRIPTION
closes #907 
![image](https://github.com/OpenSAGE/OpenSAGE/assets/147560985/37f8d641-e4ca-4269-adb6-f0794aa14c8d)
