### PR TITLE
Fix Neutral house colors

### DIFF
--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -736,7 +736,7 @@ namespace OpenSage.Logic
             }
             else
             {
-                color = new ColorRgb(0, 0, 0);
+                color = new ColorRgb(255, 255, 255); // neutral appears to be white
             }
 
             var result = new Player(index, template, color, game)


### PR DESCRIPTION
Note the house colors on the oil derrick, the cash text, and the radar spots on the minimap change in the before/after.

## Before
![image](https://github.com/user-attachments/assets/1c5272d0-4f06-4b14-a579-4db8cb326db7)

## After
![image](https://github.com/user-attachments/assets/d84c96bf-6ecf-47d1-9288-762022d93456)
