### PR TITLE
Add debug function to persister to log segment bytes

### DIFF
--- a/src/OpenSage.Game/StatePersister.cs
+++ b/src/OpenSage.Game/StatePersister.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
@@ -256,6 +256,8 @@ namespace OpenSage
         public virtual void EndArray() { }
 
         public abstract void SkipUnknownBytes(int numBytes);
+
+        public virtual void LogToSegmentEnd() { }
     }
 
     public enum StatePersistMode
@@ -357,6 +359,21 @@ namespace OpenSage
                     throw new InvalidStateException($"Expected byte (index {i}) to be 0 but it was {value}");
                 }
             }
+        }
+
+        /// <summary>
+        /// Only to be used for local debugging and should not be present in committed code.
+        /// </summary>
+        public override void LogToSegmentEnd()
+        {
+            var segment = Segments.Pop();
+            for (var i = _binaryReader.BaseStream.Position; i < segment.End; i++)
+            {
+                Console.Write(_binaryReader.ReadByte().ToString("x2"));
+                Console.Write(" ");
+            }
+            Console.WriteLine();
+            Segments.Push(segment);
         }
     }
 


### PR DESCRIPTION
I've found myself using this function a _lot_ when testing. Maybe someone can point me to a better way, but my workflow has been:
- create a sav file with the behavior I'm interested in introspecting
- replace the `Load` function of the behavior with `LogToSegmentEnd()`
- run Sav2Json

If this would benefit others, I'd like to commit this that way I don't have to keep stashing and popping it 😆 

Output might look something like this. It's also easy to copy/paste something like this into HexEd.it for further processing.
```
[22:23:22.3900][Trace] Skirmish game status is now Started
[22:23:22.4205][Info] Set active condition state for AmericaVehicleDozer
01 00 00 00 00 00 00 00 00 00 00 
[22:23:22.4424][Info] Weapon DozerMineDisarmingWeapon on game object  transitioning to state Inactive
[22:23:22.4424][Info] Set active condition state for AmericaCommandCenter
```
