### PR TITLE
Replace Quadtree with more accurate implementation

### DIFF
--- a/src/OpenSage.Benchmarks.DataStructures/BenchQuadtreeItem.cs
+++ b/src/OpenSage.Benchmarks.DataStructures/BenchQuadtreeItem.cs
@@ -27,11 +27,10 @@ namespace OpenSage.Benchmarks.DataStructures
 
         public static BenchQuadtreeItem Generate(int id, RectangleF bounds, SizeF maxSize, Random random)
         {
-            var x = (float) random.NextDouble() * bounds.Width - bounds.Left;
-            var y = (float) random.NextDouble() * bounds.Height - bounds.Top;
-
-            var width = MathF.Min(bounds.Right - x, (float) (random.NextDouble() * maxSize.Width));
-            var height = MathF.Min(bounds.Bottom - y, (float) (random.NextDouble() * maxSize.Height));
+            var x = (float)(bounds.X + random.NextDouble() * bounds.Width);
+            var y = (float)(bounds.Y + random.NextDouble() * bounds.Height);
+            var width = (float)(random.NextDouble() * Math.Min(bounds.Width - x, maxSize.Width));
+            var height = (float)(random.NextDouble() * Math.Min(bounds.Height - y, maxSize.Height));
 
             return new BenchQuadtreeItem(id, new RectangleF(x, y, width, height));
         }

--- a/src/OpenSage.Game.Tests/DataStructures/QuadtreeTests.cs
+++ b/src/OpenSage.Game.Tests/DataStructures/QuadtreeTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using OpenSage.DataStructures;
@@ -29,9 +30,30 @@ namespace OpenSage.Tests.DataStructures
                 Colliders = new List<Collider> { collider };
             }
 
+            // implementation copied from GameObject
             public bool CollidesWith(ICollidable other, bool twoDimensional)
             {
-                throw new System.NotImplementedException();
+                if (RoughCollider == null || other.RoughCollider == null)
+                {
+                    return false;
+                }
+
+                if (!RoughCollider.Intersects(other.RoughCollider, twoDimensional))
+                {
+                    return false;
+                }
+
+                foreach (var collider in Colliders)
+                {
+                    foreach (var otherCollider in other.Colliders)
+                    {
+                        if (collider.Intersects(otherCollider, twoDimensional))
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
             }
         }
 
@@ -134,6 +156,294 @@ namespace OpenSage.Tests.DataStructures
             quadtree.Remove(notInsertedItem);
 
             Assert.Equal(new[] {item}, quadtree.FindIntersecting(quadtree.Bounds));
+        }
+
+        #region Searcher
+
+        [Fact]
+        public void SearcherDoesNotIntersectItself()
+        {
+            var quadtree = new Quadtree<MockQuadtreeItem>(new RectangleF(0, 0, 100, 100));
+
+            var item = new MockQuadtreeItem(1, new RectangleF(60, 60, 2, 2));
+
+            quadtree.Insert(item);
+
+            Assert.Empty(quadtree.FindIntersecting(item));
+        }
+
+        [Fact]
+        public void SearcherDoesNotIntersectOthersNearby()
+        {
+            var quadtree = new Quadtree<MockQuadtreeItem>(new RectangleF(0, 0, 100, 100));
+
+            var item = new MockQuadtreeItem(1, new RectangleF(60, 60, 2, 2));
+
+            quadtree.Insert(item);
+
+            var item2 = new MockQuadtreeItem(2, new RectangleF(60, 57, 2, 2));
+
+            quadtree.Insert(item2);
+
+            Assert.Empty(quadtree.FindIntersecting(item));
+        }
+
+        [Fact]
+        public void SearcherIntersectsOthers()
+        {
+            var quadtree = new Quadtree<MockQuadtreeItem>(new RectangleF(0, 0, 100, 100));
+
+            var item = new MockQuadtreeItem(1, new RectangleF(60, 60, 2, 2));
+
+            quadtree.Insert(item);
+
+            var item2 = new MockQuadtreeItem(2, new RectangleF(60, 59, 2, 2));
+
+            quadtree.Insert(item2);
+
+            Assert.Equal(new[] { item2 }, quadtree.FindIntersecting(item));
+        }
+
+        [Fact]
+        public void SearcherTouchesOthersEdgeNoIntersection()
+        {
+            var quadtree = new Quadtree<MockQuadtreeItem>(new RectangleF(0, 0, 100, 100));
+
+            var item = new MockQuadtreeItem(1, new RectangleF(60, 60, 2, 2));
+
+            quadtree.Insert(item);
+
+            var item2 = new MockQuadtreeItem(2, new RectangleF(60, 58, 2, 2));
+
+            quadtree.Insert(item2);
+
+            Assert.Empty(quadtree.FindIntersecting(item));
+        }
+
+        [Fact]
+        public void SearcherTouchesOthersCornerNoIntersection()
+        {
+            var quadtree = new Quadtree<MockQuadtreeItem>(new RectangleF(0, 0, 100, 100));
+
+            var item = new MockQuadtreeItem(1, new RectangleF(60, 60, 2, 2));
+
+            quadtree.Insert(item);
+
+            var item2 = new MockQuadtreeItem(2, new RectangleF(58, 58, 2, 2));
+
+            quadtree.Insert(item2);
+
+            Assert.Empty(quadtree.FindIntersecting(item));
+        }
+
+        [Fact]
+        public void SearcherContainsOthers()
+        {
+            var quadtree = new Quadtree<MockQuadtreeItem>(new RectangleF(0, 0, 100, 100));
+
+            var item = new MockQuadtreeItem(1, new RectangleF(59, 59, 3, 3));
+
+            quadtree.Insert(item);
+
+            var item2 = new MockQuadtreeItem(2, new RectangleF(60, 60, 1, 1));
+
+            quadtree.Insert(item2);
+
+            Assert.Equal(new[] { item2 }, quadtree.FindIntersecting(item));
+        }
+
+        [Fact]
+        public void SearcherIsContainedByOthers()
+        {
+            var quadtree = new Quadtree<MockQuadtreeItem>(new RectangleF(0, 0, 100, 100));
+
+            var item = new MockQuadtreeItem(1, new RectangleF(60, 60, 1, 1));
+
+            quadtree.Insert(item);
+
+            var item2 = new MockQuadtreeItem(2, new RectangleF(59, 59, 3, 3));
+
+            quadtree.Insert(item2);
+
+            Assert.Equal(new[] { item2 }, quadtree.FindIntersecting(item));
+        }
+
+        [Fact]
+        public void SearcherIntersectsOthersOverlappingBoundary()
+        {
+            var quadtree = new Quadtree<MockQuadtreeItem>(new RectangleF(0, 0, 10, 10));
+
+            var item = new MockQuadtreeItem(1, new RectangleF(0, 0, 1, 1));
+            var item2 = new MockQuadtreeItem(1, new RectangleF(4, 0, 2, 2));
+            var item3 = new MockQuadtreeItem(1, new RectangleF(3, 0, 2, 2));
+            var item4 = new MockQuadtreeItem(1, new RectangleF(5, 0, 2, 2));
+
+            quadtree.Insert(item);
+            quadtree.Insert(item2);
+            quadtree.Insert(item3);
+            quadtree.Insert(item4);
+
+            Assert.Equal(new[] { item2 }, quadtree.FindIntersecting(item3));
+            Assert.Equal(new[] { item2 }, quadtree.FindIntersecting(item4));
+        }
+
+        #endregion
+
+        #region Bounding Box
+
+        [Fact]
+        public void RectangleDoesNotIntersectOthersNearby()
+        {
+            var quadtree = new Quadtree<MockQuadtreeItem>(new RectangleF(0, 0, 100, 100));
+
+            var item = new MockQuadtreeItem(1, new RectangleF(60, 60, 2, 2));
+
+            quadtree.Insert(item);
+
+            Assert.Empty(quadtree.FindIntersecting(new BoxCollider(new RectangleF(60, 57, 2, 2))));
+        }
+
+        [Fact]
+        public void RectangleIntersectsOthers()
+        {
+            var quadtree = new Quadtree<MockQuadtreeItem>(new RectangleF(0, 0, 100, 100));
+
+            var item = new MockQuadtreeItem(1, new RectangleF(60, 60, 2, 2));
+
+            quadtree.Insert(item);
+
+            Assert.Equal(new[] { item }, quadtree.FindIntersecting(new BoxCollider(new RectangleF(60, 59, 2, 2))));
+        }
+
+        [Fact]
+        public void RectangleTouchesOthersEdgeNoIntersection()
+        {
+            var quadtree = new Quadtree<MockQuadtreeItem>(new RectangleF(0, 0, 100, 100));
+
+            var item = new MockQuadtreeItem(1, new RectangleF(60, 60, 2, 2));
+
+            quadtree.Insert(item);
+
+            Assert.Empty(quadtree.FindIntersecting(new BoxCollider(new RectangleF(60, 58, 2, 2))));
+        }
+
+        [Fact]
+        public void RectangleTouchesOthersCornerNoIntersection()
+        {
+            var quadtree = new Quadtree<MockQuadtreeItem>(new RectangleF(0, 0, 100, 100));
+
+            var item = new MockQuadtreeItem(1, new RectangleF(60, 60, 2, 2));
+
+            quadtree.Insert(item);
+
+            Assert.Empty(quadtree.FindIntersecting(new BoxCollider(new RectangleF(58, 58, 2, 2))));
+        }
+
+        [Fact]
+        public void RectangleContainsOthers()
+        {
+            var quadtree = new Quadtree<MockQuadtreeItem>(new RectangleF(0, 0, 100, 100));
+
+            var item = new MockQuadtreeItem(1, new RectangleF(60, 60, 1, 1));
+
+            quadtree.Insert(item);
+
+            Assert.Equal(new[] { item }, quadtree.FindIntersecting(new BoxCollider(new RectangleF(59, 59, 3, 3))));
+        }
+
+        [Fact]
+        public void RectangleIsContainedByOthers()
+        {
+            var quadtree = new Quadtree<MockQuadtreeItem>(new RectangleF(0, 0, 100, 100));
+
+            var item = new MockQuadtreeItem(1, new RectangleF(59, 59, 3, 3));
+
+            quadtree.Insert(item);
+
+            Assert.Equal(new[] { item }, quadtree.FindIntersecting(new BoxCollider(new RectangleF(60, 60, 1, 1))));
+        }
+
+        [Fact]
+        public void RectangleIntersectsOthersOverlappingBoundary()
+        {
+            var quadtree = new Quadtree<MockQuadtreeItem>(new RectangleF(0, 0, 10, 10));
+
+            var item = new MockQuadtreeItem(1, new RectangleF(0, 0, 1, 1));
+            var item2 = new MockQuadtreeItem(1, new RectangleF(0, 0, 1, 1));
+
+            quadtree.Insert(item);
+            quadtree.Insert(item2);
+
+            var item3 = new MockQuadtreeItem(1, new RectangleF(4, 0, 2, 2));
+            quadtree.Insert(item3);
+
+            Assert.Equal(new[] { item3 }, quadtree.FindIntersecting(new BoxCollider(new RectangleF(5, 0, 2, 2))));
+            Assert.Equal(new[] { item3 }, quadtree.FindIntersecting(new BoxCollider(new RectangleF(3, 0, 2, 2))));
+        }
+
+        #endregion
+
+        // This tests a large number of items against the "dumb" way of checking for collisions to ensure the quadtree implementation is correct.
+        [Fact]
+        public void FuzzFindIntersecting()
+        {
+            const int itemsToGenerate = 1000;
+            const float minX = 0f;
+            const float minY = 0f;
+            const float maxX = 200f;
+            const float maxY = 150f;
+            const int seed = 42; // fix seed to fuzz results are consistent
+
+            var r = new Random(seed);
+
+            var quadtree = new Quadtree<MockQuadtreeItem>(new RectangleF(minX, minY, maxX, maxY));
+
+            var items = new List<MockQuadtreeItem>();
+
+            for (var i = 0; i < itemsToGenerate; i++)
+            {
+                var iMinX = minX + r.NextDouble() * (maxX - minX);
+                var iMinY = minY + r.NextDouble() * (maxY - minY);
+                var width = r.NextDouble() * Math.Min(maxX - iMinX, maxX / 10);
+                var height = r.NextDouble() * Math.Min(maxY - iMinY, maxY / 10);
+
+                var item = new MockQuadtreeItem(i, new RectangleF((float)iMinX, (float)iMinY, (float)width, (float)height));
+                items.Add(item);
+                Assert.True(quadtree.Insert(item));
+            }
+
+            var collisions = new Dictionary<int, HashSet<int>>();
+
+            // build a manual register of intersecting items to test the quadtree against
+            foreach (var item1 in items)
+            {
+                if (!collisions.ContainsKey(item1.Id))
+                {
+                    collisions[item1.Id] = [];
+                }
+
+                foreach (var item2 in items.Where(item2 => item1.RoughCollider.Intersects(item2.RoughCollider)))
+                {
+                    if (item1.Id == item2.Id)
+                    {
+                        continue;
+                    }
+
+                    if (!collisions.ContainsKey(item2.Id))
+                    {
+                        collisions[item2.Id] = [];
+                    }
+
+                    collisions[item1.Id].Add(item2.Id);
+                    collisions[item2.Id].Add(item1.Id);
+                }
+            }
+
+            foreach (var i in items)
+            {
+                var results = quadtree.FindIntersecting(i).Select(item => item.Id).ToHashSet();
+                Assert.Equal(collisions[i.Id].Count, results.Intersect(collisions[i.Id]).Count());
+            }
         }
     }
 }

--- a/src/OpenSage.Game/DataStructures/ICollidable.cs
+++ b/src/OpenSage.Game/DataStructures/ICollidable.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Numerics;
+using OpenSage.Logic.Object;
+
+namespace OpenSage.DataStructures;
+
+public interface ICollidable
+{
+    Collider RoughCollider { get; }
+    List<Collider> Colliders { get; }
+    Vector3 Translation { get; }
+
+    bool CollidesWith(ICollidable other, bool twoDimensional);
+}

--- a/src/OpenSage.Game/DataStructures/IQuadtree.cs
+++ b/src/OpenSage.Game/DataStructures/IQuadtree.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using OpenSage.Logic.Object;
+using OpenSage.Mathematics;
+
+namespace OpenSage.DataStructures;
+
+public interface IQuadtree<T> where T : class, ICollidable
+{
+    IEnumerable<T> FindNearby(T obj, Transform transform, float radius);
+    IEnumerable<T> FindIntersecting(in RectangleF bounds);
+    IEnumerable<T> FindIntersecting(T searcher);
+    IEnumerable<T> FindIntersecting(in Collider collider, T searcher = null);
+    bool Insert(in T item);
+    bool Remove(in T item);
+    bool Update(in T item);
+}

--- a/src/OpenSage.Game/DataStructures/Quadtree.cs
+++ b/src/OpenSage.Game/DataStructures/Quadtree.cs
@@ -1,266 +1,60 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using OpenSage.Graphics.Cameras;
-using OpenSage.Gui;
 using OpenSage.Logic.Object;
 using OpenSage.Mathematics;
 
-namespace OpenSage.DataStructures
+namespace OpenSage.DataStructures;
+
+public sealed class Quadtree<T> : IQuadtree<T> where T : class, ICollidable
 {
-    public sealed class Quadtree<T> where T : class, ICollidable
+    public readonly RectangleF Bounds;
+
+    private readonly QuadtreeNode<T> _rootNode;
+
+    public Quadtree(RectangleF bounds) : this(bounds, bounds, 5, 1.15f, 16)
     {
-        private const int MaxDepth = 8;
-        private const int MaxItemsPerLeaf = 2;
-
-        public readonly RectangleF Bounds;
-
-        // If this is a leaf, this array is null.
-        // If this a tree node, this array is initialized
-        private Quadtree<T>[] _children;
-
-        private HashSet<T> _items = new HashSet<T>();
-
-        private readonly int _depth;
-
-        private bool IsLeaf => _children == null;
-        private bool ReachedItemLimit => _items.Count >= MaxItemsPerLeaf;
-        private bool ReachedDepthLimit => _depth >= MaxDepth;
-        private bool IsEmpty => _children == null && _items.Count == 0;
-
-        public Quadtree(RectangleF bounds)
-        {
-            Bounds = bounds;
-            _depth = 0;
-        }
-
-        private Quadtree(in RectangleF parentBounds, Quad quad, int depth)
-        {
-            var halfWidth = parentBounds.Width / 2.0f;
-            var halfHeight = parentBounds.Height / 2.0f;
-
-            var position = parentBounds.Position;
-
-            // position this 'child'-quadtree according to its Quad position
-            switch (quad)
-            {
-                case Quad.LowerLeft: // our lower left corner aligns with the parents lower left corner so nothing to do
-                    break;
-                case Quad.LowerRight: 
-                    position.X += halfWidth;
-                    break;
-                case Quad.UpperLeft:
-                    position.Y += halfHeight;
-                    break;
-                case Quad.UpperRight:
-                    position.X += halfWidth;
-                    position.Y += halfHeight;
-                    break;
-            }
-
-            Bounds = new RectangleF(position, halfWidth, halfHeight);
-            _depth = depth;
-        }
-
-        public IEnumerable<T> FindNearby(T obj, Transform transform, float radius) => FindIntersectingInternal(new SphereCollider(transform, radius), obj, twoDimensional: true, false);
-
-        public IEnumerable<T> FindIntersecting(in RectangleF bounds) => FindIntersecting(new BoxCollider(bounds));
-
-        public IEnumerable<T> FindIntersecting(T searcher)
-        {
-            var result = FindIntersectingInternal(searcher.RoughCollider, searcher);
-            if (searcher.Colliders.Count == 1)
-            {
-                return result;
-            }
-
-            for (var i = 1; i < searcher.Colliders.Count; i++)
-            {
-                var intersections = FindIntersectingInternal(searcher.Colliders[i], searcher);
-                foreach (var intersection in intersections) result.Append(intersection);
-            }
-            return result;
-        }
-
-        public IEnumerable<T> FindIntersecting(in Collider collider, T searcher = null)
-        {
-            return !collider.Intersects(Bounds) ? Enumerable.Empty<T>() : FindIntersectingInternal(collider, searcher);
-        }
-
-        private IEnumerable<T> FindIntersectingInternal(Collider collider, T searcher, bool twoDimensional = false, bool hasToCollideWithSearcher = true)
-        {
-            if (!IsLeaf)
-            {
-                foreach (var subtree in _children)
-                {
-                    if (subtree.IsEmpty)
-                    {
-                        continue;
-                    }
-
-                    var containment = subtree.Bounds.Intersect(collider.AxisAlignedBoundingArea);
-
-                    if (containment == ContainmentType.Disjoint)
-                    {
-                        continue;
-                    }
-
-                    foreach (var item in subtree.FindIntersectingInternal(collider, searcher, twoDimensional, hasToCollideWithSearcher))
-                    {
-                        yield return item;
-                    }
-
-                    // If the rect is entirely contained in the subtree, we don't need to check other subtrees.
-                    if (containment == ContainmentType.Contains)
-                    {
-                        yield break;
-                    }
-                }
-            }
-
-            foreach (var item in _items)
-            {
-                if (!item.Equals(searcher))
-                {
-                    if (searcher != null && hasToCollideWithSearcher && !searcher.CollidesWith(item, twoDimensional))
-                    {
-                        continue;
-                    }
-                    yield return item;
-                }
-            }
-        }
-
-        private void Subdivide()
-        {
-            var depth = _depth + 1;
-            _children = new []
-            {
-                new Quadtree<T>(Bounds, Quad.UpperLeft, depth),
-                new Quadtree<T>(Bounds, Quad.UpperRight, depth),
-                new Quadtree<T>(Bounds, Quad.LowerLeft, depth),
-                new Quadtree<T>(Bounds, Quad.LowerRight, depth)
-            };
-
-            var oldItems = _items;
-            _items = new HashSet<T>();
-
-            foreach (var oldItem in oldItems)
-            {
-                Insert(oldItem);
-            }
-        }
-
-        public void Insert(in T item)
-        {
-            // 1. If this is a leaf, either insert it or subdivide.
-            if (IsLeaf)
-            {
-                // If we've reached the limit and can subdivide, do so.
-                if (ReachedItemLimit && !ReachedDepthLimit)
-                {
-                    Subdivide();
-                    // Control flow continues to the for loop below.
-                }
-                else
-                {
-                    _items.Add(item);
-                    return;
-                }
-            }
-
-            // 2. Check if the item fully fits into any of the children.
-            foreach (var subTree in _children)
-            {
-                var containment = subTree.Bounds.Intersect(item.RoughCollider.AxisAlignedBoundingArea);
-
-                switch (containment)
-                {
-                    case ContainmentType.Disjoint:
-                        continue;
-
-                    case ContainmentType.Contains:
-                        subTree.Insert(item);
-                        return;
-
-                    // 3. Item fits into multiple subtrees.
-                    // In that case, add it to this node while ignoring the item limit.
-                    case ContainmentType.Intersects:
-                        _items.Add(item);
-                        return;
-
-                    // This should be unreachable.
-                    default:
-                        return;
-                }
-            }
-        }
-
-        public bool Remove(in T item)
-        {
-            if (_children != null)
-            {
-                foreach (var subTree in _children)
-                {
-                    if (subTree.Remove(item))
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return _items.Remove(item);
-        }
-
-        public void Update(in T item)
-        {
-            Remove(item);
-            Insert(item);
-        }
-
-        public void DebugDraw(DrawingContext2D drawingContext, Camera camera)
-        {
-            var strokeColor = new ColorRgbaF(0, 220, 0, 255);
-
-            var ltWorld = new Vector3(Bounds.Position + new Vector2(0, Bounds.Height), 0);
-            var rtWorld = new Vector3(Bounds.Position + new Vector2(Bounds.Width, Bounds.Height), 0);
-            var rbWorld = new Vector3(Bounds.Position + new Vector2(Bounds.Width, 0), 0);
-            var lbWorld = new Vector3(Bounds.Position, 0);
-
-            var ltScreen = camera.WorldToScreenPoint(ltWorld).Vector2XY();
-            var rtScreen = camera.WorldToScreenPoint(rtWorld).Vector2XY();
-            var rbScreen = camera.WorldToScreenPoint(rbWorld).Vector2XY();
-            var lbScreen = camera.WorldToScreenPoint(lbWorld).Vector2XY();
-
-            drawingContext.DrawLine(new Line2D(ltScreen, lbScreen), 1, strokeColor);
-            drawingContext.DrawLine(new Line2D(lbScreen, rbScreen), 1, strokeColor);
-            drawingContext.DrawLine(new Line2D(rbScreen, rtScreen), 1, strokeColor);
-            drawingContext.DrawLine(new Line2D(rtScreen, ltScreen), 1, strokeColor);
-
-            if (!IsLeaf)
-            {
-                foreach (var child in _children)
-                {
-                    child.DebugDraw(drawingContext, camera);
-                }
-            }
-        }
-
-        internal enum Quad
-        {
-            UpperLeft = 0,
-            UpperRight,
-            LowerLeft,
-            LowerRight,
-        }
     }
 
-    public interface ICollidable
+    private Quadtree(RectangleF bounds, RectangleF maxSize, float minNodeSideLength, float scaleFactor, int maxItemsPerNode)
     {
-        Collider RoughCollider { get; }
-        List<Collider> Colliders { get; }
-        Vector3 Translation { get; }
+        Bounds = bounds;
+        _rootNode = new QuadtreeNode<T>(Bounds, maxSize, minNodeSideLength, scaleFactor, maxItemsPerNode);
+    }
 
-        bool CollidesWith(ICollidable other, bool twoDimensional);
+    public IEnumerable<T> FindNearby(T obj, Transform transform, float radius) => Find(new SphereCollider(transform, radius), obj, true, false);
+
+    public IEnumerable<T> FindIntersecting(in RectangleF bounds) => FindIntersecting(new BoxCollider(bounds));
+
+    public IEnumerable<T> FindIntersecting(T searcher) => Find(searcher.RoughCollider, searcher);
+
+    public IEnumerable<T> FindIntersecting(in Collider collider, T searcher = null) => Find(collider, searcher);
+
+    public IEnumerable<T> Find(in Collider collider, T searcher, bool twoDimensional = false, bool hasToCollideWithSearcher = true)
+    {
+        return !collider.Intersects(Bounds) ? [] : FindIntersectingInternal(collider, searcher, twoDimensional, hasToCollideWithSearcher);
+    }
+
+    // collider is what we use to determine intersections _unless_ hasToCollideWithSearcher is true, in which case searcher is also used
+    // otherwise searcher is just excluded from the results
+    // twoDimensional is passed into CollidesWith calls
+
+    private IEnumerable<T> FindIntersectingInternal(Collider collider, T searcher, bool twoDimensional = false, bool hasToCollideWithSearcher = true)
+    {
+        return _rootNode.Find(collider, searcher, twoDimensional, hasToCollideWithSearcher);
+    }
+
+    public bool Insert(in T item)
+    {
+        return _rootNode.Insert(item);
+    }
+
+    public bool Remove(in T item)
+    {
+        return _rootNode.Remove(item);
+    }
+
+    public bool Update(in T item)
+    {
+        Remove(item);
+        return Insert(item);
     }
 }

--- a/src/OpenSage.Game/DataStructures/QuadtreeNode.cs
+++ b/src/OpenSage.Game/DataStructures/QuadtreeNode.cs
@@ -1,0 +1,196 @@
+﻿using System.Collections.Generic;
+using System.Numerics;
+using OpenSage.Logic.Object;
+using OpenSage.Mathematics;
+
+namespace OpenSage.DataStructures;
+
+public class QuadtreeNode<T> where T : class, ICollidable
+{
+    private readonly RectangleF _box;
+    private readonly int _maxItemsPerNode;
+    private readonly HashSet<T> _data;
+    private readonly QuadtreeNode<T>[] _children = new QuadtreeNode<T>[4];
+    private bool _hasChildren;
+    private readonly RectangleF _originalSize;
+    private readonly float _overlapFactor;
+    private readonly float _minNodeSideLength;
+    private readonly Vector2 _center;
+
+    private bool IsMinSize => _originalSize.Width * _overlapFactor / 2 < _minNodeSideLength || _originalSize.Height * _overlapFactor / 2 < _minNodeSideLength;
+
+    public QuadtreeNode(in RectangleF bounds, in RectangleF originalSize, float minNodeSideLength, float scaleFactor, int maxItemsPerNode)
+    {
+        _box = bounds;
+        _overlapFactor = scaleFactor;
+        _originalSize = originalSize;
+        _minNodeSideLength = minNodeSideLength;
+        _maxItemsPerNode = maxItemsPerNode;
+        _center = new Vector2(bounds.X + bounds.Width / 2, bounds.Y + bounds.Height / 2);
+        _data = new HashSet<T>(maxItemsPerNode);
+    }
+
+    public IEnumerable<T> Find(Collider collider, T? searcher, bool twoDimensional, bool hasToCollideWithSearcher)
+    {
+        if (_hasChildren)
+        {
+            foreach (var child in _children)
+            {
+                if (!child.Touches(collider))
+                {
+                    continue;
+                }
+
+                foreach (var subChild in child.Find(collider, searcher, twoDimensional, hasToCollideWithSearcher))
+                {
+                    if (CollidesForReal(subChild, collider, searcher, twoDimensional, hasToCollideWithSearcher))
+                    {
+                        yield return subChild;
+                    }
+                }
+            }
+        }
+
+        foreach (var data in _data)
+        {
+            if (!collider.Intersects(data.RoughCollider.AxisAlignedBoundingArea))
+            {
+                continue;
+            }
+
+            if (CollidesForReal(data, collider, searcher, twoDimensional, hasToCollideWithSearcher))
+            {
+                yield return data;
+            }
+        }
+    }
+
+    private static bool CollidesForReal(T item, Collider collider, T? searcher, bool twoDimensional, bool hasToCollideWithSearcher)
+    {
+        if (searcher != null)
+        {
+            if (item.Equals(searcher))
+            {
+                return false;
+            }
+
+            if (hasToCollideWithSearcher)
+            {
+                if (searcher.CollidesWith(item, twoDimensional))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        if (collider.Intersects(item.RoughCollider))
+        {
+            foreach (var c in item.Colliders)
+            {
+                if (collider.Intersects(c, twoDimensional))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public bool Insert(in T item)
+    {
+        if (!FullyContains(item.RoughCollider.AxisAlignedBoundingArea))
+        {
+            return false;
+        }
+
+        if (_data.Count >= _maxItemsPerNode && !IsMinSize)
+        {
+            if (!_hasChildren)
+            {
+                GenerateChildren();
+            }
+
+            var bestChild = BestFitChild(item);
+            if (_children[bestChild].Insert(item))
+            {
+                return true;
+            }
+        }
+
+        _data.Add(item);
+        return true;
+    }
+
+    public bool Remove(in T item)
+    {
+        if (_hasChildren)
+        {
+            var bestChild = BestFitChild(item);
+            if (_children[bestChild].Remove(item))
+            {
+                return true;
+            }
+        }
+
+        return _data.Remove(item);
+    }
+
+    /// <summary>
+    /// Find which child node this object would be most likely to fit in.
+    /// </summary>
+    private int BestFitChild(in T item)
+    {
+        var aabb = item.RoughCollider.AxisAlignedBoundingArea;
+
+        var total = 0;
+
+        // bottom left is 0
+        // bottom right is 1
+        // top left is 2
+        // top right is 3
+
+        if (aabb.X + aabb.Width / 2 >= _center.X)
+        {
+            total = 1;
+        }
+
+        if (aabb.Y + aabb.Height / 2 >= _center.Y)
+        {
+            total += 2;
+        }
+
+        return total;
+    }
+
+    private bool FullyContains(in RectangleF box) => _box.Contains(box);
+
+    private bool Touches(in Collider box) => box.Intersects(_box);
+
+    private void GenerateChildren()
+    {
+        var halfSize =  RectangleF.Scale(_originalSize, 0.5f);
+
+        var halfWidth = halfSize.Width;
+        var halfHeight = halfSize.Height;
+
+        // bottom left is 0
+        // bottom right is 1
+        // top left is 2
+        // top right is 3
+
+        var bottomLeft = RectangleF.Scale(new RectangleF(_box.X, _box.Y, halfWidth, halfHeight), _overlapFactor);
+        var bottomRight = RectangleF.Scale(new RectangleF(_center.X, _box.Y, halfWidth, halfHeight), _overlapFactor);
+        var topLeft = RectangleF.Scale(new RectangleF(_box.X, _center.Y, halfWidth, halfHeight), _overlapFactor);
+        var topRight = RectangleF.Scale(new RectangleF(_center.X, _center.Y, halfWidth, halfHeight), _overlapFactor);
+
+        _children[0] = new QuadtreeNode<T>(bottomLeft, halfSize, _minNodeSideLength, _overlapFactor, _maxItemsPerNode);
+        _children[1] = new QuadtreeNode<T>(bottomRight, halfSize, _minNodeSideLength, _overlapFactor, _maxItemsPerNode);
+        _children[2] = new QuadtreeNode<T>(topLeft, halfSize, _minNodeSideLength, _overlapFactor, _maxItemsPerNode);
+        _children[3] = new QuadtreeNode<T>(topRight, halfSize, _minNodeSideLength, _overlapFactor, _maxItemsPerNode);
+
+        _hasChildren = true;
+    }
+}

--- a/src/OpenSage.Game/DataStructures/QuadtreeNode.cs
+++ b/src/OpenSage.Game/DataStructures/QuadtreeNode.cs
@@ -43,7 +43,7 @@ public class QuadtreeNode<T> where T : class, ICollidable
 
                 foreach (var subChild in child.Find(collider, searcher, twoDimensional, hasToCollideWithSearcher))
                 {
-                    if (CollidesForReal(subChild, collider, searcher, twoDimensional, hasToCollideWithSearcher))
+                    if (CollidesPrecise(subChild, collider, searcher, twoDimensional, hasToCollideWithSearcher))
                     {
                         yield return subChild;
                     }
@@ -58,14 +58,14 @@ public class QuadtreeNode<T> where T : class, ICollidable
                 continue;
             }
 
-            if (CollidesForReal(data, collider, searcher, twoDimensional, hasToCollideWithSearcher))
+            if (CollidesPrecise(data, collider, searcher, twoDimensional, hasToCollideWithSearcher))
             {
                 yield return data;
             }
         }
     }
 
-    private static bool CollidesForReal(T item, Collider collider, T? searcher, bool twoDimensional, bool hasToCollideWithSearcher)
+    private static bool CollidesPrecise(T item, Collider collider, T? searcher, bool twoDimensional, bool hasToCollideWithSearcher)
     {
         if (searcher != null)
         {

--- a/src/OpenSage.Game/GameContext.cs
+++ b/src/OpenSage.Game/GameContext.cs
@@ -37,7 +37,7 @@ namespace OpenSage
 
         // TODO: Make this readonly.
         public GameObjectCollection GameObjects;
-        public readonly Quadtree<GameObject> Quadtree;
+        public readonly IQuadtree<GameObject> Quadtree;
 
         // TODO: This is temporary until Scene3D and GameContext are merged.
         public readonly Scene3D Scene3D;
@@ -50,7 +50,7 @@ namespace OpenSage
             Terrain.Terrain terrain,
             Navigation.Navigation navigation,
             Radar radar,
-            Quadtree<GameObject> quadtree,
+            IQuadtree<GameObject> quadtree,
             Scene3D scene)
         {
             AssetLoadContext = assetLoadContext;

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -54,7 +54,7 @@ namespace OpenSage
 
         public readonly Terrain.Terrain Terrain;
 
-        public readonly Quadtree<GameObject> Quadtree;
+        public readonly IQuadtree<GameObject> Quadtree;
         public bool ShowTerrain
         {
             get => RenderScene.GetRenderBucket("Terrain").Visible;


### PR DESCRIPTION
Supersedes #925 (ported over tests)

## Implementation

After benchmark testing with [Orthogonal Arrays](https://en.wikipedia.org/wiki/Orthogonal_array), the minimum node geometric size and max items per node parameters were tweaked for better performance.

Additionally, an overlap parameter was added. This scales the subgrids by the provided factor, such that each subgrid overlaps its neighbors. This helps prevent hotspots on cell borders from piling up in the parent nodes.

This new implementation persists the existing behavior that two entities whose borders perfectly touch are **not** considered colliding. If that is not the desired behavior we may wish to address that separately.

This also switches to using an interface in the method signatures instead of the class name itself, partially because that made it easier for me to flip back and forth between testing and partially so that if someone else ever wants to burn this quadtree with fire and replace it with their implementation that's even better, it will be easier for them as well :)

## Benchmarks vs previous implementation
### Insert
I would have expected the performance here to be similar, so it's interesting the new quadtree is so much faster.
| Method         | MaxItemSize | InsertedItems | Mean       | Error     | StdDev    | Ratio |
|--------------- |------------ |-------------- |-----------:|----------:|----------:|------:|
| InsertQuadtree | 15          | 5000          | 839.493 us | 8.9584 us | 8.3797 us | 1.000 |
| InsertNewTree   | 15          | 5000          |   3.346 us | 0.0241 us | 0.0226 us | 0.004 |

### Update
I'm not quite sure why the old quadtree updates were so slow. This benchmark also isn't actually recording the performance of a single update, but rather multiple.
| Method         | TotalItems | MovingItems | Mean         | Error      | StdDev     | Ratio |
|--------------- |----------- |------------ |-------------:|-----------:|-----------:|------:|
| UpdateQuadtree | 15000      | 10000       | 3,205.934 ms | 11.2854 ms | 10.0043 ms | 1.000 |
| UpdateNewTree   | 15000      | 10000       |     4.007 ms |  0.0544 ms |  0.0455 ms | 0.001 |

### Query
Here it's no surprise that the new quadtree is slower - many items were missed in the previous implementation, so it's not really an apples-to-apples comparison.
| Method            | ItemCount | ItemSize | AreaSideLength | Mean       | Error    | StdDev  | Ratio | RatioSD |
|------------------ |---------- |--------- |--------------- |-----------:|---------:|--------:|------:|--------:|
| QueryAreaQuadtree | 3000      | 10       | 100            |   406.1 ns |  2.62 ns | 2.05 ns |  1.00 |    0.00 |
| QueryAreaNewTree   | 3000      | 10       | 100            | 1,634.2 ns | 10.37 ns | 9.19 ns |  4.02 |    0.04 |

## In-game comparison
### Old
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbTZnODM5NTlneGltaDN1am92Ympjc3o0cTg5b24yNGNpeGRkZ2MzdiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/qBoyiBiSJgOVw35yFN/giphy.gif)
### New
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYXhhb3F2aGY2aXh3cTZybTB1bDIzOHdqcjR2MmYwdWZvcHl0NWI4ZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/NcgrYoDIDyTpRhtN5i/giphy.gif)