### PR TITLE
Enable persistence unit testing

### DIFF
--- a/src/OpenSage.Game.Tests/Logic/Object/BehaviorModuleTest.cs
+++ b/src/OpenSage.Game.Tests/Logic/Object/BehaviorModuleTest.cs
@@ -1,0 +1,10 @@
+﻿using OpenSage.Logic.Object;
+
+namespace OpenSage.Tests.Logic.Object;
+
+public abstract class BehaviorModuleTest<TModule, TData> : ModuleTest where TModule : BehaviorModule where TData : BehaviorModuleData, new()
+{
+    protected override byte[] ModuleData() => [V1, V1, .. base.ModuleData()];
+
+    protected TModule SampleModule() => (TModule)new TData().CreateModule(null!, null!);
+}

--- a/src/OpenSage.Game.Tests/Logic/Object/Behaviors/OverchargeBehaviorTests.cs
+++ b/src/OpenSage.Game.Tests/Logic/Object/Behaviors/OverchargeBehaviorTests.cs
@@ -1,0 +1,34 @@
+﻿using OpenSage.Logic.Object;
+using OpenSage.Tests.Logic.Object.Update;
+using Xunit;
+
+namespace OpenSage.Tests.Logic.Object.Behaviors;
+
+public class OverchargeBehaviorTests : UpdateModuleTest<OverchargeBehavior, OverchargeBehaviorModuleData>
+{
+    [Fact]
+    public void Enabled_V1()
+    {
+        byte[] enabledSampleData = [0x01];
+
+        var stream = SaveData(enabledSampleData);
+        var reader = new StateReader(stream, Generals);
+        var behavior = SampleModule();
+        behavior.Load(reader);
+
+        Assert.True(behavior.Enabled);
+    }
+
+    [Fact]
+    public void Disabled_V1()
+    {
+        byte[] disabledSampleData = [0x00];
+
+        var stream = SaveData(disabledSampleData);
+        var reader = new StateReader(stream, Generals);
+        var behavior = SampleModule();
+        behavior.Load(reader);
+
+        Assert.False(behavior.Enabled);
+    }
+}

--- a/src/OpenSage.Game.Tests/Logic/Object/ModuleTest.cs
+++ b/src/OpenSage.Game.Tests/Logic/Object/ModuleTest.cs
@@ -1,0 +1,14 @@
+﻿using System.IO;
+
+namespace OpenSage.Tests.Logic.Object;
+
+public abstract class ModuleTest : MockedGameTest
+{
+    protected const byte V1 = 0x01;
+    protected virtual byte[] ModuleData() => [V1];
+
+    protected MemoryStream SaveData(byte[] data, byte version = V1)
+    {
+        return new MemoryStream([version, .. ModuleData(), ..data]);
+    }
+}

--- a/src/OpenSage.Game.Tests/Logic/Object/Update/UpdateModuleTest.cs
+++ b/src/OpenSage.Game.Tests/Logic/Object/Update/UpdateModuleTest.cs
@@ -1,0 +1,10 @@
+﻿using OpenSage.Logic.Object;
+
+namespace OpenSage.Tests.Logic.Object.Update;
+
+public abstract class UpdateModuleTest<TModule, TData> : BehaviorModuleTest<TModule, TData> where TModule : UpdateModule where TData : UpdateModuleData, new()
+{
+    private readonly byte[] _nextUpdateFrame = [0x00, 0x00, 0x00, 0x00];
+
+    protected override byte[] ModuleData() => [V1, .. base.ModuleData(), .. _nextUpdateFrame];
+}

--- a/src/OpenSage.Game.Tests/StatePersisterTest.cs
+++ b/src/OpenSage.Game.Tests/StatePersisterTest.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using OpenSage.Client;
+using OpenSage.Content;
+using OpenSage.Data.Sav;
+using OpenSage.Logic;
+using OpenSage.Network;
+using OpenSage.Scripting;
+using OpenSage.Terrain;
+
+namespace OpenSage.Tests;
+
+public abstract class MockedGameTest : IDisposable
+{
+    private protected TestGame Generals { get; } = new(SageGame.CncGenerals);
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+    }
+
+    private protected class TestGame(SageGame game) : IGame
+    {
+        public SageGame SageGame { get; } = game;
+        public AssetStore AssetStore { get; }
+        public ContentManager ContentManager { get; }
+        public SkirmishManager SkirmishManager { get; set; }
+        public LobbyManager LobbyManager { get; }
+        public ScriptingSystem Scripting { get; }
+        public GameState GameState { get; }
+        public GameStateMap GameStateMap { get; }
+        public CampaignManager CampaignManager { get; }
+        public TerrainLogic TerrainLogic { get; }
+        public TerrainVisual TerrainVisual { get; }
+        public GhostObjectManager GhostObjectManager { get; }
+        public Scene2D Scene2D { get; }
+        public Scene3D Scene3D { get; }
+        public GameLogic GameLogic { get; }
+        public GameClient GameClient { get; }
+        public PlayerManager PlayerManager { get; }
+        public TeamFactory TeamFactory { get; }
+        public PartitionCellManager PartitionCellManager { get; }
+        public bool InGame { get; }
+
+        public void StartCampaign(string campaignName, string missionName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void StartSkirmishOrMultiPlayerGame(string mapFileName, IConnection connection, PlayerSetting[] playerSettings,
+            int seed, bool isMultiPlayer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void StartSinglePlayerGame(string mapFileName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<PlayerTemplate> GetPlayableSides()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/OpenSage.Game/Data/Sav/SaveFile.cs
+++ b/src/OpenSage.Game/Data/Sav/SaveFile.cs
@@ -48,7 +48,7 @@ namespace OpenSage.Data.Sav
             Persist(statePersister);
         }
 
-        private record struct ChunkDefinition(string ChunkName, Func<Game, IPersistableObject> GetPersistableObject);
+        private record struct ChunkDefinition(string ChunkName, Func<IGame, IPersistableObject> GetPersistableObject);
 
         private static readonly List<ChunkDefinition> ChunkDefinitions = new()
         {

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -36,7 +36,7 @@ using Veldrid.ImageSharp;
 
 namespace OpenSage
 {
-    public sealed class Game : DisposableBase
+    public sealed class Game : DisposableBase, IGame
     {
         static Game()
         {
@@ -105,6 +105,9 @@ namespace OpenSage
         public AudioSystem Audio { get; }
 
         public GameState GameState { get; } = new GameState();
+
+        GameStateMap IGame.GameStateMap => GameStateMap;
+
         internal GameStateMap GameStateMap { get; } = new GameStateMap();
 
         public CampaignManager CampaignManager { get; } = new CampaignManager();
@@ -378,15 +381,22 @@ namespace OpenSage
 
         public Texture LauncherImage { get; }
 
+        // currently, the only way to implement internal interface properties is explicitly
+        GameLogic IGame.GameLogic => GameLogic;
+
         internal readonly GameLogic GameLogic;
+
+        GameClient IGame.GameClient => GameClient;
 
         internal readonly GameClient GameClient;
 
-        public readonly PlayerManager PlayerManager;
+        public PlayerManager PlayerManager { get; }
+
+        TeamFactory IGame.TeamFactory => TeamFactory;
 
         internal readonly TeamFactory TeamFactory;
 
-        public readonly PartitionCellManager PartitionCellManager;
+        public PartitionCellManager PartitionCellManager { get; }
 
         public Game(GameInstallation installation)
             : this(installation, null, new Configuration(), null)

--- a/src/OpenSage.Game/IGame.cs
+++ b/src/OpenSage.Game/IGame.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using OpenSage.Client;
+using OpenSage.Content;
+using OpenSage.Data.Sav;
+using OpenSage.Logic;
+using OpenSage.Network;
+using OpenSage.Scripting;
+
+namespace OpenSage;
+
+public interface IGame
+{
+    SageGame SageGame { get; }
+    AssetStore AssetStore { get; }
+    public ContentManager ContentManager { get; }
+    public SkirmishManager SkirmishManager { get; set; }
+    LobbyManager LobbyManager { get; }
+    ScriptingSystem Scripting { get; }
+    GameState GameState { get; }
+    internal GameStateMap GameStateMap { get; }
+    CampaignManager CampaignManager { get; }
+    Terrain.TerrainLogic TerrainLogic { get; }
+    Terrain.TerrainVisual TerrainVisual { get; }
+    GhostObjectManager GhostObjectManager { get; }
+    Scene2D Scene2D { get; }
+    Scene3D Scene3D { get; }
+    internal GameLogic GameLogic { get; }
+    internal GameClient GameClient { get; }
+    PlayerManager PlayerManager { get; }
+    TeamFactory TeamFactory { get; }
+    PartitionCellManager PartitionCellManager { get; }
+    bool InGame { get; }
+
+    void StartCampaign(string campaignName, string missionName);
+    void StartSkirmishOrMultiPlayerGame(string mapFileName, IConnection connection, PlayerSetting[] playerSettings, int seed, bool isMultiPlayer);
+    void StartSinglePlayerGame(string mapFileName);
+    IEnumerable<PlayerTemplate> GetPlayableSides();
+}

--- a/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
@@ -81,7 +81,7 @@ namespace OpenSage.Logic.Object
     /// Allows this object to turn on or off the <see cref="ModelConditionFlag.PowerPlantUpgrading"/>
     /// and <see cref="ModelConditionFlag.PowerPlantUpgraded"/> condition states.
     /// </summary>
-    public sealed class OverchargeBehaviorModuleData : BehaviorModuleData
+    public sealed class OverchargeBehaviorModuleData : UpdateModuleData
     {
         internal static OverchargeBehaviorModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
 

--- a/src/OpenSage.Game/Network/SkirmishGameSettings.cs
+++ b/src/OpenSage.Game/Network/SkirmishGameSettings.cs
@@ -135,7 +135,7 @@ namespace OpenSage.Network
             {
                 _startingCash = new Money
                 {
-                    Amount = (uint)reader.Game.AssetStore.GameData.Current.DefaultStartingCash
+                    Amount = (uint)reader.AssetStore.GameData.Current.DefaultStartingCash
                 };
             }
         }

--- a/src/OpenSage.Game/Network/SkirmishManager.cs
+++ b/src/OpenSage.Game/Network/SkirmishManager.cs
@@ -17,11 +17,11 @@ namespace OpenSage.Network
     {
         protected static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
-        protected Game _game;
+        protected IGame Game { get; }
 
-        public SkirmishManager(Game game, bool isHosting)
+        public SkirmishManager(IGame game, bool isHosting)
         {
-            _game = game;
+            Game = game;
 
             IsHosting = isHosting;
             Settings = new SkirmishGameSettings(isHosting);
@@ -43,7 +43,7 @@ namespace OpenSage.Network
 
             if (Settings.Status == SkirmishGameStatus.ReadyToStart)
             {
-                _game.Scene2D.WndWindowManager.PopWindow();
+                Game.Scene2D.WndWindowManager.PopWindow();
                 StartGame();
             }
         }
@@ -75,14 +75,14 @@ namespace OpenSage.Network
 
                 playerSettings.Add(new PlayerSetting(
                     slot.StartPosition,
-                    _game.GetPlayableSides().ElementAt(slot.FactionIndex - 1).Name,
-                    _game.AssetStore.MultiplayerColors.GetByIndex(slot.ColorIndex).RgbColor,
+                    Game.GetPlayableSides().ElementAt(slot.FactionIndex - 1).Name,
+                    Game.AssetStore.MultiplayerColors.GetByIndex(slot.ColorIndex).RgbColor,
                     slot.Team,
                     owner,
                     isLocalForMultiplayer: i == Settings.LocalSlotIndex));
             }
 
-            _game.StartSkirmishOrMultiPlayerGame(
+            Game.StartSkirmishOrMultiPlayerGame(
                 Settings.MapName,
                 Connection,
                 playerSettings.ToArray(),
@@ -95,7 +95,7 @@ namespace OpenSage.Network
 
     public sealed class LocalSkirmishManager : SkirmishManager
     {
-        public LocalSkirmishManager(Game game)
+        public LocalSkirmishManager(IGame game)
             : base(game, isHosting: true)
         {
             Settings.LocalSlotIndex = 0;
@@ -274,7 +274,7 @@ namespace OpenSage.Network
             _writer.Reset();
             _processor.Write(_writer, new SkirmishClientConnectPacket()
             {
-                PlayerName = _game.LobbyManager.Username,
+                PlayerName = Game.LobbyManager.Username,
                 ClientId = ClientInstance.Id,
             });
 
@@ -308,8 +308,8 @@ namespace OpenSage.Network
                 _ => "LAN:HostNotResponding"
             };
 
-            _game.Scene2D.WndWindowManager.SetWindow(@"Menus\LanLobbyMenu.wnd");
-            _game.Scene2D.WndWindowManager.ShowMessageBox(title.Translate(), text.Translate());
+            Game.Scene2D.WndWindowManager.SetWindow(@"Menus\LanLobbyMenu.wnd");
+            Game.Scene2D.WndWindowManager.ShowMessageBox(title.Translate(), text.Translate());
             _disconnectReason = null;
 
             Stop();
@@ -474,7 +474,7 @@ namespace OpenSage.Network
             Settings.LocalSlotIndex = 0;
 
             var localSlot = Settings.LocalSlot;
-            localSlot.PlayerName = _game.LobbyManager.Username;
+            localSlot.PlayerName = Game.LobbyManager.Username;
             localSlot.State = SkirmishSlotState.Human;
             localSlot.EndPoint = new IPEndPoint(IPAddress.Any, Ports.SkirmishHost); // The host does not know his own external IP address
 

--- a/src/OpenSage.Game/StatePersister.cs
+++ b/src/OpenSage.Game/StatePersister.cs
@@ -17,11 +17,11 @@ namespace OpenSage
 
         public readonly StatePersistMode Mode;
 
-        public readonly Game Game;
+        public readonly IGame Game;
         public readonly SageGame SageGame;
         public readonly AssetStore AssetStore;
 
-        protected StatePersister(Game game, StatePersistMode mode)
+        protected StatePersister(IGame game, StatePersistMode mode)
         {
             Segments = new Stack<Segment>();
 
@@ -268,7 +268,7 @@ namespace OpenSage
     {
         private readonly BinaryReader _binaryReader;
 
-        internal StateReader(Stream stream, Game game)
+        internal StateReader(Stream stream, IGame game)
             : base(game, StatePersistMode.Read)
         {
             _binaryReader = AddDisposable(new BinaryReader(stream, Encoding.Unicode, true));
@@ -364,7 +364,7 @@ namespace OpenSage
     {
         private readonly BinaryWriter _binaryWriter;
 
-        internal StateWriter(Stream stream, Game game)
+        internal StateWriter(Stream stream, IGame game)
             : base(game, StatePersistMode.Read)
         {
             _binaryWriter = AddDisposable(new BinaryWriter(stream, Encoding.Unicode, true));

--- a/src/OpenSage.Tools.Sav2Json/JsonSaveWriter.cs
+++ b/src/OpenSage.Tools.Sav2Json/JsonSaveWriter.cs
@@ -9,7 +9,7 @@ internal sealed class JsonSaveWriter : StatePersister
 {
     private readonly Utf8JsonWriter _writer;
 
-    public JsonSaveWriter(Game game, string filePath)
+    public JsonSaveWriter(IGame game, string filePath)
         : base(game, StatePersistMode.Write)
     {
         var stream = AddDisposable(File.OpenWrite(filePath));
@@ -28,7 +28,7 @@ internal sealed class JsonSaveWriter : StatePersister
 
     public override void EndSegment()
     {
-        
+
     }
 
     public override void BeginArray()
@@ -127,7 +127,7 @@ internal sealed class JsonSaveWriter : StatePersister
 
     public override void PersistSpan(Span<byte> span)
     {
-        
+
     }
 
     public override void PersistUInt16Value(ref ushort value)
@@ -156,6 +156,6 @@ internal sealed class JsonSaveWriter : StatePersister
 
     public override void SkipUnknownBytes(int numBytes)
     {
-        
+
     }
 }


### PR DESCRIPTION
`IGame` is the bare minimum interface required and does not extract _all_ behavior from `Game`. I also have not gone through to replace other usages of `Game` with `IGame` where not required for the persister.
++++++++++++++++++
(my cat typed that line ^. I felt it important to leave in.)

I added basic tests for OverchargeBehavior parsing as a proof of concept, since it's very simple. This framework should be easy enough to expand to other behaviors (or even things that aren't behaviors). In some places when parsing we rely on the various properties of `IGame` being implemented, but I think we can cross those bridges as we come to them.