### PR TITLE
Improve .sav file parsing

### DIFF
--- a/src/OpenSage.Game/Logic/AI/AIPlayer.cs
+++ b/src/OpenSage.Game/Logic/AI/AIPlayer.cs
@@ -14,8 +14,8 @@ namespace OpenSage.Logic.AI
         private bool _unknownBool2;
         private uint _unknownInt1;
         private int _unknownInt2;
-        private uint _unknownInt3;
-        private uint _unknownInt4;
+        private uint _countdownSomething1;
+        private uint _countdownSomething2;
         private uint _unknownObjectId;
         private uint _unknownInt5;
         private uint _unknownInt6;
@@ -71,8 +71,8 @@ namespace OpenSage.Logic.AI
                 throw new InvalidStateException();
             }
 
-            reader.PersistUInt32(ref _unknownInt3); // 50, 51, 8, 35
-            reader.PersistUInt32(ref _unknownInt4); // 0, 50
+            reader.PersistUInt32(ref _countdownSomething1); // Decrements by 1 each logic frame. When it reaches 0, it resets to 60.
+            reader.PersistUInt32(ref _countdownSomething2); // Decrements by 1 each logic frame. When it reaches 0, it resets to 150.
 
             var unknown6 = 10u;
             reader.PersistUInt32(ref unknown6);

--- a/src/OpenSage.Game/Logic/AI/AIStates/MoveTowardsState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/MoveTowardsState.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using OpenSage.Logic.Object;
 
 namespace OpenSage.Logic.AI.AIStates
 {
@@ -8,7 +9,7 @@ namespace OpenSage.Logic.AI.AIStates
         private uint _unknownInt1;
         private bool _unknownBool1;
         private Vector3 _unknownPosition2;
-        private uint _unknownInt2;
+        private LogicFrame _unknownFrame;
         private uint _unknownInt3;
         private bool _unknownBool2;
 
@@ -18,9 +19,9 @@ namespace OpenSage.Logic.AI.AIStates
 
             reader.PersistVector3(ref _targetPosition);
             reader.PersistUInt32(ref _unknownInt1);
-            reader.PersistBoolean(ref _unknownBool1);
-            reader.PersistVector3(ref _unknownPosition2);
-            reader.PersistUInt32(ref _unknownInt2);
+            reader.PersistBoolean(ref _unknownBool1); // True until frame after path is ready in AIUpdate, then it's false
+            reader.PersistVector3(ref _unknownPosition2); // Empty until frame after path is ready in AIUpdate, then it's the original path destination (original because the one in _targetPosition will have been modified to be at the centre of a terrain cell)
+            reader.PersistLogicFrame(ref _unknownFrame); // 0 until frame X after path is ready in AIUpdate, then it's frame X
             reader.PersistUInt32(ref _unknownInt3);
             reader.PersistBoolean(ref _unknownBool2);
         }

--- a/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
@@ -30,6 +30,7 @@ namespace OpenSage.Logic.Object
         private bool _hasNoFirePoints;
         private readonly List<QueuedForEvac> _evacQueue = new();
         private int _unknownInt;
+        private bool _passengersAllowedToFire;
 
         public virtual IList<uint> ContainedObjectIds => _containedObjectIds;
         public bool DrawPips => _moduleData.ShouldDrawPips;
@@ -255,7 +256,7 @@ namespace OpenSage.Logic.Object
 
             if (version >= 2)
             {
-                reader.SkipUnknownBytes(1);
+                reader.PersistBoolean(ref _passengersAllowedToFire);
             }
         }
 

--- a/src/OpenSage.Game/Logic/Object/Locomotor.cs
+++ b/src/OpenSage.Game/Logic/Object/Locomotor.cs
@@ -372,7 +372,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(2);
 
-            reader.PersistFrame(ref _frameSomething);
+            reader.PersistFrame(ref _frameSomething); // Equal to CurrentFrame + 75
             reader.PersistVector3(ref _positionSomething);
             reader.PersistSingle(ref _unknownFloat1);
 

--- a/src/OpenSage.Game/Logic/Object/ObjectCreationList.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectCreationList.cs
@@ -152,11 +152,12 @@ namespace OpenSage.Logic.Object
 
             if (Disposition.Get(ObjectDisposition.SendItFlying))
             {
+                var forceMultiplier = 200 / 30.0f * Mass; // TODO: Is this right?
                 physicsBehavior.AddForce(
                     new Vector3(
-                        ((float) context.GameContext.Random.NextDouble() - 0.5f) * DispositionIntensity * 200,
-                        ((float) context.GameContext.Random.NextDouble() - 0.5f) * DispositionIntensity * 200,
-                        DispositionIntensity * 200));
+                        ((float) context.GameContext.Random.NextDouble() - 0.5f) * DispositionIntensity * forceMultiplier,
+                        ((float) context.GameContext.Random.NextDouble() - 0.5f) * DispositionIntensity * forceMultiplier,
+                        DispositionIntensity * forceMultiplier));
             }
 
             // TODO: Count, Disposition, DispositionIntensity

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -55,7 +55,7 @@ namespace OpenSage.Logic.Object
         private uint _unknownInt14;
         private bool _unknownBool7;
         private uint _unknownInt15;
-        private bool _unknownBool8;
+        private bool _pathSomething;
         private PathfindingPath _path;
         private uint _unknownInt16;
         private Vector3 _unknownPosition1;
@@ -346,7 +346,7 @@ namespace OpenSage.Logic.Object
                 throw new InvalidStateException();
             }
 
-            reader.PersistBoolean(ref _unknownBool8);
+            reader.PersistBoolean(ref _pathSomething); // This is true on the frame that a unit is moved, and then false on the frame that a path is present
 
             var hasPath = _path != null;
             reader.PersistBoolean(ref hasPath);
@@ -403,7 +403,7 @@ namespace OpenSage.Logic.Object
                 throw new InvalidStateException();
             }
 
-            reader.PersistUInt32(ref _unknownInt18); // 0, 1
+            reader.PersistUInt32(ref _unknownInt18); // 0 when unit stationary, 1 when moving
             reader.PersistVector3(ref _unknownPosition3);
 
             if (_moduleData.Turret != null)
@@ -560,7 +560,6 @@ namespace OpenSage.Logic.Object
     {
         private readonly List<PathPoint> _points = new();
         private bool _unknownBool1;
-        private uint _unknownInt1;
         private uint _unknownInt2;
         private bool _unknownBool2;
 
@@ -576,7 +575,7 @@ namespace OpenSage.Logic.Object
                 });
 
             reader.PersistBoolean(ref _unknownBool1);
-            reader.PersistUInt32(ref _unknownInt1);
+            reader.SkipUnknownBytes(4);
             reader.PersistUInt32(ref _unknownInt2); // 1
             reader.PersistBoolean(ref _unknownBool2);
         }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAndWorkerState.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAndWorkerState.cs
@@ -219,7 +219,7 @@ internal sealed class DozerAndWorkerState
 
         private sealed class WorkerUnknown0State : State
         {
-            private int _unknown1;
+            private LogicFrame _unknown1;
             private int _unknown2;
             private bool _unknown3;
 
@@ -227,7 +227,7 @@ internal sealed class DozerAndWorkerState
             {
                 reader.PersistVersion(1);
 
-                reader.PersistInt32(ref _unknown1);
+                reader.PersistLogicFrame(ref _unknown1);
                 reader.PersistInt32(ref _unknown2);
                 reader.PersistBoolean(ref _unknown3);
             }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TransportAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TransportAIUpdate.cs
@@ -13,7 +13,9 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
+            reader.BeginObject("Base");
             base.Load(reader);
+            reader.EndObject();
         }
     }
 

--- a/src/OpenSage.Game/Scripting/ScriptingSystem.cs
+++ b/src/OpenSage.Game/Scripting/ScriptingSystem.cs
@@ -35,6 +35,7 @@ namespace OpenSage.Scripting
         private readonly ScienceSet[] _sciences;
         private readonly float[] _unknownFloats = new float[6];
         private uint _unknown17;
+        private bool _timeFrozen;
         private readonly List<MapReveal> _mapReveals = new();
         private readonly List<ObjectTypeList> _objectTypeLists = new();
         private string _musicTrackName;
@@ -439,7 +440,7 @@ namespace OpenSage.Scripting
                 throw new InvalidStateException();
             }
 
-            reader.SkipUnknownBytes(1);
+            reader.PersistBoolean(ref _timeFrozen);
 
             reader.PersistList(
                 _mapReveals,

--- a/src/OpenSage.Game/StatePersister.cs
+++ b/src/OpenSage.Game/StatePersister.cs
@@ -286,7 +286,7 @@ namespace OpenSage
 
         public override void PersistUInt32Value(ref uint value) => value = _binaryReader.ReadUInt32();
 
-        public override void PersistBooleanValue(ref bool value) => value = _binaryReader.ReadBoolean();
+        public override void PersistBooleanValue(ref bool value) => value = _binaryReader.ReadBooleanChecked();
 
         public override void PersistAsciiStringValue(ref string value) => value = _binaryReader.ReadBytePrefixedAsciiString();
 


### PR DESCRIPTION
This PR has a few tweaks for parsing `.sav` files, including giving names to a few more fields related to pathing and physics. I used a test map with a single Humvee, and a script that moved that Humvee only in the X direction, to work this out.