### PR TITLE
Fix health able to go below zero

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Body/ActiveBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/ActiveBody.cs
@@ -39,6 +39,10 @@ namespace OpenSage.Logic.Object
         private void SetHealth(Fix64 value, bool takingDamage)
         {
             Health = value;
+            if (Health < Fix64.Zero)
+            {
+                Health = Fix64.Zero;
+            }
             GameObject.UpdateDamageFlags(HealthPercentage, takingDamage);
         }
 

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -279,7 +279,7 @@ namespace OpenSage.Logic.Object
         public Fix64 Health
         {
             get => _body?.Health ?? Fix64.Zero;
-            set => _body.Health = value;
+            set => _body.Health = value < Fix64.Zero ? Fix64.Zero : value;
         }
 
         public Fix64 MaxHealth


### PR DESCRIPTION
Noticed then when I was doing #931 

## Before
Note the red health bar going left temporarily.
![OpenSage Launcher_ttsWQR89jF](https://github.com/user-attachments/assets/79618091-f5a3-4cd5-808d-a6b7ecbeddad)

## After
![OpenSage Launcher_9ScvQlft1F](https://github.com/user-attachments/assets/92787b8f-2ad8-4d92-8e82-ccf90f53f7b4)
