### PR TITLE
Add W3dScienceModelDraw

### DIFF
--- a/src/OpenSage.Game/Logic/Object/Draw/W3dScienceModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dScienceModelDraw.cs
@@ -1,20 +1,40 @@
-﻿using OpenSage.Client;
+﻿#nullable enable
+
+using OpenSage.Client;
+using OpenSage.Content;
 using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
     public sealed class W3dScienceModelDraw : W3dModelDraw
     {
+        private readonly W3dScienceModelDrawModuleData _data;
+        private readonly Drawable _drawable;
+        private readonly GameContext _context;
+
         internal W3dScienceModelDraw(W3dScienceModelDrawModuleData data, Drawable drawable, GameContext context)
             : base(data, drawable, context)
         {
+            _data = data;
+            _drawable = drawable;
+            _context = context;
         }
 
         internal override void Load(StatePersister reader)
         {
             reader.PersistVersion(1);
 
+            reader.BeginObject("Base");
             base.Load(reader);
+            reader.EndObject();
+        }
+
+        internal override void Update(in TimeInterval gameTime)
+        {
+            if (_data.RequiredScience is null || _context.Game.PlayerManager.LocalPlayer.HasScience(_data.RequiredScience.Value))
+            {
+                base.Update(in gameTime);
+            }
         }
     }
 
@@ -25,10 +45,10 @@ namespace OpenSage.Logic.Object
         private static new readonly IniParseTable<W3dScienceModelDrawModuleData> FieldParseTable = W3dModelDrawModuleData.FieldParseTable
             .Concat(new IniParseTable<W3dScienceModelDrawModuleData>
             {
-                { "RequiredScience", (parser, x) => x.RequiredScience = parser.ParseAssetReference() }
+                { "RequiredScience", (parser, x) => x.RequiredScience = parser.ParseScienceReference() }
             });
 
-        public string RequiredScience { get; private set; }
+        public LazyAssetReference<Science>? RequiredScience { get; private set; }
 
         internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
         {


### PR DESCRIPTION
Not sure if this is the right way to do this, but it does work.

This is only used by Salvage Crates in Generals, so that only GLA players see them. As implemented salvage crates are still generated as expected in CreateCrateDie (see #976) but are not displayed for non-GLA players.

It's also unclear how this works for observers, since an observer (who doesn't have their view set to a non-GLA player) should be able to see them too, but observers are probably a deep in the future problem.