### PR TITLE
Update slaved module capabilities

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
@@ -38,11 +38,9 @@ namespace OpenSage.Logic.Object
             var spawnedObject = _gameObject.GameContext.GameLogic.CreateObject(_moduleData.SpawnTemplate.Value, _gameObject.Owner);
             _spawnedUnits.Add(spawnedObject);
 
+            spawnedObject.CreatedByObjectID = _gameObject.ID;
             var slavedUpdate = spawnedObject.FindBehavior<SlavedUpdateModule>();
-            if (slavedUpdate != null)
-            {
-                slavedUpdate.Master = _gameObject;
-            }
+            slavedUpdate?.SetMaster(_gameObject);
 
             if (!TryTransformViaProductionExit(spawnedObject) &&
                 !TryTransformViaOpenContainer(spawnedObject))

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -291,7 +291,7 @@ namespace OpenSage.Logic.Object
 
         public bool IsFullHealth => Health >= MaxHealth;
 
-        public bool IsDead => Health == Fix64.Zero;
+        public bool IsDead => Health <= Fix64.Zero;
 
         public void DoDamage(DamageType damageType, Fix64 amount, DeathType deathType)
         {

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
@@ -25,11 +25,9 @@ namespace OpenSage.Logic.Object
 
                 foreach (var createdObject in createdObjects)
                 {
+                    createdObject.CreatedByObjectID = _gameObject.ID;
                     var slavedUpdateBehaviour = createdObject.FindBehavior<SlavedUpdateModule>();
-                    if (slavedUpdateBehaviour != null)
-                    {
-                        slavedUpdateBehaviour.Master = _gameObject;
-                    }
+                    slavedUpdateBehaviour?.SetMaster(_gameObject);
                 }
             }
         }


### PR DESCRIPTION
UpgradeDie is now properly implemented (though removing applied upgrades isn't yet supported - we'll still have to figure out how we want to tackle that one), and additional parts of SlavedUpdate are now persisted (though the module still needs to be fixed up to be fully compatible with generals saves).

### child death
The upgrade is no longer considered purchased (though is still disabled as it's considered triggered), and the spy drone upgrade is now purchasable.
![OpenSage Launcher_VkZiLPBkmJ](https://github.com/user-attachments/assets/599d2a17-b7a1-4238-8177-5d30c5c1be50)

### parent death
When the parent dies, the child dies too.
![OpenSage Launcher_ttsWQR89jF](https://github.com/user-attachments/assets/68f38969-cbab-459d-9af1-196ae1244f7c)
