### PR TITLE
Move hacking behavior to state classes

### DIFF
--- a/src/OpenSage.Game/Logic/AI/AIStateMachine.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStateMachine.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Numerics;
 using OpenSage.Logic.AI.AIStates;
+using OpenSage.Logic.Object;
 
 namespace OpenSage.Logic.AI
 {
@@ -13,9 +14,9 @@ namespace OpenSage.Logic.AI
         private uint _stateSomethingId;
         private State _stateSomething;
 
-        public AIStateMachine()
+        public AIStateMachine(GameObject gameObject)
         {
-            AddState(0, new IdleState());
+            AddState(IdleState.Id, new IdleState());
             AddState(1, new MoveTowardsState());
             AddState(2, new FollowWaypointsState(true));
             AddState(3, new FollowWaypointsState(false));
@@ -43,9 +44,9 @@ namespace OpenSage.Logic.AI
             AddState(34, new FaceState(FaceTargetType.FaceWaypoint));
             AddState(37, new ExitContainerState());
             AddState(40, new WanderInPlaceState());
-            AddState(1000, new StartHackingInternetState());
-            AddState(1001, new HackInternetState());
-            AddState(1002, new StopHackingInternetState());
+            AddState(StartHackingInternetState.Id, new StartHackingInternetState(gameObject));
+            AddState(HackInternetState.Id, new HackInternetState(gameObject));
+            AddState(StopHackingInternetState.Id, new StopHackingInternetState(gameObject));
             AddState(1013, new WaitForAirfieldState());
         }
 
@@ -130,7 +131,7 @@ namespace OpenSage.Logic.AI
     {
         public AIState32StateMachine()
         {
-            AddState(0, new IdleState());
+            AddState(IdleState.Id, new IdleState());
         }
 
         public override void Persist(StatePersister reader)

--- a/src/OpenSage.Game/Logic/AI/AIStates/AttackAreaState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/AttackAreaState.cs
@@ -31,7 +31,7 @@
     {
         public AttackAreaStateMachine()
         {
-            AddState(0, new IdleState());
+            AddState(IdleState.Id, new IdleState());
             AddState(10, new AttackState());
         }
 

--- a/src/OpenSage.Game/Logic/AI/AIStates/AttackMoveState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/AttackMoveState.cs
@@ -28,7 +28,7 @@
     {
         public AttackMoveStateMachine()
         {
-            AddState(0, new IdleState());
+            AddState(IdleState.Id, new IdleState());
         }
 
         public override void Persist(StatePersister reader)

--- a/src/OpenSage.Game/Logic/AI/AIStates/HackInternetState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/HackInternetState.cs
@@ -1,16 +1,80 @@
-﻿using OpenSage.Logic.Object;
+﻿using System;
+using System.Numerics;
+using OpenSage.Logic.Object;
+using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.AI.AIStates
 {
     internal sealed class HackInternetState : State
     {
-        public LogicFrameSpan FramesUntilNextHack;
+        public const uint Id = 1001;
+
+        private readonly GameObject _gameObject;
+
+        private LogicFrameSpan _framesUntilNextHack;
+
+        private HackInternetAIUpdateModuleData ModuleData => ((HackInternetAIUpdate)_gameObject.AIUpdate).ModuleData;
+
+        public HackInternetState(GameObject gameObject)
+        {
+            _gameObject = gameObject;
+        }
+
+        public override void OnEnter()
+        {
+            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Unpacking, false);
+            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.FiringA, true);
+            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Packing, false);
+
+            SetFramesUntilNextHack();
+        }
+
+        public override UpdateStateResult Update()
+        {
+            if (_framesUntilNextHack-- == LogicFrameSpan.Zero)
+            {
+                SetFramesUntilNextHack();
+
+                _gameObject.GameContext.AudioSystem.PlayAudioEvent(_gameObject, _gameObject.Definition.UnitSpecificSounds.UnitCashPing?.Value);
+
+                var amount = GetCashGrant();
+
+                _gameObject.Owner.BankAccount.Deposit((uint)amount);
+
+                _gameObject.ActiveCashEvent = new CashEvent(amount, new ColorRgb(0, 255, 0), new Vector3(0, 0, 20));
+
+                _gameObject.GainExperience(ModuleData.XpPerCashUpdate);
+            }
+
+            return UpdateStateResult.Continue();
+        }
+
+        public override void OnExit()
+        {
+            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.FiringA, false);
+        }
+
+        private void SetFramesUntilNextHack()
+        {
+            _framesUntilNextHack = _gameObject.ContainerId != 0
+                ? ModuleData.CashUpdateDelayFast
+                : ModuleData.CashUpdateDelay;
+        }
+
+        private int GetCashGrant() => _gameObject.Rank switch
+        {
+            0 => ModuleData.RegularCashAmount,
+            1 => ModuleData.VeteranCashAmount,
+            2 => ModuleData.EliteCashAmount,
+            3 => ModuleData.HeroicCashAmount,
+            _ => throw new ArgumentOutOfRangeException(nameof(GameObject.Rank)),
+        };
 
         public override void Persist(StatePersister reader)
         {
             reader.PersistVersion(1);
 
-            reader.PersistLogicFrameSpan(ref FramesUntilNextHack);
+            reader.PersistLogicFrameSpan(ref _framesUntilNextHack);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/AI/AIStates/IdleState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/IdleState.cs
@@ -2,6 +2,8 @@
 {
     internal sealed class IdleState : State
     {
+        public const uint Id = 0;
+
         private ushort _unknownShort;
         private bool _unknownBool1;
         private bool _unknownBool2;

--- a/src/OpenSage.Game/Logic/AI/AIStates/StartHackingInternetState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/StartHackingInternetState.cs
@@ -4,13 +4,54 @@ namespace OpenSage.Logic.AI.AIStates
 {
     internal sealed class StartHackingInternetState : State
     {
-        public LogicFrameSpan FramesUntilHackingBegins;
+        public const uint Id = 1000;
+
+        private readonly GameObject _gameObject;
+
+        private LogicFrameSpan _framesUntilHackingBegins;
+
+        public StartHackingInternetState(GameObject gameObject)
+        {
+            _gameObject = gameObject;
+        }
+
+        public override void OnEnter()
+        {
+            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Unpacking, true);
+            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.FiringA, false);
+            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Packing, false);
+
+            _gameObject.GameContext.AudioSystem.PlayAudioEvent(_gameObject, _gameObject.Definition.UnitSpecificSounds.UnitUnpack?.Value);
+
+            var aiUpdate = (HackInternetAIUpdate)_gameObject.AIUpdate;
+
+            var frames = aiUpdate.GetVariableFrames(aiUpdate.ModuleData.UnpackTime);
+
+            _gameObject.Drawable.SetAnimationDuration(frames);
+
+            _framesUntilHackingBegins = frames;
+        }
+
+        public override UpdateStateResult Update()
+        {
+            if (_framesUntilHackingBegins-- == LogicFrameSpan.Zero)
+            {
+                return UpdateStateResult.TransitionToState(HackInternetState.Id);
+            }
+
+            return UpdateStateResult.Continue();
+        }
+
+        public override void OnExit()
+        {
+            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Unpacking, false);
+        }
 
         public override void Persist(StatePersister reader)
         {
             reader.PersistVersion(1);
 
-            reader.PersistLogicFrameSpan(ref FramesUntilHackingBegins);
+            reader.PersistLogicFrameSpan(ref _framesUntilHackingBegins);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/AI/AIStates/StopHackingInternetState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/StopHackingInternetState.cs
@@ -4,13 +4,54 @@ namespace OpenSage.Logic.AI.AIStates
 {
     internal sealed class StopHackingInternetState : State
     {
-        public LogicFrameSpan FramesUntilFinishedPacking;
+        public const uint Id = 1002;
+
+        private readonly GameObject _gameObject;
+
+        private LogicFrameSpan _framesUntilFinishedPacking;
+
+        public StopHackingInternetState(GameObject gameObject)
+        {
+            _gameObject = gameObject;
+        }
+
+        public override void OnEnter()
+        {
+            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Unpacking, false);
+            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.FiringA, false);
+            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Packing, true);
+
+            _gameObject.GameContext.AudioSystem.PlayAudioEvent(_gameObject, _gameObject.Definition.UnitSpecificSounds.UnitPack?.Value);
+
+            var aiUpdate = (HackInternetAIUpdate)_gameObject.AIUpdate;
+
+            var frames = aiUpdate.GetVariableFrames(aiUpdate.ModuleData.PackTime);
+
+            _gameObject.Drawable.SetAnimationDuration(frames);
+
+            _framesUntilFinishedPacking = frames;
+        }
+
+        public override UpdateStateResult Update()
+        {
+            if (_framesUntilFinishedPacking-- == LogicFrameSpan.Zero)
+            {
+                return UpdateStateResult.TransitionToState(IdleState.Id);
+            }
+
+            return UpdateStateResult.Continue();
+        }
+
+        public override void OnExit()
+        {
+            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Packing, false);
+        }
 
         public override void Persist(StatePersister reader)
         {
             reader.PersistVersion(1);
 
-            reader.PersistLogicFrameSpan(ref FramesUntilFinishedPacking);
+            reader.PersistLogicFrameSpan(ref _framesUntilFinishedPacking);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/AI/State.cs
+++ b/src/OpenSage.Game/Logic/AI/State.cs
@@ -2,6 +2,34 @@
 {
     internal abstract class State : IPersistableObject
     {
+        public virtual void OnEnter() { }
+
+        public virtual UpdateStateResult Update() => UpdateStateResult.Continue();
+
+        public virtual void OnExit() { }
+
         public abstract void Persist(StatePersister reader);
+    }
+
+    public readonly struct UpdateStateResult
+    {
+        public static UpdateStateResult Continue() => new(UpdateStateResultType.Continue, null);
+
+        public static UpdateStateResult TransitionToState(uint stateId) => new(UpdateStateResultType.TransitionToState, stateId);
+
+        public readonly UpdateStateResultType Type;
+        public readonly uint? TransitionToStateId;
+
+        private UpdateStateResult(UpdateStateResultType type, uint? transitionToStateId)
+        {
+            Type = type;
+            TransitionToStateId = transitionToStateId;
+        }
+    }
+
+    public enum UpdateStateResultType
+    {
+        Continue,
+        TransitionToState,
     }
 }

--- a/src/OpenSage.Game/Logic/AI/StateMachineBase.cs
+++ b/src/OpenSage.Game/Logic/AI/StateMachineBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Numerics;
+using OpenSage.Logic.Object;
 
 namespace OpenSage.Logic.AI
 {
@@ -19,6 +20,8 @@ namespace OpenSage.Logic.AI
         private Vector3 _unknownPosition;
         private bool _unknownBool1;
         private bool _unknownBool2;
+
+        public readonly GameObject GameObject;
 
         protected StateMachineBase()
         {
@@ -42,7 +45,34 @@ namespace OpenSage.Logic.AI
 
         internal void SetState(uint id)
         {
+            _currentState?.OnExit();
+
             _currentState = GetState(id);
+
+            _currentState.OnEnter();
+        }
+
+        internal void Update()
+        {
+            if (_currentState == null)
+            {
+                return;
+            }
+
+            var updateResult = _currentState.Update();
+
+            switch (updateResult.Type)
+            {
+                case UpdateStateResultType.Continue:
+                    break;
+
+                case UpdateStateResultType.TransitionToState:
+                    SetState(updateResult.TransitionToStateId.Value);
+                    break;
+
+                default:
+                    break;
+            }
         }
 
         public virtual void Persist(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -1477,6 +1477,8 @@ namespace OpenSage.Logic.Object
             reader.PersistUInt32(ref teamId);
             Team = GameContext.Game.TeamFactory.FindTeamById(teamId);
 
+            Owner = Team.Template.Owner;
+
             reader.PersistObjectID(ref CreatedByObjectID);
             reader.PersistUInt32(ref BuiltByObjectID);
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -91,7 +91,7 @@ namespace OpenSage.Logic.Object
 
             TargetPoints = new List<Vector3>();
 
-            StateMachine = new AIStateMachine();
+            StateMachine = new AIStateMachine(gameObject);
 
             _locomotorSet = new LocomotorSet(gameObject);
             _currentLocomotorSetType = (LocomotorSetType)(-1);
@@ -233,6 +233,8 @@ namespace OpenSage.Logic.Object
 
         internal override void Update(BehaviorUpdateContext context)
         {
+            StateMachine.Update();
+
             if (_turretAIUpdate != null)
             {
                 _turretAIUpdate.Update(context, _moduleData.AutoAcquireEnemiesWhenIdle);


### PR DESCRIPTION
As a prerequisite to #879, I wanted to make `State` subclasses contain not just data, but also behavior. 

We've done this already with our [WeaponStateMachine](https://github.com/OpenSAGE/OpenSAGE/blob/master/src/OpenSage.Game/Logic/Object/Weapon/WeaponStates/WeaponStateMachine.cs), and it's pretty standard in any case. See [Super Simple State Machine](https://keithmaggio.wordpress.com/code/supersimplestatemachine/) for another example. 

Having `State` subclasses contain behavior and handle transitions to the next state should provide a nice framework for implementing more of these.