### PR TITLE
Implement CreateCrateDie

### DIFF
--- a/src/OpenSage.Game/Logic/CrateData.cs
+++ b/src/OpenSage.Game/Logic/CrateData.cs
@@ -1,6 +1,10 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+
+using System.Collections.Generic;
+using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.Logic.Object;
+using OpenSage.Mathematics;
 
 namespace OpenSage.Logic
 {
@@ -17,19 +21,41 @@ namespace OpenSage.Logic
         {
             { "CreationChance", (parser, x) => x.CreationChance = parser.ParseFloat() },
             { "KilledByType", (parser, x) => x.KilledByType = parser.ParseEnum<ObjectKinds>() },
-            { "KillerScience", (parser, x) => x.KillerScience = parser.ParseAssetReference() },
+            { "KillerScience", (parser, x) => x.KillerScience = parser.ParseScienceReference() },
             { "VeterancyLevel", (parser, x) => x.VeterancyLevel = parser.ParseEnum<VeterancyLevel>() },
             { "OwnedByMaker", (parser, x) => x.OwnedByMaker = parser.ParseBoolean() },
             { "CrateObject", (parser, x) => x.CrateObjects.Add(CrateObject.Parse(parser)) },
         };
 
+        /// <summary>
+        /// Chance of a crate being created.
+        /// </summary>
         public float CreationChance { get; private set; }
+
+        /// <summary>
+        /// <see cref="ObjectKinds"/> required by the killer in order to create the crate.
+        /// </summary>
         public ObjectKinds? KilledByType { get; private set; }
-        public string KillerScience { get; private set; }
+
+        /// <summary>
+        /// Science required by the killer in order to create the crate.
+        /// </summary>
+        public LazyAssetReference<Science>? KillerScience { get; private set; }
+
+        /// <summary>
+        /// The <b>victim</b> must have this veterancy level in order to generate the crate.
+        /// </summary>
         public VeterancyLevel? VeterancyLevel { get; private set; }
+
+        /// <summary>
+        /// Used "to have the Crate assigned to the default team of the dead guy's player for scripting."
+        /// </summary>
         public bool OwnedByMaker { get; private set; }
 
-        public List<CrateObject> CrateObjects { get; } = new List<CrateObject>();
+        /// <summary>
+        /// Different crates which may be created if all conditions succeed.
+        /// </summary>
+        public List<CrateObject> CrateObjects { get; } = [];
     }
 
     public enum VeterancyLevel
@@ -44,21 +70,14 @@ namespace OpenSage.Logic
         Elite,
 
         [IniEnum("HEROIC")]
-        Heroic
+        Heroic,
     }
 
-    public sealed class CrateObject
+    public readonly record struct CrateObject(LazyAssetReference<ObjectDefinition>? Object, float Probability)
     {
         internal static CrateObject Parse(IniParser parser)
         {
-            return new CrateObject
-            {
-                ObjectName = parser.ParseAssetReference(),
-                Probability = parser.ParseFloat()
-            };
+            return new CrateObject(parser.ParseObjectReference(), parser.ParseFloat());
         }
-
-        public string ObjectName { get; private set; }
-        public float Probability { get; private set; }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
+++ b/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
@@ -98,6 +98,11 @@ namespace OpenSage.Logic.Object
         {
             return left.Value >= right.Value;
         }
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
     }
 
     public readonly struct LogicFrameSpan

--- a/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
@@ -1,13 +1,79 @@
-﻿using OpenSage.Content;
+﻿#nullable enable
+
+using OpenSage.Content;
 using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
     public sealed class CreateCrateDie : DieModule
     {
-        // TODO
-        public CreateCrateDie(CreateCrateDieModuleData moduleData) : base(moduleData)
+        private readonly GameObject _gameObject;
+        private readonly GameContext _context;
+        private readonly CreateCrateDieModuleData _moduleData;
+
+        internal CreateCrateDie(GameObject gameObject, GameContext context, CreateCrateDieModuleData moduleData) : base(moduleData)
         {
+            _gameObject = gameObject;
+            _context = context;
+            _moduleData = moduleData;
+        }
+
+        private protected override void Die(BehaviorUpdateContext context, DeathType deathType)
+        {
+            var crateData = _moduleData.CrateData.Value;
+
+            if (_gameObject.TryGetLastDamage(out var lastDamageData))
+            {
+                var killer = _context.GameObjects.GetObjectById(lastDamageData.Request.DamageDealer);
+
+                if (KillerCanSpawnCrate(killer, crateData))
+                {
+                    if (_context.Random.NextSingle() < crateData.CreationChance)
+                    {
+                        // actually create the crate
+                        float totalProbability = 0;
+                        var selection = _context.Random.NextSingle();
+                        foreach (var crate in crateData.CrateObjects)
+                        {
+                            totalProbability += crate.Probability;
+                            if (totalProbability > selection)
+                            {
+                                SpawnCrate(crate, crateData);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            base.Die(context, deathType);
+        }
+
+        private bool KillerCanSpawnCrate(GameObject? killer, CrateData crateData)
+        {
+            if (killer is null)
+            {
+                return crateData.VeterancyLevel is null && crateData.KillerScience is null; // if we don't need to match veterancy or killer science, everything else passes by default
+            }
+
+            return (!crateData.KilledByType.HasValue || killer.Definition.KindOf.Get(crateData.KilledByType.Value)) && // killer type ok
+                   killer.Team != _gameObject.Team && // we can't generate our own salvage
+                   (crateData.VeterancyLevel is not { } v || v != _gameObject.VeterancyHelper.VeterancyLevel) && // killer meets veterancy requirements
+                   (crateData.KillerScience is null || killer.Owner.HasScience(crateData.KillerScience.Value)); // killer owner meets science requirements
+        }
+
+        private void SpawnCrate(CrateObject crate, CrateData crateData)
+        {
+            if (crate.Object is not null)
+            {
+                var newCrate = _context.GameLogic.CreateObject(crate.Object.Value, _gameObject.Owner);
+                newCrate.SetTransformMatrix(_gameObject.TransformMatrix);
+
+                if (crateData.OwnedByMaker)
+                {
+                    newCrate.Team = _gameObject.Team;
+                }
+            }
         }
 
         internal override void Load(StatePersister reader)
@@ -34,7 +100,7 @@ namespace OpenSage.Logic.Object
 
         internal override CreateCrateDie CreateModule(GameObject gameObject, GameContext context)
         {
-            return new CreateCrateDie(this);
+            return new CreateCrateDie(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
@@ -53,7 +53,7 @@ namespace OpenSage.Logic.Object
         {
             if (killer is null)
             {
-                return crateData.VeterancyLevel is null && crateData.KillerScience is null; // if we don't need to match veterancy or killer science, everything else passes by default
+                return crateData.KillerScience is null; // if we don't need to match killer science, everything else passes by default
             }
 
             return (!crateData.KilledByType.HasValue || killer.Definition.KindOf.Get(crateData.KilledByType.Value)) && // killer type ok

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -21,6 +21,7 @@ using FixedMath.NET;
 using OpenSage.Diagnostics.Util;
 using OpenSage.Terrain;
 using OpenSage.FileFormats;
+using OpenSage.Logic.Object.Damage;
 
 namespace OpenSage.Logic.Object
 {
@@ -277,6 +278,18 @@ namespace OpenSage.Logic.Object
         private readonly BodyModule _body;
         public bool HasActiveBody() => _body is ActiveBody;
 
+        public bool TryGetLastDamage(out DamageData damageData)
+        {
+            damageData = default;
+            if (_body is ActiveBody b)
+            {
+                damageData = b.LastDamage;
+                return true;
+            }
+
+            return false;
+        }
+
         public Fix64 Health
         {
             get => _body?.Health ?? Fix64.Zero;
@@ -368,7 +381,7 @@ namespace OpenSage.Logic.Object
 
         public TeamTemplate TeamTemplate { get; set; }
 
-        public Team Team { get; private set; }
+        public Team Team { get; internal set; }
 
         public bool IsSelectable;
         public bool IsProjectile { get; private set; } = false;
@@ -770,9 +783,9 @@ namespace OpenSage.Logic.Object
             CheckDisabledStates();
             foreach (var behavior in _behaviorModules)
             {
-                if (IsDead && behavior is not SlowDeathBehavior and not LifetimeUpdate)
+                if (IsDead && behavior is not SlowDeathBehavior and not LifetimeUpdate and not DeletionUpdate)
                 {
-                    continue; // if we're dead, we should only update SlowDeathBehavior or LifetimeUpdate
+                    continue; // if we're dead, we should only update SlowDeathBehavior, LifetimeUpdate, or DeletionUpdate
                 }
                 behavior.Update(_behaviorUpdateContext);
             }

--- a/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ImGuiNET;
 using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
@@ -16,6 +17,7 @@ namespace OpenSage.Logic.Object
             _moduleData = moduleData;
 
             _frameToDelete = gameObject.GameContext.GameLogic.CurrentFrame + gameObject.GameContext.GetRandomLogicFrameSpan(_moduleData.MinLifetime, _moduleData.MaxLifetime);
+            NextUpdateFrame = new UpdateFrame(_frameToDelete);
         }
 
         internal override void Update(BehaviorUpdateContext context)
@@ -33,6 +35,12 @@ namespace OpenSage.Logic.Object
             base.Load(reader);
 
             reader.PersistLogicFrame(ref _frameToDelete);
+        }
+
+        internal override void DrawInspector()
+        {
+            base.DrawInspector();
+            ImGui.LabelText("Frame to delete", _frameToDelete.ToString());
         }
     }
 


### PR DESCRIPTION
Fixes #975

Creating a crate would normally be disabled with a null killer, but I've disabled that check for these tests. Additionally, the crate normally wouldn't be visible for a non-GLA player, but that hasn't been implemented yet.

Changes also needed to be made to run DeletionUpdate for "dead" objects, so that crates are deleted per their behavior definition.

![OpenSage Launcher_Aw06lqjCL6](https://github.com/user-attachments/assets/e9dac29f-7fbb-473e-b781-3cd842411e35)
