### PR TITLE
Add initial implementation of GenerateMinefieldBehavior

### DIFF
--- a/src/OpenSage.Game.Tests/Logic/Object/Behaviors/GenerateMinefieldBehaviorTests.cs
+++ b/src/OpenSage.Game.Tests/Logic/Object/Behaviors/GenerateMinefieldBehaviorTests.cs
@@ -1,0 +1,161 @@
+﻿using OpenSage.Logic.Object;
+using OpenSage.Tests.Logic.Object.Update;
+using Xunit;
+
+namespace OpenSage.Tests.Logic.Object.Behaviors;
+
+public class GenerateMinefieldBehaviorTests : BehaviorModuleTest<GenerateMinefieldBehavior, GenerateMinefieldBehaviorModuleData>
+{
+    /// <summary>
+    /// A structure which has not yet triggered the minefield upgrade will have nothing set except for the version of the upgrade data.
+    /// </summary>
+    private static readonly byte[] GeneralsUntriggeredBuildingUpgrade =
+        [0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+
+    [Fact]
+    public void Generals_UntriggeredUpgrade_V1()
+    {
+        var stream = SaveData(GeneralsUntriggeredBuildingUpgrade);
+        var reader = new StateReader(stream, Generals);
+        var behavior = SampleModule();
+        behavior.Load(reader);
+
+        Assert.False(behavior.UpgradeLogic.Triggered);
+        Assert.False(behavior.Generated);
+        Assert.False(behavior.Upgraded);
+        Assert.False(behavior.GenerationPosition.HasValue);
+        Assert.Empty(behavior.GeneratedMineIds);
+    }
+
+    /// <summary>
+    /// A structure which has been triggered will have the triggered object set as triggered, as well as the matching generated flag.
+    /// </summary>
+    private static readonly byte[] GeneralsTriggeredBuildingUpgrade =
+        [0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+
+    [Fact]
+    public void Generals_TriggeredUpgrade_V1()
+    {
+        var stream = SaveData(GeneralsTriggeredBuildingUpgrade);
+        var reader = new StateReader(stream, Generals);
+        var behavior = SampleModule();
+        behavior.Load(reader);
+
+        Assert.True(behavior.UpgradeLogic.Triggered);
+        Assert.True(behavior.Generated);
+        Assert.False(behavior.Upgraded);
+        Assert.False(behavior.GenerationPosition.HasValue);
+        Assert.Empty(behavior.GeneratedMineIds);
+    }
+
+    /// <summary>
+    /// A falling cluster mine bomb does not trigger until it dies, but has stored coordinates for where to generate the minefield when it does die.
+    /// </summary>
+    private static readonly byte[] GeneralsClusterMineBombFalling =
+        [0x01, 0x00, 0x00, 0x01, 0x54, 0x92, 0x67, 0x43, 0x5b, 0x4e, 0x40, 0x44, 0x00, 0x00, 0x20, 0x41];
+
+    [Fact]
+    public void Generals_ClusterMineBomb_Falling_V1()
+    {
+        var stream = SaveData(GeneralsClusterMineBombFalling);
+        var reader = new StateReader(stream, Generals);
+        var behavior = SampleModule();
+        behavior.Load(reader);
+
+        Assert.False(behavior.UpgradeLogic.Triggered);
+        Assert.False(behavior.Generated);
+        Assert.False(behavior.Upgraded);
+        Assert.True(behavior.GenerationPosition.HasValue);
+        Assert.Equal(231.57159f, behavior.GenerationPosition.Value.X, 0.01);
+        Assert.Equal(769.2243f, behavior.GenerationPosition.Value.Y, 0.01);
+        Assert.Equal(10f, behavior.GenerationPosition.Value.Z, 0.01);
+        Assert.Empty(behavior.GeneratedMineIds);
+    }
+
+    /// <summary>
+    /// A structure which has not yet triggered the minefield upgrade will have nothing set except for the version of the upgrade data.
+    /// </summary>
+    private static readonly byte[] ZeroHourUntriggeredBuildingUpgrade =
+        [0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+
+    [Fact]
+    public void ZeroHour_UntriggeredUpgrade_V1()
+    {
+        var stream = SaveData(ZeroHourUntriggeredBuildingUpgrade);
+        var reader = new StateReader(stream, ZeroHour);
+        var behavior = SampleModule();
+        behavior.Load(reader);
+
+        Assert.False(behavior.UpgradeLogic.Triggered);
+        Assert.False(behavior.Generated);
+        Assert.False(behavior.Upgraded);
+        Assert.False(behavior.GenerationPosition.HasValue);
+        Assert.Empty(behavior.GeneratedMineIds);
+    }
+
+    /// <summary>
+    /// A structure which has been triggered will have the triggered object set as triggered, the matching generated flag, and an array of the mines created.
+    /// </summary>
+    private static readonly byte[] ZeroHourTriggeredBuildingUpgrade =
+        [0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0d, 0x04, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x0e, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00];
+
+    [Fact]
+    public void ZeroHour_TriggeredUpgrade_V1()
+    {
+        var stream = SaveData(ZeroHourTriggeredBuildingUpgrade);
+        var reader = new StateReader(stream, ZeroHour);
+        var behavior = SampleModule();
+        behavior.Load(reader);
+
+        Assert.True(behavior.UpgradeLogic.Triggered);
+        Assert.True(behavior.Generated);
+        Assert.False(behavior.Upgraded);
+        Assert.False(behavior.GenerationPosition.HasValue);
+        Assert.Collection(behavior.GeneratedMineIds, id => Assert.Equal(0x04u, id), id => Assert.Equal(0x05u, id), id => Assert.Equal(0x06u, id), id => Assert.Equal(0x07u, id), id => Assert.Equal(0x08u, id), id => Assert.Equal(0x09u, id), id => Assert.Equal(0x0au, id), id => Assert.Equal(0x0bu, id), id => Assert.Equal(0x0cu, id), id => Assert.Equal(0x0du, id), id => Assert.Equal(0x0eu, id), id => Assert.Equal(0x0fu, id), id => Assert.Equal(0x10u, id));
+    }
+
+    /// <summary>
+    /// A structure whose mines have been upgraded will have the triggered object set as triggered, the matching generated flag, and an array of the mines created.
+    /// </summary>
+    private static readonly byte[] ZeroHourUpgradedBuildingUpgrade =
+        [0x01, 0x01, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0d, 0x11, 0x00, 0x00, 0x00, 0x12, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x14, 0x00, 0x00, 0x00, 0x15, 0x00, 0x00, 0x00, 0x16, 0x00, 0x00, 0x00, 0x17, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x00, 0x00, 0x1b, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x1d, 0x00, 0x00, 0x00];
+
+    [Fact]
+    public void ZeroHour_UpgradedUpgrade_V1()
+    {
+        var stream = SaveData(ZeroHourUpgradedBuildingUpgrade);
+        var reader = new StateReader(stream, ZeroHour);
+        var behavior = SampleModule();
+        behavior.Load(reader);
+
+        Assert.True(behavior.UpgradeLogic.Triggered);
+        Assert.True(behavior.Generated);
+        Assert.True(behavior.Upgraded);
+        Assert.False(behavior.GenerationPosition.HasValue);
+        Assert.Collection(behavior.GeneratedMineIds, id => Assert.Equal(0x11u, id), id => Assert.Equal(0x12u, id), id => Assert.Equal(0x13u, id), id => Assert.Equal(0x14u, id), id => Assert.Equal(0x15u, id), id => Assert.Equal(0x16u, id), id => Assert.Equal(0x17u, id), id => Assert.Equal(0x18u, id), id => Assert.Equal(0x19u, id), id => Assert.Equal(0x1au, id), id => Assert.Equal(0x1bu, id), id => Assert.Equal(0x1cu, id), id => Assert.Equal(0x1du, id));
+    }
+
+    /// <summary>
+    /// A falling cluster mine bomb does not trigger until it dies, but has stored coordinates for where to generate the minefield when it does die.
+    /// </summary>
+    private static readonly byte[] ZeroHourClusterMineBombFalling =
+        [0x01, 0x00, 0x00, 0x01, 0x00, 0x03, 0x53, 0xb9, 0x43, 0x09, 0xf4, 0x2d, 0x44, 0x00, 0x00, 0x20, 0x41, 00];
+
+    [Fact]
+    public void ZeroHour_ClusterMineBomb_Falling_V1()
+    {
+        var stream = SaveData(ZeroHourClusterMineBombFalling);
+        var reader = new StateReader(stream, ZeroHour);
+        var behavior = SampleModule();
+        behavior.Load(reader);
+
+        Assert.False(behavior.UpgradeLogic.Triggered);
+        Assert.False(behavior.Generated);
+        Assert.False(behavior.Upgraded);
+        Assert.True(behavior.GenerationPosition.HasValue);
+        Assert.Equal(370.64853f, behavior.GenerationPosition.Value.X, 0.01);
+        Assert.Equal(695.81305f, behavior.GenerationPosition.Value.Y, 0.01);
+        Assert.Equal(10f, behavior.GenerationPosition.Value.Z, 0.01);
+        Assert.Empty(behavior.GeneratedMineIds);
+    }
+}

--- a/src/OpenSage.Game.Tests/StatePersisterTest.cs
+++ b/src/OpenSage.Game.Tests/StatePersisterTest.cs
@@ -13,6 +13,7 @@ namespace OpenSage.Tests;
 public abstract class MockedGameTest : IDisposable
 {
     private protected TestGame Generals { get; } = new(SageGame.CncGenerals);
+    private protected TestGame ZeroHour { get; } = new(SageGame.CncGeneralsZeroHour);
 
     public void Dispose()
     {

--- a/src/OpenSage.Game/Logic/Object/Behaviors/GenerateMinefieldBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/GenerateMinefieldBehavior.cs
@@ -1,24 +1,172 @@
-﻿using OpenSage.Data.Ini;
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using OpenSage.Content;
+using OpenSage.Data.Ini;
+using OpenSage.FX;
+using OpenSage.Mathematics;
+using OpenSage.Utilities.Extensions;
 
 namespace OpenSage.Logic.Object
 {
     public sealed class GenerateMinefieldBehavior : BehaviorModule, IUpgradeableModule
     {
-        private readonly UpgradeLogic _upgradeLogic;
-        private bool _unknown;
+        internal UpgradeLogic UpgradeLogic { get; }
+        internal bool Generated => _generated;
+        internal bool Upgraded => _upgraded;
+        internal Vector3? GenerationPosition => _hasGenerationPosition ? _generationPosition : null;
+        internal IReadOnlyList<uint> GeneratedMineIds => _generatedMineIds;
 
-        internal GenerateMinefieldBehavior(GenerateMinefieldBehaviorModuleData moduleData)
+        private readonly GameObject _gameObject;
+        private readonly GameContext _context;
+        private readonly GenerateMinefieldBehaviorModuleData _moduleData;
+
+        // whether the minefield has been generated? (seems to always match _upgradeLogic.Triggered)
+        private bool _generated;
+        // whether the minefield has been upgraded (after being generated)
+        private bool _upgraded;
+
+        // a falling cluster bomb will have this set to true along with a position to generate at
+        private bool _hasGenerationPosition;
+        private Vector3 _generationPosition;
+
+        private readonly List<uint> _generatedMineIds = [];
+
+        internal GenerateMinefieldBehavior(GameObject gameObject, GameContext context, GenerateMinefieldBehaviorModuleData moduleData)
         {
-            _upgradeLogic = new UpgradeLogic(moduleData.UpgradeData, OnUpgrade);
+            _gameObject = gameObject;
+            _context = context;
+            _moduleData = moduleData;
+            UpgradeLogic = new UpgradeLogic(moduleData.UpgradeData, OnUpgrade);
         }
 
-        public bool CanUpgrade(UpgradeSet existingUpgrades) => _upgradeLogic.CanUpgrade(existingUpgrades);
+        public bool CanUpgrade(UpgradeSet existingUpgrades) => UpgradeLogic.CanUpgrade(existingUpgrades);
 
-        public void TryUpgrade(UpgradeSet completedUpgrades) => _upgradeLogic.TryUpgrade(completedUpgrades);
+        public void TryUpgrade(UpgradeSet completedUpgrades) => UpgradeLogic.TryUpgrade(completedUpgrades);
 
+        // todo: this behavior is "doubly" upgradable - the first upgrade creates the mines, and the second upgrade replaces them with a different template
         private void OnUpgrade()
         {
-            // TODO
+            if (_moduleData.GenerateOnlyOnDeath)
+            {
+                return;
+            }
+
+            GenerateMinefield(new BehaviorUpdateContext(_context, _gameObject));
+        }
+
+        internal override void OnDie(BehaviorUpdateContext context, DeathType deathType, BitArray<ObjectStatus> status)
+        {
+            if (_moduleData.GenerateOnlyOnDeath)
+            {
+                GenerateMinefield(context);
+            }
+
+            base.OnDie(context, deathType, status);
+        }
+
+        private void GenerateMinefield(BehaviorUpdateContext context)
+        {
+            _moduleData.GenerationFX?.Value.Execute(context);
+
+            var mineTemplate = _moduleData.MineName?.Value;
+
+            if (mineTemplate is null)
+            {
+                return;
+            }
+
+            var centerPoint = _hasGenerationPosition ? _generationPosition : _gameObject.Transform.Translation;
+            var gameData = _context.Game.AssetStore.GameData.Current;
+            var mineObjectSize = mineTemplate.Geometry.BoundingCircleRadius * 2;
+            var outerPerimeter = _moduleData.DistanceAroundObject ?? gameData.StandardMinefieldDistance;
+            var smartRadius = _gameObject.ShapedCollider.WorldBounds.Radius; // todo: this should be a rectangle when AlwaysCircular is false
+            var innerPerimeter = 0f;
+
+            if (_moduleData.SmartBorder)
+            {
+                outerPerimeter = Math.Max(outerPerimeter, smartRadius);
+                if (_moduleData.SmartBorderSkipInterior)
+                {
+                    innerPerimeter = smartRadius;
+                }
+            }
+
+            innerPerimeter += mineTemplate.Geometry.BoundingCircleRadius;
+            outerPerimeter += mineTemplate.Geometry.BoundingCircleRadius;
+
+            // just create a list of the xy coordinates we'd like to generate at first
+            var mineCandidateLocations = new List<Vector2>();
+
+            // potentially iterate over this multiple times to make multiple rings if necessary
+            for (var radius = innerPerimeter; radius <= outerPerimeter; radius += mineObjectSize)
+            {
+                if (_moduleData.AlwaysCircular)
+                {
+                    // we're making circles
+                    var circumference = Math.PI * radius * 2;
+                    var minesToPlace = (int)Math.Floor(circumference / mineObjectSize); // this may not be technically correct since the chord distance is shorter than the arc distance, but in testing seems to be accurate
+                    var radialGainPerMine = (float)(2 * Math.PI / minesToPlace);
+
+                    //convert polar to cartesian coordinates
+                    for (var mineIndex = 0; mineIndex < minesToPlace; mineIndex++)
+                    {
+                        var theta = mineIndex * radialGainPerMine;
+                        var x = centerPoint.X + radius * float.Cos(theta);
+                        var y = centerPoint.Y + radius * float.Sin(theta);
+
+                        mineCandidateLocations.Add(new Vector2(x, y));
+                    }
+                }
+                else
+                {
+                    // we're making rectangles - aligned with world object, NOT axis-aligned
+                    // nothing in the game currently uses this - still, the engine _does_ support it
+                    throw new NotImplementedException();
+                }
+            }
+
+            // then take those xy coordinates and determine which of them we could actually spawn mines at
+            // we don't spawn them yet to avoid issues with them potentially "colliding" with each other
+            var newMineTransforms = mineCandidateLocations
+                .Select(v => new Vector3(v.X, v.Y, _context.Terrain.HeightMap.GetHeight(v.X, v.Y)))
+                .WhereNot(_context.Terrain.ImpassableAt) // this might not be exactly correct, but seems to be close?
+                .Select(NormalTransformAtLocation)
+                .Where(TransformIsValidMineLocation)
+                .ToList();
+
+            // now that we know where to actually spawn the mines, spawn them
+            foreach (var transform in newMineTransforms)
+            {
+                var newMine = _gameObject.GameContext.GameLogic.CreateObject(mineTemplate, _gameObject.Owner);
+                newMine.UpdateTransform(transform.Translation, transform.Rotation);
+                newMine.CreatedByObjectID = _gameObject.ID;
+                _generatedMineIds.Add(newMine.ID);
+            }
+        }
+
+        private Transform NormalTransformAtLocation(Vector3 location)
+        {
+            // todo: should the normal matching be handled by KindOf STICK_TO_TERRAIN_SLOPE?
+            var normal = _context.Terrain.HeightMap.GetNormal(location.X, location.Y);
+            var rotation = (float)(_context.Random.NextDouble() * 2 * Math.PI);
+            return new Transform(location, Quaternion.CreateFromAxisAngle(normal, rotation));
+        }
+
+        private bool TransformIsValidMineLocation(Transform transform)
+        {
+            var mineTemplate = _moduleData.MineName?.Value;
+
+            if (mineTemplate is null)
+            {
+                return false;
+            }
+
+            var intersecting = _context.Quadtree.FindIntersecting(new SphereCollider(transform, mineTemplate.Geometry.BoundingCircleRadius));
+            return !intersecting.Any(obj => obj != _gameObject && (obj.IsKindOf(ObjectKinds.Structure) || obj.IsKindOf(ObjectKinds.Mine)));
         }
 
         internal override void Load(StatePersister reader)
@@ -29,14 +177,26 @@ namespace OpenSage.Logic.Object
             base.Load(reader);
             reader.EndObject();
 
-            reader.PersistObject(_upgradeLogic);
-            reader.PersistBoolean(ref _unknown);
+            reader.PersistObject(UpgradeLogic);
+            reader.PersistBoolean(ref _generated);
 
-            reader.SkipUnknownBytes(13);
+            if (_generated != UpgradeLogic.Triggered)
+            {
+                throw new InvalidStateException();
+            }
+
+            reader.PersistBoolean(ref _hasGenerationPosition);
 
             if (reader.SageGame >= SageGame.CncGeneralsZeroHour)
             {
-                reader.SkipUnknownBytes(2);
+                reader.PersistBoolean(ref _upgraded);
+            }
+
+            reader.PersistVector3(ref _generationPosition);
+
+            if (reader.SageGame >= SageGame.CncGeneralsZeroHour)
+            {
+                reader.PersistListWithByteCount(_generatedMineIds, (StatePersister persister, ref uint item) => persister.PersistObjectIDValue(ref item));
             }
         }
     }
@@ -49,40 +209,97 @@ namespace OpenSage.Logic.Object
             new IniParseTableChild<GenerateMinefieldBehaviorModuleData, UpgradeLogicData>(x => x.UpgradeData, UpgradeLogicData.FieldParseTable)
             .Concat(new IniParseTable<GenerateMinefieldBehaviorModuleData>
             {
-                { "MineName", (parser, x) => x.MineName = parser.ParseAssetReference() },
-                { "DistanceAroundObject", (parser, x) => x.DistanceAroundObject = parser.ParseInteger() },
+                { "MineName", (parser, x) => x.MineName = parser.ParseObjectReference() },
+                { "DistanceAroundObject", (parser, x) => x.DistanceAroundObject = parser.ParseFloat() },
                 { "GenerateOnlyOnDeath", (parser, x) => x.GenerateOnlyOnDeath = parser.ParseBoolean() },
                 { "SmartBorder", (parser, x) => x.SmartBorder = parser.ParseBoolean() },
                 { "SmartBorderSkipInterior", (parser, x) => x.SmartBorderSkipInterior = parser.ParseBoolean() },
                 { "AlwaysCircular", (parser, x) => x.AlwaysCircular = parser.ParseBoolean() },
-                { "GenerationFX", (parser, x) => x.GenerationFX = parser.ParseAssetReference() },
+                { "GenerationFX", (parser, x) => x.GenerationFX = parser.ParseFXListReference() },
                 { "Upgradable", (parser, x) => x.Upgradable = parser.ParseBoolean() },
-                { "UpgradedTriggeredBy", (parser, x) => x.UpgradedTriggeredBy = parser.ParseAssetReference() },
-                { "UpgradedMineName", (parser, x) => x.UpgradedMineName = parser.ParseAssetReference() },
+                { "UpgradedTriggeredBy", (parser, x) => x.UpgradedTriggeredBy = parser.ParseUpgradeReference() },
+                { "UpgradedMineName", (parser, x) => x.UpgradedMineName = parser.ParseObjectReference() },
             });
 
         public UpgradeLogicData UpgradeData { get; } = new();
 
-        public string MineName { get; private set; }
-        public int DistanceAroundObject { get; private set; }
-        public bool GenerateOnlyOnDeath { get; private set; }
-        public bool SmartBorder { get; private set; }
-        public bool SmartBorderSkipInterior { get; private set; }
-        public bool AlwaysCircular { get; private set; }
-        public string GenerationFX { get; private set; }
+        /// <summary>
+        /// The mine object to generate.
+        /// </summary>
+        public LazyAssetReference<ObjectDefinition>? MineName { get; private set; }
 
+        /// <summary>
+        /// The outer perimeter of the mines. If <see cref="SmartBorder"/> is <c>true</c>, this is not necessarily the inner perimeter,
+        /// and we may end up with a ring with some thickness. If <see cref="SmartBorder"/> is true and this value is less than the
+        /// computed value of <see cref="SmartBorder"/>, this setting is ignored.
+        /// </summary>
+        /// <remarks>
+        /// A setting of <c>0</c> and a setting of <c>null</c> are <b>not</b> the same thing.
+        /// <list type="table">
+        /// <item>
+        /// <term><c>null</c></term>
+        /// <description>Use <see cref="GameData.StandardMinefieldDistance"/></description>
+        /// </item>
+        /// <item>
+        /// <term><c>0</c></term>
+        /// <description>Set the outer perimeter to 0</description>
+        /// </item>
+        /// </list>
+        /// </remarks>
+        public float? DistanceAroundObject { get; private set; }
+
+        /// <summary>
+        /// Whether the minefield should be generated when the object dies (e.g. with a cluster mine bomb).
+        /// </summary>
+        public bool GenerateOnlyOnDeath { get; private set; }
+
+        /// <summary>
+        /// Whether to set an inner perimeter based on the object's bounding box (or bounding sphere if <see cref="AlwaysCircular"/> is <c>true</c>).
+        /// If set to <c>false</c>, <see cref="DistanceAroundObject"/> is used as the inner perimeter.
+        /// </summary>
+        public bool SmartBorder { get; private set; }
+
+        /// <summary>
+        /// This seems to be whether <see cref="SmartBorder"/> should be used as an inner perimeter - if false, it is used as an outer perimeter
+        /// (but can be overridden by <see cref="DistanceAroundObject"/>).
+        /// </summary>
+        /// <remarks>
+        /// When set to <c>false</c> for a building with only <see cref="SmartBorder"/> and no <see cref="DistanceAroundObject"/>, no mines spawned.
+        /// This seems to be because the game builds a grid of mine locations, and then doesn't place any in places where there are existing structures.
+        /// </remarks>
+        public bool SmartBorderSkipInterior { get; private set; } = true;
+
+        /// <summary>
+        /// Whether the mines should form a ring or a box around the generating object.
+        /// </summary>
+        public bool AlwaysCircular { get; private set; }
+
+        /// <summary>
+        /// FX to play upon generation.
+        /// </summary>
+        public LazyAssetReference<FXList>? GenerationFX { get; private set; } // used for e.g. cluster mines, but not China structure mines
+
+        /// <summary>
+        /// Whether the mines can be upgraded to a new mine type.
+        /// </summary>
         [AddedIn(SageGame.CncGeneralsZeroHour)]
         public bool Upgradable { get; private set; }
 
+        /// <summary>
+        /// The upgrade which triggers the mines to be replaced with <see cref="UpgradedMineName"/>.
+        /// </summary>
         [AddedIn(SageGame.CncGeneralsZeroHour)]
-        public string UpgradedTriggeredBy { get; private set; }
+        public LazyAssetReference<UpgradeTemplate>? UpgradedTriggeredBy { get; private set; }
 
+        /// <summary>
+        /// The template with which to replace the existing mines upon <see cref="UpgradedTriggeredBy"/>.
+        /// </summary>
         [AddedIn(SageGame.CncGeneralsZeroHour)]
-        public string UpgradedMineName { get; private set; }
+        public LazyAssetReference<ObjectDefinition>? UpgradedMineName { get; private set; }
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new GenerateMinefieldBehavior(this);
+            return new GenerateMinefieldBehavior(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -1224,7 +1224,7 @@ namespace OpenSage.Logic.Object
 
             var upgradeModuleCanUpgrade = false;
             var hasUpgradeBehaviors = false; // some objects don't have upgrade modules
-            foreach (var upgradeModule in FindBehaviors<UpgradeModule>())
+            foreach (var upgradeModule in FindBehaviors<IUpgradeableModule>())
             {
                 hasUpgradeBehaviors = true;
                 if (upgradeModule.CanUpgrade(existingUpgrades))

--- a/src/OpenSage.Game/Logic/OrderGenerators/UnitOrderGenerator.cs
+++ b/src/OpenSage.Game/Logic/OrderGenerators/UnitOrderGenerator.cs
@@ -338,15 +338,7 @@ namespace OpenSage.Logic.OrderGenerators
 
         private bool TerrainUnderTargetIsImpassable()
         {
-            var mapCoords = Game.Scene3D.Terrain.HeightMap.GetTilePosition(WorldPosition);
-            if (!mapCoords.HasValue)
-            {
-                // we're outside of the map, so definitely impassable
-                return true;
-            }
-
-            var (x, y) = mapCoords.Value;
-            return Game.Scene3D.Terrain.Map.BlendTileData.Impassability[x, y];
+            return Game.Scene3D.Terrain.ImpassableAt(WorldPosition);
         }
 
         private bool AnySelectedUnitCanTraverseCliffs()

--- a/src/OpenSage.Game/StatePersister.cs
+++ b/src/OpenSage.Game/StatePersister.cs
@@ -367,6 +367,7 @@ namespace OpenSage
         public override void LogToSegmentEnd()
         {
             var segment = Segments.Pop();
+            Console.WriteLine(segment.Name);
             for (var i = _binaryReader.BaseStream.Position; i < segment.End; i++)
             {
                 Console.Write(_binaryReader.ReadByte().ToString("x2"));

--- a/src/OpenSage.Game/Terrain/Terrain.cs
+++ b/src/OpenSage.Game/Terrain/Terrain.cs
@@ -188,6 +188,19 @@ namespace OpenSage.Terrain
             return result;
         }
 
+        public bool ImpassableAt(Vector3 worldPosition)
+        {
+            var mapCoords = HeightMap.GetTilePosition(worldPosition);
+            if (!mapCoords.HasValue)
+            {
+                // we're outside of the map, so definitely impassable
+                return true;
+            }
+
+            var (x, y) = mapCoords.Value;
+            return Map.BlendTileData.Impassability[x, y];
+        }
+
         /// <summary>
         /// Adjusts the terrain height within the specified collider. Does not consider z-axis.
         /// </summary>


### PR DESCRIPTION
This still doesn't handle certain things such as generating rectangular minefields or the ability to upgrade minefields.

#968

![OpenSage Launcher_IXdqDSIFen](https://github.com/user-attachments/assets/2d869fb3-237a-437a-9d6b-6fc94411015f)
Demonstrating different packing depending on the unit type:
![OpenSage Launcher_E24NP9SrKq](https://github.com/user-attachments/assets/e4e66010-4585-406c-9224-f147dff6b2e4)
