### PR TITLE
Implement QueueProductionExitUpdate

### DIFF
--- a/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
+++ b/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
@@ -168,6 +168,26 @@ namespace OpenSage.Logic.Object
             return !(left == right);
         }
 
+        public static bool operator >(LogicFrameSpan left, LogicFrameSpan right)
+        {
+            return left.Value > right.Value;
+        }
+
+        public static bool operator <(LogicFrameSpan left, LogicFrameSpan right)
+        {
+            return left.Value < right.Value;
+        }
+
+        public static bool operator >=(LogicFrameSpan left, LogicFrameSpan right)
+        {
+            return left.Value >= right.Value;
+        }
+
+        public static bool operator <=(LogicFrameSpan left, LogicFrameSpan right)
+        {
+            return left.Value <= right.Value;
+        }
+
         public override bool Equals(object obj)
         {
             return obj is LogicFrameSpan logicFrameSpan && Equals(logicFrameSpan);
@@ -181,6 +201,11 @@ namespace OpenSage.Logic.Object
         public override int GetHashCode()
         {
             return (int)Value;
+        }
+
+        public override string ToString()
+        {
+            return Value.ToString();
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Production/ProductionJob.cs
+++ b/src/OpenSage.Game/Logic/Object/Production/ProductionJob.cs
@@ -4,55 +4,122 @@ namespace OpenSage.Logic.Object.Production
 {
     public sealed class ProductionJob : IPersistableObject
     {
-        private readonly uint _duration;
+        public ProductionJobType Type => _jobType;
+        public uint UnitsProduced => _numberOfItemsProduced;
 
+        // todo: this won't properly persist build time with modifiers - we should probably be fetching on-demand?
+        // this will need to take into account things like MinLowEnergyProductionSpeed
+        private LogicFrameSpan _buildTime;
+
+        private ProductionJobType _jobType;
+        private string _templateName;
         private uint _jobId;
-        private float _progressPercentage;
-        private uint _progressInFrames;
-        private int _unknownInt2;
-        private int _unknownInt3;
+        private float _progressPercentage; // can be over 100% when producing multiple items
+        private LogicFrameSpan _progressInFrames;
+        private uint _totalItemsToProduce; // in the case of china red guard, this is 2
+        private uint _numberOfItemsProduced; // when building multiple items, if one of two has been produced this is 1
         private int _unknownInt4;
-
-        public ProductionJobType Type { get; }
 
         public float Progress => Math.Max(0, Math.Min(1, _progressPercentage));
 
-        public ProductionJobResult Produce()
+        public void Update()
         {
             _progressInFrames++;
-            _progressPercentage = _progressInFrames / (float)_duration;
-            if (_progressInFrames >= _duration)
+            _progressPercentage = _progressInFrames / _buildTime;
+        }
+
+        public ProductionJobResult Produce()
+        {
+            if (_progressPercentage >= 1)
             {
-                return ProductionJobResult.Finished;
+                if (_jobType is ProductionJobType.Upgrade)
+                {
+                    return ProductionJobResult.Finished;
+                }
+
+                _numberOfItemsProduced++;
+
+                if (_numberOfItemsProduced >= _totalItemsToProduce)
+                {
+                    return ProductionJobResult.Finished;
+                }
+
+                return ProductionJobResult.UnitReady;
             }
+
+
+
             return ProductionJobResult.Producing;
         }
 
-        public ObjectDefinition ObjectDefinition { get; }
-        public UpgradeTemplate UpgradeDefinition { get; }
+        public ObjectDefinition ObjectDefinition { get; private set; }
+        public UpgradeTemplate UpgradeDefinition { get; private set; }
 
-        public ProductionJob(ObjectDefinition definition, LogicFrameSpan buildTime)
+        public ProductionJob(ObjectDefinition definition, LogicFrameSpan buildTime, uint jobId, uint quantity = 1) :
+            this(definition.Name, ProductionJobType.Unit, buildTime, jobId, quantity)
         {
             ObjectDefinition = definition;
-            Type = ProductionJobType.Unit;
-            _duration = buildTime.Value;
         }
 
-        public ProductionJob(UpgradeTemplate definition)
+        // quantity intentionally set to 0
+        public ProductionJob(UpgradeTemplate definition, uint jobId) :
+            this(definition.Name, ProductionJobType.Upgrade, definition.BuildTime, jobId, 0)
         {
             UpgradeDefinition = definition;
-            Type = ProductionJobType.Upgrade;
-            _duration = definition.BuildTime.Value;
+        }
+
+        private ProductionJob(string templateName, ProductionJobType type, LogicFrameSpan buildTime, uint jobId, uint quantity)
+        {
+            _templateName = templateName;
+            _jobType = type;
+            _buildTime = buildTime;
+            _jobId = jobId;
+            _totalItemsToProduce = quantity;
+        }
+
+        /// <summary>
+        /// Used for creating new copies for persistence.
+        /// </summary>
+        internal ProductionJob()
+        {
         }
 
         public void Persist(StatePersister reader)
         {
+            reader.PersistEnum(ref _jobType);
+
+            reader.PersistAsciiString(ref _templateName);
+
+            if (reader.Mode is StatePersistMode.Read)
+            {
+                switch (_jobType)
+                {
+                    case ProductionJobType.Unit:
+                        ObjectDefinition =
+                            reader.AssetStore.ObjectDefinitions.GetByName(_templateName);
+                        _buildTime = ObjectDefinition.BuildTime;
+                        break;
+                    case ProductionJobType.Upgrade:
+                        UpgradeDefinition = reader.AssetStore.Upgrades.GetByName(_templateName);
+                        _buildTime = UpgradeDefinition.BuildTime;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(_jobType));
+                }
+            }
+
             reader.PersistUInt32(ref _jobId);
             reader.PersistSingle(ref _progressPercentage);
-            reader.PersistUInt32(ref _progressInFrames);
-            reader.PersistInt32(ref _unknownInt2);
-            reader.PersistInt32(ref _unknownInt3);
+            reader.PersistLogicFrameSpan(ref _progressInFrames);
+            reader.PersistUInt32(ref _totalItemsToProduce);
+            reader.PersistUInt32(ref _numberOfItemsProduced);
             reader.PersistInt32(ref _unknownInt4);
+
+            if (_unknownInt4 != 0 && _unknownInt4 != -1)
+            {
+                // 0 when producing upgrade, -1 when producing unit
+                throw new InvalidStateException();
+            }
         }
     }
 
@@ -65,6 +132,7 @@ namespace OpenSage.Logic.Object.Production
     public enum ProductionJobResult
     {
         Producing,
-        Finished
+        UnitReady,
+        Finished,
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/IProductionExit.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/IProductionExit.cs
@@ -4,7 +4,9 @@ namespace OpenSage.Logic.Object
 {
     interface IProductionExit
     {
+        bool CanProduce => true;
         Vector3 GetUnitCreatePoint();
         Vector3? GetNaturalRallyPoint();
+        void ProduceUnit() {}
     }
 }


### PR DESCRIPTION
Includes a fairly sizeable refactor of ProductionUpdate and ProductionJob as well, updating the classes so most of the core state information is persisted.

Fixes #948

Some of the BFME stuff has been commented out as it no longer fits the proper implementation. We'll also still need to investigate scaling production times (for example, USA/China low power or GLA with power)

![OpenSage Launcher_cziofLQwdF](https://github.com/user-attachments/assets/2c1578c4-e9d1-493d-8157-473032ee5229)
