### PR TITLE
Fix units not sinking/disappearing after death

### DIFF
--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -734,9 +734,9 @@ namespace OpenSage.Logic.Object
             CheckDisabledStates();
             foreach (var behavior in _behaviorModules)
             {
-                if (HasActiveBody() && IsDead && behavior is not SlowDeathBehavior)
+                if (IsDead && behavior is not SlowDeathBehavior and not LifetimeUpdate)
                 {
-                    continue; // if we're dead, we should only update SlowDeathBehavior
+                    continue; // if we're dead, we should only update SlowDeathBehavior or LifetimeUpdate
                 }
                 behavior.Update(_behaviorUpdateContext);
             }

--- a/src/OpenSage.Game/Logic/Object/ObjectCreationList.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectCreationList.cs
@@ -137,6 +137,7 @@ namespace OpenSage.Logic.Object
             debrisObject.LifeTime = context.LogicFrame + lifeTime;
 
             debrisObject.UpdateTransform(context.GameObject.Translation + Offset, context.GameObject.Rotation);
+            debrisObject.Die(DeathType.Normal);
 
             // Model
             var w3dDebrisDraw = (W3dDebrisDraw) debrisObject.Drawable.DrawModules[0];

--- a/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
@@ -33,6 +33,7 @@ namespace OpenSage.Logic.Object
             if (context.LogicFrame >= _frameToDie)
             {
                 _gameObject.Die(_moduleData.DeathType);
+                _frameToDie = LogicFrame.MaxValue;
             }
         }
 


### PR DESCRIPTION
## Before
Unit and rubble persist indefinitely.
![OpenSage Launcher_lnArPBSgDI](https://github.com/user-attachments/assets/79467c34-f79f-43f7-930f-df7452e64d6e)

## After
Unit and rubble sink and are deleted according to `LifetimeUpdate` and `SlowDeathBehavior`
![OpenSage Launcher_mRhyKxLQjh](https://github.com/user-attachments/assets/c370d532-fce0-4086-b57e-3bdbc656b996)
