### PR TITLE
Move rally point marker drawing to order generator

### DIFF
--- a/src/OpenSage.Game/Client/Drawable.cs
+++ b/src/OpenSage.Game/Client/Drawable.cs
@@ -28,6 +28,8 @@ namespace OpenSage.Client
         private readonly Dictionary<string, bool> _hiddenSubObjects;
         private readonly Dictionary<string, bool> _shownSubObjects;
 
+        public override Transform Transform => GameObject?.Transform ?? base.Transform;
+
         public Dictionary<string, bool> ShownSubObjects => _shownSubObjects;
         public Dictionary<string, bool> HiddenSubObjects => _hiddenSubObjects;
 

--- a/src/OpenSage.Game/Client/GameClient.cs
+++ b/src/OpenSage.Game/Client/GameClient.cs
@@ -93,8 +93,8 @@ namespace OpenSage.Client
             reader.BeginArray("Drawables");
             if (reader.Mode == StatePersistMode.Read)
             {
-                _drawables.Clear();
-                _drawables.Capacity = drawablesCount;
+                DestroyAllDrawablesNow();
+                _drawables.EnsureCapacity(drawablesCount);
 
                 for (var i = 0; i < drawablesCount; i++)
                 {

--- a/src/OpenSage.Game/Entity.cs
+++ b/src/OpenSage.Game/Entity.cs
@@ -1,9 +1,60 @@
-﻿using System.Collections.Generic;
+﻿using System.Numerics;
 
 namespace OpenSage
 {
     public abstract class Entity : DisposableBase
     {
-        
+        private readonly Transform _transform = Transform.CreateIdentity();
+
+        public virtual Transform Transform => _transform;
+
+        public float Yaw => _transform.Yaw;
+        public Vector3 EulerAngles => _transform.EulerAngles;
+        public Vector3 LookDirection => _transform.LookDirection;
+        public Vector3 Translation => _transform.Translation;
+        public Quaternion Rotation => _transform.Rotation;
+        public Matrix4x4 TransformMatrix => _transform.Matrix;
+
+        public void SetTransformMatrix(Matrix4x4 matrix)
+        {
+            _transform.Matrix = matrix;
+            OnEntityMoved();
+        }
+
+        public void SetTranslation(Vector3 translation)
+        {
+            if (_transform.Translation == translation)
+            {
+                return;
+            }
+            _transform.Translation = translation;
+            OnEntityMoved();
+        }
+
+        public void SetRotation(Quaternion rotation)
+        {
+            if (_transform.Rotation == rotation)
+            {
+                return;
+            }
+            _transform.Rotation = rotation;
+            OnEntityMoved();
+        }
+
+        public void SetScale(float scale)
+        {
+            _transform.Scale = scale;
+            OnEntityMoved();
+        }
+
+        public void UpdateTransform(in Vector3? translation = null, in Quaternion? rotation = null, float scale = 1.0f)
+        {
+            _transform.Translation = translation ?? _transform.Translation;
+            _transform.Rotation = rotation ?? _transform.Rotation;
+            _transform.Scale = scale;
+            OnEntityMoved();
+        }
+
+        protected virtual void OnEntityMoved() { }
     }
 }

--- a/src/OpenSage.Game/Logic/GameLogic.cs
+++ b/src/OpenSage.Game/Logic/GameLogic.cs
@@ -197,8 +197,8 @@ namespace OpenSage.Logic
             reader.BeginArray("Objects");
             if (reader.Mode == StatePersistMode.Read)
             {
-                _objects.Clear();
-                _objects.Capacity = (int)objectsCount;
+                DestroyAllObjectsNow();
+                _objects.EnsureCapacity((int)objectsCount);
 
                 for (var i = 0; i < objectsCount; i++)
                 {

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -101,7 +101,7 @@ namespace OpenSage.Logic.Object
             _activeConditionState = conditionState;
             _activeModelDrawConditionState = modelDrawConditionState;
 
-            NLog.LogManager.GetCurrentClassLogger().Info($"Set active condition state for {GameObject.Definition.Name}");
+            NLog.LogManager.GetCurrentClassLogger().Info($"Set active condition state for {Drawable.Definition.Name}");
         }
 
         private bool ShouldWaitForRunningAnimationsToFinish()
@@ -160,7 +160,7 @@ namespace OpenSage.Logic.Object
                 animationInstance.Play(animationBlock.AnimationSpeedFactorRange.GetValue(random));
             }
 
-            NLog.LogManager.GetCurrentClassLogger().Info($"Set active animation state for {GameObject.Definition.Name}");
+            NLog.LogManager.GetCurrentClassLogger().Info($"Set active animation state for {Drawable.Definition.Name}");
 
             return true;
         }
@@ -364,7 +364,7 @@ namespace OpenSage.Logic.Object
 
         internal override void SetWorldMatrix(in Matrix4x4 worldMatrix)
         {
-            if (GameObject.VerticalOffset != 0)
+            if (GameObject != null && GameObject.VerticalOffset != 0)
             {
                 var mat = worldMatrix * Matrix4x4.CreateTranslation(Vector3.UnitZ * GameObject.VerticalOffset);
                 _activeModelDrawConditionState?.SetWorldMatrix(mat);

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -147,8 +147,6 @@ namespace OpenSage.Logic.Object
 
         private readonly BehaviorUpdateContext _behaviorUpdateContext;
 
-        private readonly GameObject _rallyPointMarker;
-
         private BodyDamageType _bodyDamageType = BodyDamageType.Pristine;
 
         internal BitArray<WeaponSetConditions> WeaponSetConditions;
@@ -161,7 +159,6 @@ namespace OpenSage.Logic.Object
 
         public readonly Geometry Geometry;
 
-        private readonly Transform _transform;
         public readonly Transform ModelTransform;
 
         private bool _objectMoved;
@@ -212,55 +209,7 @@ namespace OpenSage.Logic.Object
         private byte _weaponSomethingTertiary;
         private BitArray<SpecialPowerType> _specialPowers = new();
 
-        public Transform Transform => _transform;
-        public float Yaw => _transform.Yaw;
-        public Vector3 EulerAngles => _transform.EulerAngles;
-        public Vector3 LookDirection => _transform.LookDirection;
-        public Vector3 Translation => _transform.Translation;
-        public Quaternion Rotation => _transform.Rotation;
-        public Matrix4x4 TransformMatrix => _transform.Matrix;
-
-        public void SetTransformMatrix(Matrix4x4 matrix)
-        {
-            _transform.Matrix = matrix;
-            _objectMoved = true;
-        }
-
-        public void SetTranslation(Vector3 translation)
-        {
-            if (_transform.Translation == translation)
-            {
-                return;
-            }
-            _transform.Translation = translation;
-            OnObjectMoved();
-        }
-
-        public void SetRotation(Quaternion rotation)
-        {
-            if (_transform.Rotation == rotation)
-            {
-                return;
-            }
-            _transform.Rotation = rotation;
-            OnObjectMoved();
-        }
-
-        public void SetScale(float scale)
-        {
-            _transform.Scale = scale;
-            OnObjectMoved();
-        }
-
-        public void UpdateTransform(in Vector3? translation = null, in Quaternion? rotation = null, float scale = 1.0f)
-        {
-            _transform.Translation = translation ?? _transform.Translation;
-            _transform.Rotation = rotation ?? _transform.Rotation;
-            _transform.Scale = scale;
-            OnObjectMoved();
-        }
-
-        private void OnObjectMoved()
+        protected override void OnEntityMoved()
         {
             _objectMoved = true;
             PartitionObject?.SetDirty();
@@ -515,9 +464,8 @@ namespace OpenSage.Logic.Object
             WeaponSetConditions = new BitArray<WeaponSetConditions>();
             UpdateWeaponSet();
 
-            _transform = Transform.CreateIdentity();
             ModelTransform = Transform.CreateIdentity();
-            _transform.Scale = Definition.Scale;
+            Transform.Scale = Definition.Scale;
 
             // TODO: Instead of GameObject owning the drawable, which makes logic tests a little awkward,
             // perhaps create Drawable somewhere else and attach it to this GameObject?
@@ -602,7 +550,7 @@ namespace OpenSage.Logic.Object
             Colliders = new List<Collider>();
             foreach (var geometry in Geometry.Shapes)
             {
-                Colliders.Add(Collider.Create(geometry, _transform));
+                Colliders.Add(Collider.Create(geometry, Transform));
             }
 
             RoughCollider = Collider.Create(Colliders);
@@ -613,13 +561,6 @@ namespace OpenSage.Logic.Object
 
             IsSelectable = Definition.KindOf.Get(ObjectKinds.Selectable);
             CanAttack = Definition.KindOf.Get(ObjectKinds.CanAttack);
-
-            if (Definition.KindOf.Get(ObjectKinds.AutoRallyPoint))
-            {
-                var rpMarkerDef = gameContext.AssetLoadContext.AssetStore.ObjectDefinitions.GetByName("RallyPointMarker");
-                // TODO: Only create a Drawable, as suggested by DRAWABLE_ONLY.
-                _rallyPointMarker = AddDisposable(new GameObject(rpMarkerDef, gameContext, owner));
-            }
 
             if (Definition.KindOf.Get(ObjectKinds.Projectile))
             {
@@ -729,10 +670,10 @@ namespace OpenSage.Logic.Object
 
         public void UpdateColliders()
         {
-            RoughCollider.Update(_transform);
+            RoughCollider.Update(Transform);
             foreach (var collider in Colliders)
             {
-                collider.Update(_transform);
+                collider.Update(Transform);
             }
             _gameContext.Quadtree.Update(this);
         }
@@ -862,13 +803,13 @@ namespace OpenSage.Logic.Object
 
         internal Vector3 ToWorldspace(in Vector3 localPos)
         {
-            var worldPos = Vector4.Transform(new Vector4(localPos, 1.0f), _transform.Matrix);
+            var worldPos = Vector4.Transform(new Vector4(localPos, 1.0f), Transform.Matrix);
             return new Vector3(worldPos.X, worldPos.Y, worldPos.Z);
         }
 
         internal Transform ToWorldspace(in Transform localPos)
         {
-            var worldPos = localPos.Matrix * _transform.Matrix;
+            var worldPos = localPos.Matrix * Transform.Matrix;
             return new Transform(worldPos);
         }
 
@@ -1001,7 +942,7 @@ namespace OpenSage.Logic.Object
             _status.Set(ObjectStatus.UnderConstruction, true);
 
             // flatten terrain around object
-            var centerPosition = _gameContext.Terrain.HeightMap.GetTilePosition(_transform.Translation);
+            var centerPosition = _gameContext.Terrain.HeightMap.GetTilePosition(Transform.Translation);
 
             if (centerPosition == null)
             {
@@ -1011,7 +952,7 @@ namespace OpenSage.Logic.Object
             var (centerX, centerY) = centerPosition.Value;
             var maxHeight = _gameContext.Terrain.HeightMap.GetHeight(centerX, centerY);
             // on slopes, the height map isn't always exactly where our cursor is (our cursor is a float, and the heightmap is always a ushort), so snap the building to the nearest heightmap value
-            UpdateTransform(_transform.Translation with { Z = maxHeight }, _transform.Rotation);
+            UpdateTransform(Transform.Translation with { Z = maxHeight }, Transform.Rotation);
 
             // clear anything applicable in the build area (trees, rubble, etc)
             var toDelete = new BitArray<ObjectKinds>(ObjectKinds.Shrubbery, ObjectKinds.ClearedByBuild); // this may not be completely accurate
@@ -1136,7 +1077,6 @@ namespace OpenSage.Logic.Object
 
         internal void LocalLogicTick(in TimeInterval gameTime, float tickT, HeightMap heightMap)
         {
-            _rallyPointMarker?.LocalLogicTick(gameTime, tickT, heightMap);
             Drawable.LogicTick();
         }
 
@@ -1155,16 +1095,8 @@ namespace OpenSage.Logic.Object
             };
 
             // This must be done after processing anything that might update this object's transform.
-            var worldMatrix = ModelTransform.Matrix * _transform.Matrix;
+            var worldMatrix = ModelTransform.Matrix * Transform.Matrix;
             Drawable.BuildRenderList(renderList, camera, gameTime, worldMatrix, renderItemConstantsPS);
-
-            if ((IsSelected || IsPlacementPreview) && _rallyPointMarker != null && RallyPoint != null)
-            {
-                _rallyPointMarker._transform.Translation = RallyPoint.Value;
-
-                // TODO: check if this should be drawn with transparency?
-                _rallyPointMarker.BuildRenderList(renderList, camera, gameTime);
-            }
         }
 
         public void ClearModelConditionFlags()
@@ -1516,7 +1448,7 @@ namespace OpenSage.Logic.Object
             }
 
             var transform = reader.Mode == StatePersistMode.Write
-                ? Matrix4x3.FromMatrix4x4(_transform.Matrix)
+                ? Matrix4x3.FromMatrix4x4(Transform.Matrix)
                 : Matrix4x3.Identity;
             reader.PersistMatrix4x3(ref transform);
             if (reader.Mode == StatePersistMode.Read)
@@ -1748,10 +1680,10 @@ namespace OpenSage.Logic.Object
             {
                 ImGui.LabelText("DisplayName", Definition.DisplayName ?? string.Empty);
 
-                var translation = _transform.Translation;
+                var translation = Transform.Translation;
                 if (ImGui.DragFloat3("Position", ref translation))
                 {
-                    _transform.Translation = translation;
+                    Transform.Translation = translation;
                 }
 
                 ImGui.LabelText("ObjectStatus", _status.DisplayName);

--- a/src/OpenSage.Game/Logic/OrderGeneratorSystem.cs
+++ b/src/OpenSage.Game/Logic/OrderGeneratorSystem.cs
@@ -177,7 +177,7 @@ namespace OpenSage.Logic
 
         public void SetRallyPoint()
         {
-            ActiveGenerator = new RallyPointOrderGenerator(Game, Game.PlayerManager.LocalPlayer.SelectedUnits.First());
+            ActiveGenerator = new RallyPointOrderGenerator(Game, Game.PlayerManager.LocalPlayer.SelectedUnits.Single());
         }
 
         public void CancelOrderGenerator()

--- a/src/OpenSage.Game/Logic/OrderGeneratorSystem.cs
+++ b/src/OpenSage.Game/Logic/OrderGeneratorSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Numerics;
 using OpenSage.Graphics.Cameras;
 using OpenSage.Graphics.Rendering;
@@ -176,7 +177,7 @@ namespace OpenSage.Logic
 
         public void SetRallyPoint()
         {
-            ActiveGenerator = new RallyPointOrderGenerator(Game);
+            ActiveGenerator = new RallyPointOrderGenerator(Game, Game.PlayerManager.LocalPlayer.SelectedUnits.First());
         }
 
         public void CancelOrderGenerator()

--- a/src/OpenSage.Game/Logic/OrderGenerators/RallyPointOrderGenerator.cs
+++ b/src/OpenSage.Game/Logic/OrderGenerators/RallyPointOrderGenerator.cs
@@ -1,5 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using OpenSage.Client;
+using OpenSage.Graphics.Cameras;
+using OpenSage.Graphics.Rendering;
+using OpenSage.Graphics.Shaders;
 using OpenSage.Input;
+using OpenSage.Logic.Object;
 using OpenSage.Logic.Orders;
 
 namespace OpenSage.Logic.OrderGenerators
@@ -7,11 +14,23 @@ namespace OpenSage.Logic.OrderGenerators
     // TODO: Cancel this when:
     // 1. Structure dies
     // 2. We lose access to the building
-    public sealed class RallyPointOrderGenerator(Game game) : OrderGenerator(game)
+    public sealed class RallyPointOrderGenerator : OrderGenerator, IDisposable
     {
         public override bool CanDrag => true;
 
+        private readonly GameObject _gameObject;
+        private readonly Drawable _rallyPointMarker;
+
         private OrderType _currentOrder = OrderType.Zero;
+
+        public RallyPointOrderGenerator(Game game, GameObject gameObject)
+            : base(game)
+        {
+            _gameObject = gameObject;
+
+            var rpMarkerDef = Game.AssetStore.ObjectDefinitions.GetByName("RallyPointMarker");
+            _rallyPointMarker = Game.GameClient.CreateDrawable(rpMarkerDef, null);
+        }
 
         public override OrderGeneratorResult TryActivate(Scene3D scene, KeyModifiers keyModifiers)
         {
@@ -54,6 +73,34 @@ namespace OpenSage.Logic.OrderGenerators
         private OrderType GetCurrentOrder()
         {
             return WorldObject != null ? OrderType.SetSelection : OrderType.SetRallyPoint;
+        }
+
+        public override void BuildRenderList(RenderList renderList, Camera camera, in TimeInterval gameTime)
+        {
+            if (_gameObject.RallyPoint == null)
+            {
+                return;
+            }
+
+            _rallyPointMarker.Transform.Translation = _gameObject.RallyPoint.Value;
+
+            var renderItemConstantsPS = new MeshShaderResources.RenderItemConstantsPS
+            {
+                Opacity = 1.0f,
+                TintColor = Vector3.One,
+            };
+
+            _rallyPointMarker.BuildRenderList(
+                renderList,
+                camera,
+                gameTime,
+                _rallyPointMarker.TransformMatrix,
+                renderItemConstantsPS);
+        }
+
+        public void Dispose()
+        {
+            Game.GameClient.DestroyDrawable(_rallyPointMarker);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/SelectionSystem.cs
+++ b/src/OpenSage.Game/Logic/SelectionSystem.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using OpenSage.Gui;
 using OpenSage.Logic.Object;
+using OpenSage.Logic.OrderGenerators;
 using OpenSage.Logic.Orders;
 using OpenSage.Mathematics;
-using OpenSage.Logic.OrderGenerators;
 
 namespace OpenSage.Logic
 {
@@ -138,7 +139,7 @@ namespace OpenSage.Logic
             {
                 if (CanSetRallyPoint(objects))
                 {
-                    Game.OrderGenerator.ActiveGenerator = new RallyPointOrderGenerator(Game, objects[0]);
+                    Game.OrderGenerator.ActiveGenerator = new RallyPointOrderGenerator(Game, objects.Single());
                 }
                 else
                 {

--- a/src/OpenSage.Game/Logic/SelectionSystem.cs
+++ b/src/OpenSage.Game/Logic/SelectionSystem.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Numerics;
 using OpenSage.Gui;
 using OpenSage.Logic.Object;
@@ -139,7 +138,7 @@ namespace OpenSage.Logic
             {
                 if (CanSetRallyPoint(objects))
                 {
-                    Game.OrderGenerator.ActiveGenerator = new RallyPointOrderGenerator(Game);
+                    Game.OrderGenerator.ActiveGenerator = new RallyPointOrderGenerator(Game, objects[0]);
                 }
                 else
                 {


### PR DESCRIPTION
This fixes #970. I found there were two causes of that crash:

1. The game object created for the rally point marker wasn't registered correctly with `GameClient`, so when it was disposed it had an unrecognized ID.
2. When a .sav is loaded, lists of existing game objects and drawables are cleared, but they're not disposed. When they get disposed later on they can cause a crash.

This PR fixes both of those. In the process I added the ability for `Drawable` to exist as a standalone thing, because I'm pretty sure that's how `RallyPointMarker` is supposed to be used.