### PR TITLE
Remove instances of calling through GameObject to access GameContext

### DIFF
--- a/src/OpenSage.Game/Logic/AI/AIStates/HackInternetState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/HackInternetState.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Numerics;
+using OpenSage.Audio;
 using OpenSage.Logic.Object;
 using OpenSage.Mathematics;
 
@@ -10,14 +11,16 @@ namespace OpenSage.Logic.AI.AIStates
         public const uint StateId = 1001;
 
         private readonly GameObject _gameObject;
+        private readonly AudioSystem _audioSystem;
 
         private LogicFrameSpan _framesUntilNextHack;
 
         private HackInternetAIUpdateModuleData ModuleData => ((HackInternetAIUpdate)_gameObject.AIUpdate).ModuleData;
 
-        public HackInternetState(GameObject gameObject)
+        public HackInternetState(GameObject gameObject, AudioSystem audioSystem)
         {
             _gameObject = gameObject;
+            _audioSystem = audioSystem;
         }
 
         public override void OnEnter()
@@ -35,7 +38,7 @@ namespace OpenSage.Logic.AI.AIStates
             {
                 SetFramesUntilNextHack();
 
-                _gameObject.GameContext.AudioSystem.PlayAudioEvent(_gameObject, _gameObject.Definition.UnitSpecificSounds.UnitCashPing?.Value);
+                _audioSystem.PlayAudioEvent(_gameObject, _gameObject.Definition.UnitSpecificSounds.UnitCashPing?.Value);
 
                 var amount = GetCashGrant();
 

--- a/src/OpenSage.Game/Logic/AI/AIStates/StartHackingInternetState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/StartHackingInternetState.cs
@@ -1,4 +1,5 @@
-﻿using OpenSage.Logic.Object;
+﻿using OpenSage.Audio;
+using OpenSage.Logic.Object;
 
 namespace OpenSage.Logic.AI.AIStates
 {
@@ -7,12 +8,14 @@ namespace OpenSage.Logic.AI.AIStates
         public const uint StateId = 1000;
 
         private readonly GameObject _gameObject;
+        private readonly AudioSystem _audioSystem;
 
         private LogicFrameSpan _framesUntilHackingBegins;
 
-        public StartHackingInternetState(GameObject gameObject)
+        public StartHackingInternetState(GameObject gameObject, AudioSystem audioSystem)
         {
             _gameObject = gameObject;
+            _audioSystem = audioSystem;
         }
 
         public override void OnEnter()
@@ -21,7 +24,7 @@ namespace OpenSage.Logic.AI.AIStates
             _gameObject.ModelConditionFlags.Set(ModelConditionFlag.FiringA, false);
             _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Packing, false);
 
-            _gameObject.GameContext.AudioSystem.PlayAudioEvent(_gameObject, _gameObject.Definition.UnitSpecificSounds.UnitUnpack?.Value);
+            _audioSystem.PlayAudioEvent(_gameObject, _gameObject.Definition.UnitSpecificSounds.UnitUnpack?.Value);
 
             var aiUpdate = (HackInternetAIUpdate)_gameObject.AIUpdate;
 

--- a/src/OpenSage.Game/Logic/AI/AIStates/StopHackingInternetState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/StopHackingInternetState.cs
@@ -1,4 +1,5 @@
-﻿using OpenSage.Logic.Object;
+﻿using OpenSage.Audio;
+using OpenSage.Logic.Object;
 
 namespace OpenSage.Logic.AI.AIStates
 {
@@ -7,12 +8,14 @@ namespace OpenSage.Logic.AI.AIStates
         public const uint StateId = 1002;
 
         private readonly GameObject _gameObject;
+        private readonly AudioSystem _audioSystem;
 
         private LogicFrameSpan _framesUntilFinishedPacking;
 
-        public StopHackingInternetState(GameObject gameObject)
+        public StopHackingInternetState(GameObject gameObject, AudioSystem audioSystem)
         {
             _gameObject = gameObject;
+            _audioSystem = audioSystem;
         }
 
         public override void OnEnter()
@@ -21,7 +24,7 @@ namespace OpenSage.Logic.AI.AIStates
             _gameObject.ModelConditionFlags.Set(ModelConditionFlag.FiringA, false);
             _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Packing, true);
 
-            _gameObject.GameContext.AudioSystem.PlayAudioEvent(_gameObject, _gameObject.Definition.UnitSpecificSounds.UnitPack?.Value);
+            _audioSystem.PlayAudioEvent(_gameObject, _gameObject.Definition.UnitSpecificSounds.UnitPack?.Value);
 
             var aiUpdate = (HackInternetAIUpdate)_gameObject.AIUpdate;
 

--- a/src/OpenSage.Game/Logic/AI/AIUpdateStateMachine.cs
+++ b/src/OpenSage.Game/Logic/AI/AIUpdateStateMachine.cs
@@ -7,6 +7,8 @@ namespace OpenSage.Logic.AI
 {
     internal class AIUpdateStateMachine : StateMachineBase
     {
+        private readonly GameObject _gameObject;
+        private readonly GameContext _context;
         private readonly List<Vector3> _targetPositions = new();
         private string _targetWaypointName;
         private TargetTeam _targetTeam;
@@ -14,8 +16,11 @@ namespace OpenSage.Logic.AI
         private State _overrideState;
         private LogicFrame _overrideStateUntilFrame;
 
-        public AIUpdateStateMachine(GameObject gameObject)
+        public AIUpdateStateMachine(GameObject gameObject, GameContext context)
         {
+            _gameObject = gameObject;
+            _context = context;
+
             AddState(IdleState.StateId, new IdleState());
             AddState(1, new MoveTowardsState());
             AddState(2, new FollowWaypointsState(true));
@@ -54,7 +59,7 @@ namespace OpenSage.Logic.AI
             {
                 var overrideStateResult = _overrideState.Update();
 
-                var currentFrame = GameObject.GameContext.GameLogic.CurrentFrame;
+                var currentFrame = _context.GameLogic.CurrentFrame;
 
                 var shouldContinueOverrideState = overrideStateResult.Type switch
                 {

--- a/src/OpenSage.Game/Logic/ModifierList.cs
+++ b/src/OpenSage.Game/Logic/ModifierList.cs
@@ -30,7 +30,7 @@ namespace OpenSage.Logic
             _delayedUpgrades = new List<(UpgradeTemplate, TimeSpan)>();
         }
 
-        public void Apply(GameObject gameObject, in TimeInterval time)
+        public void Apply(GameObject gameObject, GameContext context, in TimeInterval time)
         {
             if (_selfExpiring)
             {
@@ -68,9 +68,9 @@ namespace OpenSage.Logic
                 }
             }
 
-            TriggerFX(_modifierList.FX, gameObject);
-            TriggerFX(_modifierList.FX2, gameObject);
-            TriggerFX(_modifierList.FX3, gameObject);
+            TriggerFX(_modifierList.FX, gameObject, context);
+            TriggerFX(_modifierList.FX2, gameObject, context);
+            TriggerFX(_modifierList.FX3, gameObject, context);
 
             Applied = true;
         }
@@ -98,7 +98,7 @@ namespace OpenSage.Logic
             }
         }
 
-        public void Remove(GameObject gameObject)
+        public void Remove(GameObject gameObject, GameContext context)
         {
             foreach (var modifier in _modifierList.Modifiers)
             {
@@ -122,17 +122,17 @@ namespace OpenSage.Logic
                 }
             }
 
-            TriggerFX(_modifierList.EndFX, gameObject);
-            TriggerFX(_modifierList.EndFX2, gameObject);
-            TriggerFX(_modifierList.EndFX3, gameObject);
+            TriggerFX(_modifierList.EndFX, gameObject, context);
+            TriggerFX(_modifierList.EndFX2, gameObject, context);
+            TriggerFX(_modifierList.EndFX3, gameObject, context);
         }
 
-        private void TriggerFX(LazyAssetReference<FXList> fx, GameObject gameObject)
+        private void TriggerFX(LazyAssetReference<FXList> fx, GameObject gameObject, GameContext context)
         {
             fx?.Value?.Execute(new FXListExecutionContext(
                     gameObject.Rotation,
                     gameObject.Translation,
-                    gameObject.GameContext));
+                    context));
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/AutoHealBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/AutoHealBehavior.cs
@@ -11,6 +11,7 @@ namespace OpenSage.Logic.Object
         protected override LogicFrameSpan FramesBetweenUpdates => _moduleData.HealingDelay;
 
         private readonly GameObject _gameObject;
+        private readonly GameContext _context;
         private readonly AutoHealBehaviorModuleData _moduleData;
         private readonly UpgradeLogic _upgradeLogic;
         /// <summary>
@@ -18,9 +19,10 @@ namespace OpenSage.Logic.Object
         /// </summary>
         private LogicFrame _endOfStartHealingDelay;
 
-        public AutoHealBehavior(GameObject gameObject, AutoHealBehaviorModuleData moduleData)
+        public AutoHealBehavior(GameObject gameObject, GameContext context, AutoHealBehaviorModuleData moduleData)
         {
             _gameObject = gameObject;
+            _context = context;
             _moduleData = moduleData;
             NextUpdateFrame.Frame = uint.MaxValue;
             _upgradeLogic = new UpgradeLogic(moduleData.UpgradeData, OnUpgrade);
@@ -33,7 +35,7 @@ namespace OpenSage.Logic.Object
         private void OnUpgrade()
         {
             // todo: if unit is max health and this is a self-heal behavior, even if upgrade was triggered, nextupdateframe is still maxvalue
-            NextUpdateFrame.Frame = _gameObject.GameContext.GameLogic.CurrentFrame.Value;
+            NextUpdateFrame.Frame = _context.GameLogic.CurrentFrame.Value;
         }
 
         /// <summary>
@@ -45,7 +47,7 @@ namespace OpenSage.Logic.Object
             // make sure the upgrade is triggered before resetting any frames
             if (_moduleData.StartHealingDelay != LogicFrameSpan.Zero && _upgradeLogic.Triggered)
             {
-                var currentFrame = _gameObject.GameContext.GameLogic.CurrentFrame;
+                var currentFrame = _context.GameLogic.CurrentFrame;
                 _endOfStartHealingDelay = currentFrame + _moduleData.StartHealingDelay;
                 NextUpdateFrame = new UpdateFrame(_endOfStartHealingDelay);
             }
@@ -63,7 +65,7 @@ namespace OpenSage.Logic.Object
                 if (_moduleData.AffectsWholePlayer)
                 {
                     // USA hospital has this behavior
-                    foreach (var candidate in _gameObject.GameContext.GameLogic.Objects)
+                    foreach (var candidate in _context.GameLogic.Objects)
                     {
                         if (ObjectIsOwnedBySamePlayer(candidate) && CanHealUnit(candidate))
                         {
@@ -81,7 +83,7 @@ namespace OpenSage.Logic.Object
                 return;
             }
 
-            foreach (var candidate in _gameObject.GameContext.Quadtree.FindNearby(_gameObject, _gameObject.Transform, _moduleData.Radius))
+            foreach (var candidate in _context.Quadtree.FindNearby(_gameObject, _gameObject.Transform, _moduleData.Radius))
             {
                 if (_moduleData.SkipSelfForHealing && candidate == _gameObject) continue;
                 if (!CanHealUnit(candidate)) continue;
@@ -257,7 +259,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new AutoHealBehavior(gameObject, this);
+            return new AutoHealBehavior(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/GenerateMinefieldBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/GenerateMinefieldBehavior.cs
@@ -141,7 +141,7 @@ namespace OpenSage.Logic.Object
             // now that we know where to actually spawn the mines, spawn them
             foreach (var transform in newMineTransforms)
             {
-                var newMine = _gameObject.GameContext.GameLogic.CreateObject(mineTemplate, _gameObject.Owner);
+                var newMine = _context.GameLogic.CreateObject(mineTemplate, _gameObject.Owner);
                 newMine.UpdateTransform(transform.Translation, transform.Rotation);
                 newMine.CreatedByObjectID = _gameObject.ID;
                 _generatedMineIds.Add(newMine.ID);

--- a/src/OpenSage.Game/Logic/Object/Behaviors/InstantDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/InstantDeathBehavior.cs
@@ -8,11 +8,13 @@ namespace OpenSage.Logic.Object
     public sealed class InstantDeathBehavior : DieModule
     {
         private readonly GameObject _gameObject;
+        private readonly GameContext _context;
         private new InstantDeathBehaviorModuleData ModuleData { get; }
 
-        internal InstantDeathBehavior(GameObject gameObject, InstantDeathBehaviorModuleData moduleData) : base(moduleData)
+        internal InstantDeathBehavior(GameObject gameObject, GameContext context, InstantDeathBehaviorModuleData moduleData) : base(moduleData)
         {
             _gameObject = gameObject;
+            _context = context;
             ModuleData = moduleData;
         }
 
@@ -23,7 +25,7 @@ namespace OpenSage.Logic.Object
                 return;
             }
 
-            _gameObject.GameContext.GameLogic.DestroyObject(_gameObject);
+            _context.GameLogic.DestroyObject(_gameObject);
 
             Matrix4x4.Decompose(context.GameObject.TransformMatrix, out _, out var rotation, out var translation);
 
@@ -59,7 +61,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new InstantDeathBehavior(gameObject, this);
+            return new InstantDeathBehavior(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
@@ -8,13 +8,15 @@ namespace OpenSage.Logic.Object
     public sealed class OverchargeBehavior : UpdateModule
     {
         private readonly GameObject _gameObject;
+        private readonly GameContext _context;
         private readonly OverchargeBehaviorModuleData _moduleData;
         private bool _enabled;
         public bool Enabled => _enabled;
 
-        public OverchargeBehavior(GameObject gameObject, OverchargeBehaviorModuleData moduleData)
+        public OverchargeBehavior(GameObject gameObject, GameContext context, OverchargeBehaviorModuleData moduleData)
         {
             _gameObject = gameObject;
+            _context = context;
             _moduleData = moduleData;
         }
 
@@ -29,7 +31,7 @@ namespace OpenSage.Logic.Object
             }
 
             // todo: this is fine for now, but generals seems to have some way of making sure it doesn't immediately sap health on subsequent toggles
-            NextUpdateFrame.Frame = _gameObject.GameContext.GameLogic.CurrentFrame.Value;
+            NextUpdateFrame.Frame = _context.GameLogic.CurrentFrame.Value;
         }
 
         public void Deactivate()
@@ -102,7 +104,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new OverchargeBehavior(gameObject, this);
+            return new OverchargeBehavior(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
@@ -8,6 +8,7 @@ namespace OpenSage.Logic.Object
     public class PhysicsBehavior : UpdateModule
     {
         private readonly GameObject _gameObject;
+        private readonly GameContext _context;
         private readonly PhysicsBehaviorModuleData _moduleData;
         private readonly Vector3 _gravityAcceleration;
 
@@ -49,6 +50,7 @@ namespace OpenSage.Logic.Object
         internal PhysicsBehavior(GameObject gameObject, GameContext context, PhysicsBehaviorModuleData moduleData)
         {
             _gameObject = gameObject;
+            _context = context;
             _moduleData = moduleData;
 
             Mass = moduleData.Mass;
@@ -81,7 +83,7 @@ namespace OpenSage.Logic.Object
             // Integrate position.
             var newTranslation = _gameObject.Translation + _velocity;
 
-            var terrainHeight = _gameObject.GameContext.Game.TerrainLogic.HeightMap.GetHeight(
+            var terrainHeight = _context.Game.TerrainLogic.HeightMap.GetHeight(
                 newTranslation.X,
                 newTranslation.Y);
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PropagandaTowerBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PropagandaTowerBehavior.cs
@@ -12,6 +12,7 @@ namespace OpenSage.Logic.Object
         protected override LogicFrameSpan FramesBetweenUpdates => _moduleData.DelayBetweenUpdates;
 
         private readonly GameObject _gameObject;
+        private readonly GameContext _context;
         private readonly PropagandaTowerBehaviorModuleData _moduleData;
         private uint _unknownFrame;
         private readonly List<uint> _objectIds = new();
@@ -19,9 +20,10 @@ namespace OpenSage.Logic.Object
 
         private readonly BitArray<ObjectKinds> _allowedKinds = new();
 
-        public PropagandaTowerBehavior(GameObject gameObject, PropagandaTowerBehaviorModuleData moduleData)
+        public PropagandaTowerBehavior(GameObject gameObject, GameContext context, PropagandaTowerBehaviorModuleData moduleData)
         {
             _gameObject = gameObject;
+            _context = context;
             _moduleData = moduleData;
             _allowedKinds.Set(ObjectKinds.Infantry, true);
             _allowedKinds.Set(ObjectKinds.Vehicle, true);
@@ -50,7 +52,7 @@ namespace OpenSage.Logic.Object
 
             fx.Value.Execute(context);
 
-            foreach (var candidate in _gameObject.GameContext.Quadtree.FindNearby(_gameObject, _gameObject.Transform, _moduleData.Radius))
+            foreach (var candidate in _context.Quadtree.FindNearby(_gameObject, _gameObject.Transform, _moduleData.Radius))
             {
                 if (!_moduleData.AffectsSelf && candidate == _gameObject) continue;
                 if (!CanHealUnit(candidate)) continue;
@@ -61,7 +63,7 @@ namespace OpenSage.Logic.Object
 
         private GameObject GameObjectForId(uint unitId)
         {
-            return _gameObject.GameContext.GameLogic.GetObjectById(unitId);
+            return _context.GameLogic.GetObjectById(unitId);
         }
 
         private void HealUnit(GameObject gameObject)
@@ -170,7 +172,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new PropagandaTowerBehavior(gameObject, this);
+            return new PropagandaTowerBehavior(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
@@ -10,6 +10,7 @@ namespace OpenSage.Logic.Object
     internal sealed class SpawnBehavior : BehaviorModule
     {
         GameObject _gameObject;
+        private readonly GameContext _context;
         SpawnBehaviorModuleData _moduleData;
 
         private List<GameObject> _spawnedUnits;
@@ -30,6 +31,7 @@ namespace OpenSage.Logic.Object
         {
             _moduleData = moduleData;
             _gameObject = gameObject;
+            _context = context;
 
             _spawnedUnits = new List<GameObject>();
             _initial = true;
@@ -37,7 +39,7 @@ namespace OpenSage.Logic.Object
 
         private void SpawnUnit()
         {
-            var spawnedObject = _gameObject.GameContext.GameLogic.CreateObject(_moduleData.SpawnTemplate?.Value, _gameObject.Owner);
+            var spawnedObject = _context.GameLogic.CreateObject(_moduleData.SpawnTemplate?.Value, _gameObject.Owner);
             _spawnedUnits.Add(spawnedObject);
 
             spawnedObject.CreatedByObjectID = _gameObject.ID;

--- a/src/OpenSage.Game/Logic/Object/Body/ActiveBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/ActiveBody.cs
@@ -103,7 +103,7 @@ namespace OpenSage.Logic.Object
                     new FXListExecutionContext(
                         GameObject.Rotation,
                         GameObject.Translation,
-                        GameObject.GameContext));
+                        _context));
             }
 
             if (Health <= Fix64.Zero)

--- a/src/OpenSage.Game/Logic/Object/Collide/FireWeaponCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/FireWeaponCollide.cs
@@ -11,7 +11,7 @@ namespace OpenSage.Logic.Object
         private readonly Weapon _collideWeapon;
         private bool _unknown2;
 
-        internal FireWeaponCollide(GameObject gameObject, FireWeaponCollideModuleData moduleData)
+        internal FireWeaponCollide(GameObject gameObject, GameContext context, FireWeaponCollideModuleData moduleData)
         {
             _moduleData = moduleData;
 
@@ -19,7 +19,7 @@ namespace OpenSage.Logic.Object
                 gameObject,
                 moduleData.CollideWeapon.Value,
                 WeaponSlot.Primary,
-                gameObject.GameContext);
+                context);
         }
 
         internal override void Load(StatePersister reader)
@@ -51,7 +51,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new FireWeaponCollide(gameObject, this);
+            return new FireWeaponCollide(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Contain/HordeContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/HordeContain.cs
@@ -10,6 +10,7 @@ namespace OpenSage.Logic.Object
     public sealed class HordeContainBehavior : UpdateModule
     {
         private readonly GameObject _gameObject;
+        private readonly GameContext _context;
         private readonly HordeContainModuleData _moduleData;
 
         private Dictionary<int, List<HordeMemberPosition>> _formation;
@@ -18,10 +19,11 @@ namespace OpenSage.Logic.Object
         private ProductionUpdate _productionUpdate;
         private int _pendingRegistrations;
 
-        public HordeContainBehavior(GameObject gameObject, HordeContainModuleData moduleData)
+        public HordeContainBehavior(GameObject gameObject, GameContext context, HordeContainModuleData moduleData)
         {
             _moduleData = moduleData;
             _gameObject = gameObject;
+            _context = context;
 
             _payload = new List<GameObject>();
             _formation = CreateFormationOffsets();
@@ -64,7 +66,7 @@ namespace OpenSage.Logic.Object
             {
                 foreach (var position in rank)
                 {
-                    var createdObject = _gameObject.GameContext.GameLogic.CreateObject(position.Definition, _gameObject.Owner);
+                    var createdObject = _context.GameLogic.CreateObject(position.Definition, _gameObject.Owner);
                     createdObject.ParentHorde = _gameObject;
                     position.Object = createdObject;
                     _payload.Add(createdObject);
@@ -298,7 +300,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new HordeContainBehavior(gameObject, this);
+            return new HordeContainBehavior(gameObject, context, this);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
@@ -82,7 +82,7 @@ namespace OpenSage.Logic.Object
             unit.AddToContainer(GameObject.ID);
             if (!initial)
             {
-                GameObject.GameContext.AudioSystem.PlayAudioEvent(unit, GetEnterVoiceLine(unit.Definition.UnitSpecificSounds));
+                GameContext.AudioSystem.PlayAudioEvent(unit, GetEnterVoiceLine(unit.Definition.UnitSpecificSounds));
             }
         }
 
@@ -107,7 +107,7 @@ namespace OpenSage.Logic.Object
 
         public void Evacuate()
         {
-            GameObject.GameContext.AudioSystem.PlayAudioEvent(GameObject,
+            GameContext.AudioSystem.PlayAudioEvent(GameObject,
                 GameObject.Definition.UnitSpecificSounds.VoiceUnload?.Value);
             foreach (var id in ContainedObjectIds)
             {
@@ -179,7 +179,7 @@ namespace OpenSage.Logic.Object
             }
             else
             {
-                GameObject.GameContext.AudioSystem.PlayAudioEvent(GameObject.Definition.SoundExit?.Value);
+                GameContext.AudioSystem.PlayAudioEvent(GameObject.Definition.SoundExit?.Value);
             }
 
             unit.RemoveFromContainer();
@@ -197,7 +197,7 @@ namespace OpenSage.Logic.Object
 
         protected GameObject GameObjectForId(uint unitId)
         {
-            return GameObject.GameContext.GameLogic.GetObjectById(unitId);
+            return GameContext.GameLogic.GetObjectById(unitId);
         }
 
         internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
@@ -23,7 +23,7 @@ namespace OpenSage.Logic.Object
             {
                 for (var i = 0; i < payload.Count; i++)
                 {
-                    var unit = gameObject.GameContext.GameLogic.CreateObject(payload.Object.Value, gameObject.Owner);
+                    var unit = gameContext.GameLogic.CreateObject(payload.Object.Value, gameObject.Owner);
                     Add(unit, true);
                 }
             }
@@ -59,7 +59,7 @@ namespace OpenSage.Logic.Object
                     // testing with a humvee, evacuating individually, the units never use the same exit path
                     // using the evac command, two pairs of rangers will share an exit path, and the 5th ranger will use a 3rd exit path
                     // todo: this doesn't seem to be strictly random, but it's unclear how this works at the moment
-                    var pathToChoose = GameObject.GameContext.Random.Next(1, _moduleData.NumberOfExitPaths + 1);
+                    var pathToChoose = GameContext.Random.Next(1, _moduleData.NumberOfExitPaths + 1);
                     startBoneName = $"{startBoneName}{pathToChoose:00}";
                     endBoneName = $"{endBoneName}{pathToChoose:00}";
                 }

--- a/src/OpenSage.Game/Logic/Object/Create/SupplyCenterCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/SupplyCenterCreate.cs
@@ -5,15 +5,17 @@ namespace OpenSage.Logic.Object
     public sealed class SupplyCenterCreate : CreateModule, IDestroyModule
     {
         private readonly GameObject _gameObject;
+        private readonly GameContext _context;
 
-        public SupplyCenterCreate(GameObject gameObject)
+        public SupplyCenterCreate(GameObject gameObject, GameContext context)
         {
             _gameObject = gameObject;
+            _context = context;
         }
 
         protected override void OnBuildCompleteImpl()
         {
-            foreach (var player in _gameObject.GameContext.Scene3D.Players)
+            foreach (var player in _context.Scene3D.Players)
             {
                 player.SupplyManager.AddSupplyCenter(_gameObject);
             }
@@ -21,7 +23,7 @@ namespace OpenSage.Logic.Object
 
         public void OnDestroy()
         {
-            foreach (var player in _gameObject.GameContext.Scene3D.Players)
+            foreach (var player in _context.Scene3D.Players)
             {
                 player.SupplyManager.RemoveSupplyCenter(_gameObject);
             }
@@ -49,7 +51,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new SupplyCenterCreate(gameObject);
+            return new SupplyCenterCreate(gameObject, context);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Create/SupplyWarehouseCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/SupplyWarehouseCreate.cs
@@ -5,15 +5,17 @@ namespace OpenSage.Logic.Object
     public sealed class SupplyWarehouseCreate : CreateModule, IDestroyModule
     {
         private readonly GameObject _gameObject;
+        private readonly GameContext _context;
 
-        public SupplyWarehouseCreate(GameObject gameObject)
+        public SupplyWarehouseCreate(GameObject gameObject, GameContext context)
         {
             _gameObject = gameObject;
+            _context = context;
         }
 
         public override void OnCreate()
         {
-            foreach (var player in _gameObject.GameContext.Scene3D.Players)
+            foreach (var player in _context.Scene3D.Players)
             {
                 player.SupplyManager.AddSupplyWarehouse(_gameObject);
             }
@@ -21,7 +23,7 @@ namespace OpenSage.Logic.Object
 
         public void OnDestroy()
         {
-            foreach (var player in _gameObject.GameContext.Scene3D.Players)
+            foreach (var player in _context.Scene3D.Players)
             {
                 player.SupplyManager.RemoveSupplyWarehouse(_gameObject);
             }
@@ -48,7 +50,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new SupplyWarehouseCreate(gameObject);
+            return new SupplyWarehouseCreate(gameObject, context);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -20,6 +20,7 @@ namespace OpenSage.Logic.Object
         private readonly AIUpdateModuleData _moduleData;
 
         protected readonly GameObject GameObject;
+        protected GameContext Context { get; }
 
         private readonly TurretAIUpdate _turretAIUpdate;
 
@@ -83,9 +84,10 @@ namespace OpenSage.Logic.Object
         /// </summary>
         public List<Vector3> TargetPoints { get; set; }
 
-        internal AIUpdate(GameObject gameObject, AIUpdateModuleData moduleData)
+        internal AIUpdate(GameObject gameObject, GameContext context, AIUpdateModuleData moduleData)
         {
             GameObject = gameObject;
+            Context = context;
             _moduleData = moduleData;
 
             TargetPoints = new List<Vector3>();
@@ -103,7 +105,7 @@ namespace OpenSage.Logic.Object
             }
         }
 
-        private protected virtual AIUpdateStateMachine CreateStateMachine(GameObject gameObject) => new(gameObject);
+        private protected virtual AIUpdateStateMachine CreateStateMachine(GameObject gameObject) => new(gameObject, Context);
 
         internal void SetLocomotor(LocomotorSetType type)
         {
@@ -141,7 +143,7 @@ namespace OpenSage.Logic.Object
             if (!GameObject.Definition.KindOf.Get(ObjectKinds.Aircraft) && targetPoint != GameObject.Translation)
             {
                 var start = GameObject.Translation;
-                var path = GameObject.GameContext.Navigation.CalculatePath(start, targetPoint, out var endIsPassable);
+                var path = Context.Navigation.CalculatePath(start, targetPoint, out var endIsPassable);
                 if (path.Count > 0)
                 {
                     path.RemoveAt(0);
@@ -518,7 +520,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new AIUpdate(gameObject, this);
+            return new AIUpdate(gameObject, context, this);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AnimalAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AnimalAIUpdate.cs
@@ -8,7 +8,7 @@ namespace OpenSage.Logic.Object
     {
         private readonly AnimalAIUpdateModuleData _moduleData;
 
-        internal AnimalAIUpdate(GameObject gameObject, AnimalAIUpdateModuleData moduleData) : base(gameObject, moduleData)
+        internal AnimalAIUpdate(GameObject gameObject, GameContext context, AnimalAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
         {
             _moduleData = moduleData;
         }
@@ -41,7 +41,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new AnimalAIUpdate(gameObject, this); ;
+            return new AnimalAIUpdate(gameObject, context, this); ;
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cs
@@ -7,8 +7,8 @@ namespace OpenSage.Logic.Object
     {
         private readonly List<AssaultTransportMember> _members = new();
 
-        internal AssaultTransportAIUpdate(GameObject gameObject, AIUpdateModuleData moduleData)
-            : base(gameObject, moduleData)
+        internal AssaultTransportAIUpdate(GameObject gameObject, GameContext context, AIUpdateModuleData moduleData)
+            : base(gameObject, context, moduleData)
         {
         }
 
@@ -62,7 +62,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new AssaultTransportAIUpdate(gameObject, this);
+            return new AssaultTransportAIUpdate(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/ChinookAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/ChinookAIUpdate.cs
@@ -16,12 +16,12 @@ namespace OpenSage.Logic.Object
         private ChinookState _state;
         private uint _airfieldToRepairAt;
 
-        internal ChinookAIUpdate(GameObject gameObject, ChinookAIUpdateModuleData moduleData) : base(gameObject, moduleData)
+        internal ChinookAIUpdate(GameObject gameObject, GameContext context, ChinookAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
         {
             _moduleData = moduleData;
         }
 
-        private protected override AIUpdateStateMachine CreateStateMachine(GameObject gameObject) => new ChinookAIUpdateStateMachine(gameObject);
+        private protected override AIUpdateStateMachine CreateStateMachine(GameObject gameObject) => new ChinookAIUpdateStateMachine(gameObject, Context);
 
         protected override int GetAdditionalValuePerSupplyBox(ScopedAssetCollection<UpgradeTemplate> upgrades)
         {
@@ -67,8 +67,8 @@ namespace OpenSage.Logic.Object
 
     internal sealed class ChinookAIUpdateStateMachine : AIUpdateStateMachine
     {
-        public ChinookAIUpdateStateMachine(GameObject gameObject)
-            : base(gameObject)
+        public ChinookAIUpdateStateMachine(GameObject gameObject, GameContext context)
+            : base(gameObject, context)
         {
             AddState(1001, new ChinookTakeoffAndLandingState(false)); // Takeoff
             AddState(1002, new ChinookTakeoffAndLandingState(true));  // Landing
@@ -88,8 +88,8 @@ namespace OpenSage.Logic.Object
 
     /// <summary>
     /// Logic requires bones for either end of the rope to be defined as RopeEnd and RopeStart.
-    /// Infantry (or tanks) can be made to rappel down a rope by adding CAN_RAPPEL to the object's 
-    /// KindOf field. Having done that, the "RAPPELLING" ModelConditionState becomes available for 
+    /// Infantry (or tanks) can be made to rappel down a rope by adding CAN_RAPPEL to the object's
+    /// KindOf field. Having done that, the "RAPPELLING" ModelConditionState becomes available for
     /// rappelling out of the object that has the rappel code of this module.
     /// </summary>
     public sealed class ChinookAIUpdateModuleData : SupplyTruckAIUpdateModuleData
@@ -134,7 +134,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new ChinookAIUpdate(gameObject, this);
+            return new ChinookAIUpdate(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DeployStyleAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DeployStyleAIUpdate.cs
@@ -19,7 +19,7 @@ namespace OpenSage.Logic.Object
 
         private readonly UnknownStateData _unknownStateData = new();
 
-        internal DeployStyleAIUpdate(GameObject gameObject, AIUpdateModuleData moduleData) : base(gameObject, moduleData)
+        internal DeployStyleAIUpdate(GameObject gameObject, GameContext context, AIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
         {
         }
 
@@ -102,7 +102,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new DeployStyleAIUpdate(gameObject, this);
+            return new DeployStyleAIUpdate(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAIUpdate.cs
@@ -16,7 +16,7 @@ namespace OpenSage.Logic.Object
         private readonly DozerAndWorkerState _state;
 
         internal DozerAIUpdate(GameObject gameObject, GameContext context, DozerAIUpdateModuleData moduleData)
-            : base(gameObject, moduleData)
+            : base(gameObject, context, moduleData)
         {
             _context = context;
             _state = new DozerAndWorkerState(gameObject, context, moduleData);

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
@@ -12,8 +12,8 @@ namespace OpenSage.Logic.Object
         private LogicFrameSpan _updateInterval;
 
         //TODO: rather notify this when the corresponding order is processed and update again when the object is dead/destroyed
-        internal FoundationAIUpdate(GameObject gameObject, FoundationAIUpdateModuleData moduleData)
-            : base(gameObject, moduleData)
+        internal FoundationAIUpdate(GameObject gameObject, GameContext context, FoundationAIUpdateModuleData moduleData)
+            : base(gameObject, context, moduleData)
         {
             _moduleData = moduleData;
             _updateInterval = new LogicFrameSpan((uint)MathF.Ceiling(Game.LogicFramesPerSecond / 2)); // 0.5s, we do not have to check every frame
@@ -67,7 +67,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new FoundationAIUpdate(gameObject, this);
+            return new FoundationAIUpdate(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/HackInternetAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/HackInternetAIUpdate.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System.Numerics;
+using OpenSage.Audio;
 using OpenSage.Data.Ini;
 using OpenSage.Logic.AI;
 using OpenSage.Logic.AI.AIStates;
@@ -16,13 +17,13 @@ namespace OpenSage.Logic.Object
 
         public HackInternetAIUpdateModuleData ModuleData => _moduleData;
 
-        internal HackInternetAIUpdate(GameObject gameObject, GameContext context, HackInternetAIUpdateModuleData moduleData) : base(gameObject, moduleData)
+        internal HackInternetAIUpdate(GameObject gameObject, GameContext context, HackInternetAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
         {
             _context = context;
             _moduleData = moduleData;
         }
 
-        private protected override AIUpdateStateMachine CreateStateMachine(GameObject gameObject) => new HackInternetAIUpdateStateMachine(gameObject);
+        private protected override AIUpdateStateMachine CreateStateMachine(GameObject gameObject) => new HackInternetAIUpdateStateMachine(gameObject, _context);
 
         private protected override void RunUpdate(BehaviorUpdateContext context)
         {
@@ -101,12 +102,12 @@ namespace OpenSage.Logic.Object
 
     internal sealed class HackInternetAIUpdateStateMachine : AIUpdateStateMachine
     {
-        public HackInternetAIUpdateStateMachine(GameObject gameObject)
-            : base(gameObject)
+        public HackInternetAIUpdateStateMachine(GameObject gameObject, GameContext context)
+            : base(gameObject, context)
         {
-            AddState(StartHackingInternetState.StateId, new StartHackingInternetState(gameObject));
-            AddState(HackInternetState.StateId, new HackInternetState(gameObject));
-            AddState(StopHackingInternetState.StateId, new StopHackingInternetState(gameObject));
+            AddState(StartHackingInternetState.StateId, new StartHackingInternetState(gameObject, context.AudioSystem));
+            AddState(HackInternetState.StateId, new HackInternetState(gameObject, context.AudioSystem));
+            AddState(StopHackingInternetState.StateId, new StopHackingInternetState(gameObject, context.AudioSystem));
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/JetAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/JetAIUpdate.cs
@@ -55,14 +55,14 @@ namespace OpenSage.Logic.Object
             MovingBackToHangar
         }
 
-        internal JetAIUpdate(GameObject gameObject, JetAIUpdateModuleData moduleData)
-            : base(gameObject, moduleData)
+        internal JetAIUpdate(GameObject gameObject, GameContext context, JetAIUpdateModuleData moduleData)
+            : base(gameObject, context, moduleData)
         {
             _moduleData = moduleData;
             CurrentJetAIState = JetAIState.Parked;
         }
 
-        private protected override AIUpdateStateMachine CreateStateMachine(GameObject gameObject) => new JetAIUpdateStateMachine(gameObject);
+        private protected override AIUpdateStateMachine CreateStateMachine(GameObject gameObject) => new JetAIUpdateStateMachine(gameObject, Context);
 
         internal override void Load(StatePersister reader)
         {
@@ -315,8 +315,8 @@ namespace OpenSage.Logic.Object
 
     internal sealed class JetAIUpdateStateMachine : AIUpdateStateMachine
     {
-        public JetAIUpdateStateMachine(GameObject gameObject)
-            : base(gameObject)
+        public JetAIUpdateStateMachine(GameObject gameObject, GameContext context)
+            : base(gameObject, context)
         {
             AddState(1013, new WaitForAirfieldState());
         }
@@ -399,7 +399,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new JetAIUpdate(gameObject, this);
+            return new JetAIUpdate(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/MissileAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/MissileAIUpdate.cs
@@ -31,8 +31,8 @@ namespace OpenSage.Logic.Object
 
         internal FXList DetonationFX { get; set; }
 
-        internal MissileAIUpdate(GameObject gameObject, MissileAIUpdateModuleData moduleData)
-            : base(gameObject, moduleData)
+        internal MissileAIUpdate(GameObject gameObject, GameContext context, MissileAIUpdateModuleData moduleData)
+            : base(gameObject, context, moduleData)
         {
             _moduleData = moduleData;
 
@@ -194,7 +194,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new MissileAIUpdate(gameObject, this);
+            return new MissileAIUpdate(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyAIUpdate.cs
@@ -28,6 +28,7 @@ namespace OpenSage.Logic.Object
             FinishedDumpingSupplies
         }
 
+        protected GameContext Context { get; }
         private SupplyAIUpdateModuleData _moduleData;
 
         public GameObject CurrentSupplySource { get; set; }
@@ -40,8 +41,9 @@ namespace OpenSage.Logic.Object
 
         protected virtual int GetAdditionalValuePerSupplyBox(ScopedAssetCollection<UpgradeTemplate> upgrades) => 0;
 
-        internal SupplyAIUpdate(GameObject gameObject, SupplyAIUpdateModuleData moduleData) : base(gameObject, moduleData)
+        internal SupplyAIUpdate(GameObject gameObject, GameContext context, SupplyAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
         {
+            Context = context;
             _moduleData = moduleData;
             SupplyGatherState = SupplyGatherStates.Default;
             // todo: this is not always the case - workers produced from a command center do not go looking for supplies
@@ -74,7 +76,7 @@ namespace OpenSage.Logic.Object
         {
             if (_currentSourceDockUpdate?.GetBox() == true && !_currentSourceDockUpdate.HasBoxes())
             {
-                GameObject.GameContext.AudioSystem.PlayAudioEvent(GameObject, _moduleData.SuppliesDepletedVoice.Value);
+                Context.AudioSystem.PlayAudioEvent(GameObject, _moduleData.SuppliesDepletedVoice.Value);
             }
         }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cs
@@ -11,7 +11,7 @@ namespace OpenSage.Logic.Object
         private int _unknownInt;
         private bool _unknownBool;
 
-        internal SupplyTruckAIUpdate(GameObject gameObject, SupplyTruckAIUpdateModuleData moduleData) : base(gameObject, moduleData)
+        internal SupplyTruckAIUpdate(GameObject gameObject, GameContext context, SupplyTruckAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
         {
             _moduleData = moduleData;
         }
@@ -45,7 +45,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new SupplyTruckAIUpdate(gameObject, this);
+            return new SupplyTruckAIUpdate(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TransportAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TransportAIUpdate.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object
 {
     public sealed class TransportAIUpdate : AIUpdate
     {
-        internal TransportAIUpdate(GameObject gameObject, TransportAIUpdateModuleData moduleData)
-            : base(gameObject, moduleData)
+        internal TransportAIUpdate(GameObject gameObject, GameContext context, TransportAIUpdateModuleData moduleData)
+            : base(gameObject, context, moduleData)
         {
         }
 
@@ -31,7 +31,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new TransportAIUpdate(gameObject, this);
+            return new TransportAIUpdate(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WanderAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WanderAIUpdate.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object
 {
     public sealed class WanderAIUpdate : AIUpdate
     {
-        internal WanderAIUpdate(GameObject gameObject, WanderAIUpdateModuleData moduleData)
-            : base(gameObject, moduleData)
+        internal WanderAIUpdate(GameObject gameObject, GameContext context, WanderAIUpdateModuleData moduleData)
+            : base(gameObject, context, moduleData)
         {
         }
 
@@ -31,7 +31,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new WanderAIUpdate(gameObject, this);
+            return new WanderAIUpdate(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
@@ -24,7 +24,7 @@ namespace OpenSage.Logic.Object
         private int _unknown6;
         private readonly WorkerAIUpdateStateMachine3 _stateMachine3 = new();
 
-        internal WorkerAIUpdate(GameObject gameObject, GameContext context, WorkerAIUpdateModuleData moduleData) : base(gameObject, moduleData)
+        internal WorkerAIUpdate(GameObject gameObject, GameContext context, WorkerAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
         {
             _context = context;
             _moduleData = moduleData;

--- a/src/OpenSage.Game/Logic/Object/Update/BaseRegenerateUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BaseRegenerateUpdate.cs
@@ -21,7 +21,7 @@ namespace OpenSage.Logic.Object
         /// </summary>
         public void RegisterDamage()
         {
-            var currentFrame = _gameObject.GameContext.GameLogic.CurrentFrame;
+            var currentFrame = _context.GameLogic.CurrentFrame;
             NextUpdateFrame = new UpdateFrame(currentFrame + _context.AssetLoadContext.AssetStore.GameData.Current.BaseRegenDelay);
         }
 

--- a/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
@@ -11,12 +11,12 @@ namespace OpenSage.Logic.Object
 
         private LogicFrame _frameToDelete;
 
-        public DeletionUpdate(GameObject gameObject, DeletionUpdateModuleData moduleData)
+        public DeletionUpdate(GameObject gameObject, GameContext context, DeletionUpdateModuleData moduleData)
         {
             _gameObject = gameObject;
             _moduleData = moduleData;
 
-            _frameToDelete = gameObject.GameContext.GameLogic.CurrentFrame + gameObject.GameContext.GetRandomLogicFrameSpan(_moduleData.MinLifetime, _moduleData.MaxLifetime);
+            _frameToDelete = context.GameLogic.CurrentFrame + context.GetRandomLogicFrameSpan(_moduleData.MinLifetime, _moduleData.MaxLifetime);
             NextUpdateFrame = new UpdateFrame(_frameToDelete);
         }
 
@@ -60,7 +60,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new DeletionUpdate(gameObject, this);
+            return new DeletionUpdate(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
@@ -5,6 +5,7 @@ namespace OpenSage.Logic.Object
     internal sealed class LifetimeUpdate : UpdateModule
     {
         private readonly GameObject _gameObject;
+        private readonly GameContext _context;
         private readonly LifetimeUpdateModuleData _moduleData;
 
         private LogicFrame _frameToDie;
@@ -16,16 +17,17 @@ namespace OpenSage.Logic.Object
             set => _frameToDie = value;
         }
 
-        public LifetimeUpdate(GameObject gameObject, LifetimeUpdateModuleData moduleData)
+        public LifetimeUpdate(GameObject gameObject, GameContext context, LifetimeUpdateModuleData moduleData)
         {
             _gameObject = gameObject;
+            _context = context;
             _moduleData = moduleData;
 
-            var lifetimeFrames = gameObject.GameContext.Random.Next(
+            var lifetimeFrames = context.Random.Next(
                 (int)moduleData.MinLifetime.Value,
                 (int)moduleData.MaxLifetime.Value);
 
-            _frameToDie = gameObject.GameContext.GameLogic.CurrentFrame + new LogicFrameSpan((uint)lifetimeFrames);
+            _frameToDie = context.GameLogic.CurrentFrame + new LogicFrameSpan((uint)lifetimeFrames);
         }
 
         internal override void Update(BehaviorUpdateContext context)
@@ -72,7 +74,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new LifetimeUpdate(gameObject, this);
+            return new LifetimeUpdate(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/PowerPlantUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/PowerPlantUpdate.cs
@@ -7,15 +7,17 @@ namespace OpenSage.Logic.Object
     public sealed class PowerPlantUpdate : UpdateModule
     {
         private readonly GameObject _gameObject;
+        private readonly GameContext _context;
         private readonly PowerPlantUpdateModuleData _moduleData;
 
         private bool _rodsExtended;
 
         private LogicFrame _rodsExtendedEndFrame;
 
-        internal PowerPlantUpdate(GameObject gameObject, PowerPlantUpdateModuleData moduleData)
+        internal PowerPlantUpdate(GameObject gameObject, GameContext context, PowerPlantUpdateModuleData moduleData)
         {
             _gameObject = gameObject;
+            _context = context;
             _moduleData = moduleData;
         }
 
@@ -25,7 +27,7 @@ namespace OpenSage.Logic.Object
 
             _gameObject.Drawable.ModelConditionFlags.Set(ModelConditionFlag.PowerPlantUpgrading, true);
 
-            _rodsExtendedEndFrame = _gameObject.GameContext.GameLogic.CurrentFrame + _moduleData.RodsExtendTime;
+            _rodsExtendedEndFrame = _context.GameLogic.CurrentFrame + _moduleData.RodsExtendTime;
         }
 
         // China powerplant overcharge needs to be able to turn off
@@ -96,7 +98,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new PowerPlantUpdate(gameObject, this);
+            return new PowerPlantUpdate(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -17,6 +17,7 @@ namespace OpenSage.Logic.Object
         private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
         private readonly GameObject _gameObject;
+        private readonly GameContext _context;
         private readonly ProductionUpdateModuleData _moduleData;
         private readonly List<ProductionJob> _productionQueue = new();
 
@@ -45,9 +46,10 @@ namespace OpenSage.Logic.Object
 
         public IReadOnlyList<ProductionJob> ProductionQueue => _productionQueue;
 
-        internal ProductionUpdate(GameObject gameObject, ProductionUpdateModuleData moduleData)
+        internal ProductionUpdate(GameObject gameObject, GameContext context, ProductionUpdateModuleData moduleData)
         {
             _gameObject = gameObject;
+            _context = context;
             _moduleData = moduleData;
         }
 
@@ -154,7 +156,7 @@ namespace OpenSage.Logic.Object
         {
             _doorIndex = doorIndex;
             Logger.Info($"Door closing for {_moduleData.DoorCloseTime}");
-            SetDoorStateEndFrame(DoorState.Closing, _gameObject.GameContext.GameLogic.CurrentFrame + _moduleData.DoorCloseTime);
+            SetDoorStateEndFrame(DoorState.Closing, _context.GameLogic.CurrentFrame + _moduleData.DoorCloseTime);
             // TODO: What is ModelConditionFlag.Door1WaitingToClose?
         }
 
@@ -346,13 +348,13 @@ namespace OpenSage.Logic.Object
 
             ProductionExit.ProduceUnit();
 
-            var producedUnit = _gameObject.GameContext.GameLogic.CreateObject(objectDefinition, _gameObject.Owner);
+            var producedUnit = _context.GameLogic.CreateObject(objectDefinition, _gameObject.Owner);
             producedUnit.Owner = _gameObject.Owner;
             producedUnit.ParentHorde = ParentHorde;
 
             if (playAudio)
             {
-                producedUnit.GameContext.Scene3D.Audio.PlayAudioEvent(producedUnit, producedUnit.Definition.UnitSpecificSounds?.VoiceCreate?.Value);
+               _context.Scene3D.Audio.PlayAudioEvent(producedUnit, producedUnit.Definition.UnitSpecificSounds?.VoiceCreate?.Value);
             }
 
             if (!_moduleData.GiveNoXP)
@@ -407,7 +409,7 @@ namespace OpenSage.Logic.Object
                 producedUnit.AIUpdate.AddTargetPoint(_gameObject.RallyPoint.Value);
             }
 
-            _gameObject.GameContext.AudioSystem.PlayAudioEvent(producedUnit, producedUnit.Definition.SoundMoveStart.Value);
+            _context.AudioSystem.PlayAudioEvent(producedUnit, producedUnit.Definition.SoundMoveStart.Value);
 
             HandleHordeCreation(producedUnit);
             HandleHarvesterUnitCreation(_gameObject, producedUnit);
@@ -694,7 +696,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new ProductionUpdate(gameObject, this);
+            return new ProductionUpdate(gameObject, context, this);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/ToppleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ToppleUpdate.cs
@@ -9,6 +9,7 @@ namespace OpenSage.Logic.Object
     public sealed class ToppleUpdate : UpdateModule, ICollideModule
     {
         private readonly GameObject _gameObject;
+        private readonly GameContext _context;
         private readonly ToppleUpdateModuleData _moduleData;
 
         private ToppleState _toppleState;
@@ -19,9 +20,10 @@ namespace OpenSage.Logic.Object
         private float _unknownFloat;
         private uint _stumpId;
 
-        internal ToppleUpdate(GameObject gameObject, ToppleUpdateModuleData moduleData)
+        internal ToppleUpdate(GameObject gameObject, GameContext context, ToppleUpdateModuleData moduleData)
         {
             _gameObject = gameObject;
+            _context = context;
             _moduleData = moduleData;
 
             _toppleState = ToppleState.NotToppled;
@@ -84,7 +86,7 @@ namespace OpenSage.Logic.Object
                 new FXListExecutionContext(
                     _gameObject.Rotation,
                     _gameObject.Translation,
-                    _gameObject.GameContext));
+                    _context));
 
             CreateStump();
 
@@ -107,7 +109,7 @@ namespace OpenSage.Logic.Object
                 return;
             }
 
-            var stump = _gameObject.GameContext.GameLogic.CreateObject(_moduleData.StumpName.Value, null);
+            var stump = _context.GameLogic.CreateObject(_moduleData.StumpName.Value, null);
             stump.UpdateTransform(_gameObject.Translation, _gameObject.Rotation);
             _stumpId = stump.ID;
         }
@@ -172,7 +174,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new ToppleUpdate(gameObject, this);
+            return new ToppleUpdate(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
@@ -6,18 +6,20 @@ namespace OpenSage.Logic.Object
 {
     internal sealed class ObjectCreationUpgrade : UpgradeModule
     {
+        private readonly GameContext _context;
         private readonly ObjectCreationUpgradeModuleData _moduleData;
 
-        internal ObjectCreationUpgrade(GameObject gameObject, ObjectCreationUpgradeModuleData moduleData)
+        internal ObjectCreationUpgrade(GameObject gameObject, GameContext context, ObjectCreationUpgradeModuleData moduleData)
             : base(gameObject, moduleData)
         {
+            _context = context;
             _moduleData = moduleData;
         }
 
         protected override void OnUpgrade()
         {
             // TODO: Get rid of this context thing.
-            var context = new BehaviorUpdateContext(_gameObject.GameContext, _gameObject);
+            var context = new BehaviorUpdateContext(_context, _gameObject);
 
             foreach (var item in _moduleData.UpgradeObject.Value.Nuggets)
             {
@@ -95,7 +97,7 @@ namespace OpenSage.Logic.Object
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new ObjectCreationUpgrade(gameObject, this);
+            return new ObjectCreationUpgrade(gameObject, context, this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Weapon/WeaponSet.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/WeaponSet.cs
@@ -6,6 +6,7 @@ namespace OpenSage.Logic.Object
     public sealed class WeaponSet : IPersistableObject
     {
         private readonly GameObject _gameObject;
+        private readonly GameContext _context;
         private readonly Weapon[] _weapons;
         private WeaponTemplateSet _currentWeaponTemplateSet;
         private WeaponSlot _currentWeaponSlot;
@@ -20,9 +21,10 @@ namespace OpenSage.Logic.Object
         internal Weapon CurrentWeapon => _weapons[(int) _currentWeaponSlot];
         public IEnumerable<Weapon> Weapons => _weapons;
 
-        internal WeaponSet(GameObject gameObject)
+        internal WeaponSet(GameObject gameObject, GameContext context)
         {
             _gameObject = gameObject;
+            _context = context;
 
             _weapons = new Weapon[WeaponTemplateSet.NumWeaponSlots];
         }
@@ -51,7 +53,7 @@ namespace OpenSage.Logic.Object
                 var weaponTemplate = _currentWeaponTemplateSet.Slots[i]?.Weapon.Value;
                 if (weaponTemplate != null)
                 {
-                    _weapons[i] = new Weapon(_gameObject, weaponTemplate, (WeaponSlot) i, _gameObject.GameContext);
+                    _weapons[i] = new Weapon(_gameObject, weaponTemplate, (WeaponSlot) i, _context);
 
                     _filledWeaponSlots |= (uint) (1 << i);
                     _combinedAntiMask |= weaponTemplate.AntiMask;
@@ -90,7 +92,7 @@ namespace OpenSage.Logic.Object
                         _weapons[i] = new Weapon(
                             _gameObject,
                             _currentWeaponTemplateSet.Slots[i].Weapon.Value,
-                            (WeaponSlot)i, _gameObject.GameContext);
+                            (WeaponSlot)i, _context);
                     }
                     reader.PersistObject(_weapons[i], "Value");
                 }

--- a/src/OpenSage.Game/Scene25D.cs
+++ b/src/OpenSage.Game/Scene25D.cs
@@ -237,7 +237,7 @@ public class Scene25D(Scene3D scene3D, AssetStore assetStore)
 
         var text = _buildProgressString.Localize(gameObject.BuildProgress * 100);
         // todo: is this the correct font?
-        drawingContext.DrawText(text, gameObject.GameContext.Game.ContentManager.FontManager.GetOrCreateFont(assetStore.InGameUI.Current.MessageFont, 26, FontWeight.Normal), TextAlignment.Center, ColorRgbaF.White, buildProgressRect.Value);
+        drawingContext.DrawText(text, scene3D.Game.ContentManager.FontManager.GetOrCreateFont(assetStore.InGameUI.Current.MessageFont, 26, FontWeight.Normal), TextAlignment.Center, ColorRgbaF.White, buildProgressRect.Value);
     }
 
     private void DrawBottomLeftImage(DrawingContext2D drawingContext, GameObject gameObject, MappedImage image)


### PR DESCRIPTION
### If this isn't the direction we want to go in, that's fine - we can close this

I've noticed a lot of instances of calling through GameObject to get to GameContext when there's already a GameContext nearby. This removes the public exposure of GameContext from GameObject to encourage the use of GameContext from wherever it already is. Most of these usages are in the Modules, where module creation already has a GameContext fed in. There are a couple instances outside of the modules though, and I've refactored those to either take a GameContext in the method/constructor or just the dependency of GameContext it actually needs.

If we want to continue accessing GameContext via GameObject though, I won't be offended :)