### PR TITLE
Persist rally points

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Behaviors/ParkingPlaceBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/ParkingPlaceBehavior.cs
@@ -7,8 +7,10 @@ using OpenSage.Logic.Object.Production;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class ParkingPlaceBehaviour : UpdateModule, IProductionExit
+    public sealed class ParkingPlaceBehaviour : UpdateModule, IHasRallyPoint, IProductionExit
     {
+        public RallyPointManager RallyPointManager { get; } = new();
+
         private readonly ParkingPlaceBehaviorModuleData _moduleData;
         private readonly GameObject _gameObject;
         private readonly GameContext _gameContext;
@@ -245,7 +247,9 @@ namespace OpenSage.Logic.Object
                 throw new InvalidStateException();
             }
 
-            reader.SkipUnknownBytes(29);
+            reader.SkipUnknownBytes(16);
+
+            reader.PersistObject(RallyPointManager);
 
             var unknown3 = 0x3FFFFFFFu;
             reader.PersistUInt32(ref unknown3);
@@ -257,8 +261,8 @@ namespace OpenSage.Logic.Object
     }
 
     /// <summary>
-    /// Used by FS_AIRFIELD KindOfs. If <see cref="HasRunways"/> is set then the model requires 
-    /// RunwayStartN, RunwayEndN, RunwayNPrepN, RunwayNParkingN and RunwayNParkNHan bones where N 
+    /// Used by FS_AIRFIELD KindOfs. If <see cref="HasRunways"/> is set then the model requires
+    /// RunwayStartN, RunwayEndN, RunwayNPrepN, RunwayNParkingN and RunwayNParkNHan bones where N
     /// corresponds to rows and columns. Module will only use the HeliPark01 bone for helicopters.
     /// </summary>
     public sealed class ParkingPlaceBehaviorModuleData : BehaviorModuleData

--- a/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
@@ -9,8 +9,10 @@ using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
-    public abstract class OpenContainModule : UpdateModule
+    public abstract class OpenContainModule : UpdateModule, IHasRallyPoint
     {
+        public RallyPointManager RallyPointManager { get; } = new();
+
         private readonly OpenContainModuleData _moduleData;
         protected GameObject GameObject { get; }
         private protected GameContext GameContext { get; }
@@ -235,7 +237,7 @@ namespace OpenSage.Logic.Object
             reader.PersistUInt32(ref _numFirePoints);
             reader.PersistBoolean(ref _hasNoFirePoints);
 
-            reader.SkipUnknownBytes(13);
+            reader.PersistObject(RallyPointManager);
 
             reader.PersistList(
                 _evacQueue,

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -358,7 +358,11 @@ namespace OpenSage.Logic.Object
 
         public bool IsSelected { get; set; }
 
-        public Vector3? RallyPoint { get; set; }
+        public Vector3? RallyPoint
+        {
+            get => FindBehavior<IHasRallyPoint>()?.RallyPointManager.RallyPoint;
+            set => FindBehavior<IHasRallyPoint>()?.RallyPointManager.SetRallyPoint(value);
+        }
 
         internal Weapon CurrentWeapon => _weaponSet.CurrentWeapon;
 

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/DefaultProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/DefaultProductionExitUpdate.cs
@@ -3,12 +3,11 @@ using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class DefaultProductionExitUpdate : UpdateModule, IProductionExit
+    public sealed class DefaultProductionExitUpdate : UpdateModule, IHasRallyPoint, IProductionExit
     {
-        private readonly DefaultProductionExitUpdateModuleData _moduleData;
+        public RallyPointManager RallyPointManager { get; } = new();
 
-        private Vector3 _unknownPos;
-        private bool _unknownBool;
+        private readonly DefaultProductionExitUpdateModuleData _moduleData;
 
         internal DefaultProductionExitUpdate(DefaultProductionExitUpdateModuleData moduleData)
         {
@@ -27,8 +26,7 @@ namespace OpenSage.Logic.Object
             base.Load(reader);
             reader.EndObject();
 
-            reader.PersistVector3(ref _unknownPos);
-            reader.PersistBoolean(ref _unknownBool);
+            reader.PersistObject(RallyPointManager);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/QueueProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/QueueProductionExitUpdate.cs
@@ -1,12 +1,11 @@
-﻿using System.Numerics;
+using System.Numerics;
 using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class QueueProductionExitUpdate : UpdateModule, IProductionExit
+    public sealed class QueueProductionExitUpdate : UpdateModule, IHasRallyPoint, IProductionExit
     {
-        private Vector3 _unknownPosition;
-        private bool _unknownBool;
+        public RallyPointManager RallyPointManager { get; } = new();
 
         private readonly QueueProductionExitUpdateModuleData _moduleData;
 
@@ -30,8 +29,7 @@ namespace OpenSage.Logic.Object
             reader.EndObject();
 
             reader.SkipUnknownBytes(4);
-            reader.PersistVector3(ref _unknownPosition);
-            reader.PersistBoolean(ref _unknownBool);
+            reader.PersistObject(RallyPointManager);
             reader.SkipUnknownBytes(8);
         }
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SupplyCenterProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SupplyCenterProductionExitUpdate.cs
@@ -3,8 +3,10 @@ using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class SupplyCenterProductionExitUpdate : UpdateModule, IProductionExit
+    public sealed class SupplyCenterProductionExitUpdate : UpdateModule, IHasRallyPoint, IProductionExit
     {
+        public RallyPointManager RallyPointManager { get; } = new();
+
         private readonly SupplyCenterProductionExitUpdateModuleData _moduleData;
 
         internal SupplyCenterProductionExitUpdate(SupplyCenterProductionExitUpdateModuleData moduleData)
@@ -24,7 +26,7 @@ namespace OpenSage.Logic.Object
             base.Load(reader);
             reader.EndObject();
 
-            reader.SkipUnknownBytes(13);
+            reader.PersistObject(RallyPointManager);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/RallyPoint/IHasRallyPoint.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RallyPoint/IHasRallyPoint.cs
@@ -1,0 +1,6 @@
+﻿namespace OpenSage.Logic.Object;
+
+public interface IHasRallyPoint
+{
+    RallyPointManager RallyPointManager { get; }
+}

--- a/src/OpenSage.Game/Logic/Object/Update/RallyPoint/RallyPointManager.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RallyPoint/RallyPointManager.cs
@@ -1,0 +1,23 @@
+﻿using System.Numerics;
+
+namespace OpenSage.Logic.Object;
+
+public class RallyPointManager : IPersistableObject
+{
+    public Vector3? RallyPoint => _isRallyPointSet ? _rallyPoint : null;
+
+    private Vector3 _rallyPoint;
+    private bool _isRallyPointSet;
+
+    public void Persist(StatePersister reader)
+    {
+        reader.PersistVector3(ref _rallyPoint);
+        reader.PersistBoolean(ref _isRallyPointSet);
+    }
+
+    public void SetRallyPoint(Vector3? rallyPoint)
+    {
+        _rallyPoint = rallyPoint ?? default;
+        _isRallyPointSet = rallyPoint.HasValue;
+    }
+}


### PR DESCRIPTION
There may be other behaviors which persist rally points, but these are the ones I was able to find. Initially I thought about just having `IProductionExit` implement `IHasRallyPoint`, but `SpawnPointProductionExitUpdate` also implements `IProductionExit` and a cursory investigation doesn't reveal any obvious place that it would store the rally point.