### PR TITLE
Deselect previous units when non-additively selecting new unit

### DIFF
--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -183,14 +183,12 @@ namespace OpenSage.Logic
 
         internal void SelectUnits(ICollection<GameObject> units, bool additive = false)
         {
-            if (additive)
+            if (!additive)
             {
-                _selectedUnits.UnionWith(units);
+                DeselectUnits();
             }
-            else
-            {
-                _selectedUnits = units.ToSet();
-            }
+
+            _selectedUnits.UnionWith(units);
 
             foreach (var unit in units)
             {


### PR DESCRIPTION
Fixes #912

### Before (#912)
![335409247-1d32b891-1c5b-4c09-80e0-6ed3c33bb0f5](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/f6688e4a-d5a1-4b89-a2ce-9a0253471bbe)

### After
![OpenSage Launcher_1NmS2HHpVW](https://github.com/OpenSAGE/OpenSAGE/assets/30303272/7bbbe2ea-3d20-44e9-9dc7-2661ed6dc0d2)
