### PR TITLE
Fix Percentages with decimals being parsed incorrectly

### DIFF
--- a/src/OpenSage.Game/Data/Ini/IniParser.cs
+++ b/src/OpenSage.Game/Data/Ini/IniParser.cs
@@ -65,7 +65,7 @@ namespace OpenSage.Data.Ini
                 // https://github.com/OpenSAGE/OpenSAGE/issues/405
                 var localeSpecificFileName = Path.ChangeExtension(entry.FilePath, null) + "9x.ini";
                 var localeSpecificEntry = entry.FileSystem.GetFile(localeSpecificFileName);
-                if(localeSpecificEntry != null) 
+                if(localeSpecificEntry != null)
                 {
                     entry = localeSpecificEntry;
                     iniEncoding = localeSpecificEncoding;
@@ -401,10 +401,10 @@ namespace OpenSage.Data.Ini
 
         private float ScanPercentage(in IniToken token)
         {
-            return token.Text.Contains('.') ? ScanFloat(token) : ScanFloat(token) / 100.0f;
+            return  ScanFloat(token) / 100.0f;
         }
 
-        public Percentage ParsePercentage() => new Percentage(ScanPercentage(GetNextToken(SeparatorsPercent)));
+        public Percentage ParsePercentage() => new(ScanPercentage(GetNextToken()));
 
         private bool ScanBoolean(in IniToken token)
         {
@@ -1118,4 +1118,3 @@ namespace OpenSage.Data.Ini
         void OnParsed();
     }
 }
-


### PR DESCRIPTION
Fixes #825

auto repair on USA structures is now much slower, as expected
![OpenSage Launcher_0dL05ZHL8L](https://github.com/user-attachments/assets/6773a729-4f07-4f8d-9a3b-040e3c4c1e9d)
