### PR TITLE
Rename UpdateFrame.Something to UpdateOrder

### DIFF
--- a/src/OpenSage.Game.Tests/Logic/Object/Behaviors/PhysicsBehaviorTests.cs
+++ b/src/OpenSage.Game.Tests/Logic/Object/Behaviors/PhysicsBehaviorTests.cs
@@ -7,6 +7,8 @@ namespace OpenSage.Tests.Logic.Object.Behaviors;
 
 public class PhysicsBehaviorTests : UpdateModuleTest<PhysicsBehavior, PhysicsBehaviorModuleData>
 {
+    protected override UpdateOrder UpdateOrder => UpdateOrder.Order1;
+
     /// <summary>
     /// When a unit is stationary, acceleration and velocity are zero.
     /// </summary>

--- a/src/OpenSage.Game.Tests/Logic/Object/Update/UpdateModuleTest.cs
+++ b/src/OpenSage.Game.Tests/Logic/Object/Update/UpdateModuleTest.cs
@@ -4,7 +4,14 @@ namespace OpenSage.Tests.Logic.Object.Update;
 
 public abstract class UpdateModuleTest<TModule, TData> : BehaviorModuleTest<TModule, TData> where TModule : UpdateModule where TData : BehaviorModuleData, new()
 {
-    private readonly byte[] _nextUpdateFrame = [0x00, 0x00, 0x00, 0x00];
+    private readonly byte[] _nextUpdateFrame;
+
+    protected UpdateModuleTest()
+    {
+        _nextUpdateFrame = [(byte)UpdateOrder, 0x00, 0x00, 0x00];
+    }
 
     protected override byte[] ModuleData() => [V1, .. base.ModuleData(), .. _nextUpdateFrame];
+
+    protected virtual UpdateOrder UpdateOrder => UpdateOrder.Order2;
 }

--- a/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
+++ b/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
@@ -7,8 +7,6 @@ namespace OpenSage.Logic.Object
 {
     public abstract class BehaviorModule : ModuleBase
     {
-        internal virtual void Update(BehaviorUpdateContext context) { }
-
         internal virtual void OnDie(BehaviorUpdateContext context, DeathType deathType, BitArray<ObjectStatus> status) { }
 
         internal virtual void OnDamageStateChanged(BehaviorUpdateContext context, BodyDamageType fromDamage, BodyDamageType toDamage) { }
@@ -52,7 +50,7 @@ namespace OpenSage.Logic.Object
         }
     }
 
-    public readonly struct LogicFrame
+    public readonly struct LogicFrame : IEquatable<LogicFrame>
     {
         public static readonly LogicFrame Zero = default;
         public static readonly LogicFrame MaxValue = new LogicFrame(uint.MaxValue);
@@ -99,10 +97,26 @@ namespace OpenSage.Logic.Object
             return left.Value >= right.Value;
         }
 
+        public static bool operator ==(LogicFrame left, LogicFrame right)
+        {
+            return left.Value == right.Value;
+        }
+
+        public static bool operator !=(LogicFrame left, LogicFrame right)
+        {
+            return left.Value != right.Value;
+        }
+
         public override string ToString()
         {
             return Value.ToString();
         }
+
+        public override bool Equals(object obj) => obj is LogicFrame frame && Equals(frame);
+
+        public bool Equals(LogicFrame other) => Value == other.Value;
+
+        public override int GetHashCode() => Value.GetHashCode();
     }
 
     public readonly struct LogicFrameSpan

--- a/src/OpenSage.Game/Logic/Object/Behaviors/AutoHealBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/AutoHealBehavior.cs
@@ -25,7 +25,7 @@ namespace OpenSage.Logic.Object
             _gameObject = gameObject;
             _context = context;
             _moduleData = moduleData;
-            NextUpdateFrame.Frame = uint.MaxValue;
+            SetNextUpdateFrame(new LogicFrame(uint.MaxValue));
             _upgradeLogic = new UpgradeLogic(moduleData.UpgradeData, OnUpgrade);
         }
 
@@ -36,7 +36,7 @@ namespace OpenSage.Logic.Object
         private void OnUpgrade()
         {
             // todo: if unit is max health and this is a self-heal behavior, even if upgrade was triggered, nextupdateframe is still maxvalue
-            NextUpdateFrame.Frame = _context.GameLogic.CurrentFrame.Value;
+            SetNextUpdateFrame(_context.GameLogic.CurrentFrame);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace OpenSage.Logic.Object
             {
                 var currentFrame = _context.GameLogic.CurrentFrame;
                 _endOfStartHealingDelay = currentFrame + _moduleData.StartHealingDelay;
-                NextUpdateFrame = new UpdateFrame(_endOfStartHealingDelay);
+                SetNextUpdateFrame(_endOfStartHealingDelay);
             }
         }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BuildingBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BuildingBehavior.cs
@@ -4,7 +4,7 @@ using OpenSage.Data.Ini;
 namespace OpenSage.Logic.Object
 {
     [AddedIn(SageGame.Bfme)]
-    public class BuildingBehavior : BehaviorModule
+    public class BuildingBehavior : UpdateModule
     {
         private readonly BuildingBehaviorModuleData _moduleData;
         private readonly GameObject _gameObject;

--- a/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
@@ -21,7 +21,7 @@ namespace OpenSage.Logic.Object
         public bool IsUnpacked { get; set; }
 
         internal CastleBehavior(GameObject gameObject, GameContext context, CastleBehaviorModuleData moduleData)
-            : base(gameObject, moduleData)
+            : base(gameObject, context, moduleData)
         {
             IsUnpacked = false;
             _moduleData = moduleData;

--- a/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
@@ -9,7 +9,7 @@ using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
-    internal sealed class CastleBehavior : BehaviorModule
+    internal sealed class CastleBehavior : FoundationAIUpdate
     {
         private GameObject _gameObject;
         private CastleBehaviorModuleData _moduleData;
@@ -21,6 +21,7 @@ namespace OpenSage.Logic.Object
         public bool IsUnpacked { get; set; }
 
         internal CastleBehavior(GameObject gameObject, GameContext context, CastleBehaviorModuleData moduleData)
+            : base(gameObject, moduleData)
         {
             IsUnpacked = false;
             _moduleData = moduleData;
@@ -152,34 +153,35 @@ namespace OpenSage.Logic.Object
     }
 
     [AddedIn(SageGame.Bfme)]
-    public class CastleBehaviorModuleData : BehaviorModuleData
+    public class CastleBehaviorModuleData : FoundationAIUpdateModuleData
     {
-        internal static CastleBehaviorModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
+        internal new static CastleBehaviorModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
 
-        internal static readonly IniParseTable<CastleBehaviorModuleData> FieldParseTable = new IniParseTable<CastleBehaviorModuleData>
-        {
-            { "SidesAllowed", (parser, x) => x.SidesAllowed.Add(Side.Parse(parser)) },
-            { "UseTheNewCastleSystemInsteadOfTheClunkyBuildList", (parser, x) => x.UseTheNewCastleSystemInsteadOfTheClunkyBuildList = parser.ParseBoolean() },
-            { "FilterValidOwnedEntries", (parser, x) => x.FilterValidOwnedEntries = ObjectFilter.Parse(parser) },
-            { "UseSecondaryBuildList", (parser, x) => x.UseSecondaryBuildList = parser.ParseBoolean() },
-            { "CastleToUnpackForFaction", (parser, x) => x.CastleToUnpackForFactions.Add(CastleEntry.Parse(parser)) },
-            { "MaxCastleRadius", (parser, x) => x.MaxCastleRadius = parser.ParseFloat() },
-            { "FadeTime", (parser, x) => x.FadeTime = parser.ParseFloat() },
-            { "ScanDistance", (parser, x) => x.ScanDistance = parser.ParseInteger() },
-            { "PreBuiltList", (parser, x) => x.PreBuiltList = PreBuildObject.Parse(parser) },
-            { "PreBuiltPlyr", (parser, x) => x.PreBuiltPlayer = parser.ParseString() },
-            { "FilterCrew", (parser, x) => x.FilterCrew = ObjectFilter.Parse(parser) },
-            { "CrewReleaseFX", (parser, x) => x.CrewReleaseFX = parser.ParseAssetReference() },
-            { "CrewPrepareFX", (parser, x) => x.CrewPrepareFX = parser.ParseAssetReference() },
-            { "CrewPrepareInterval", (parser, x) => x.CrewPrepareInterval = parser.ParseInteger() },
-            { "DisableStructureRotation", (parser, x) => x.DisableStructureRotation = parser.ParseBoolean() },
-            { "FactionDecal", (parser, x) => x.FactionDecals.Add(CastleEntry.Parse(parser)) },
-            { "InstantUnpack", (parser, x) => x.InstantUnpack = parser.ParseBoolean() },
-            { "KeepDeathKillsEverything", (parser, x) => x.KeepDeathKillsEverything = parser.ParseBoolean() },
-            { "EvaEnemyCastleSightedEvent", (parser, x) => x.EvaEnemyCastleSightedEvent = parser.ParseAssetReference() },
-            { "UnpackDelayTime", (parser, x) => x.UnpackDelayTime = parser.ParseFloat() },
-            { "Summoned", (parser, x) => x.Summoned = parser.ParseBoolean() }
-        };
+        internal new static readonly IniParseTable<CastleBehaviorModuleData> FieldParseTable = FoundationAIUpdateModuleData.FieldParseTable
+            .Concat(new IniParseTable<CastleBehaviorModuleData>
+            {
+                { "SidesAllowed", (parser, x) => x.SidesAllowed.Add(Side.Parse(parser)) },
+                { "UseTheNewCastleSystemInsteadOfTheClunkyBuildList", (parser, x) => x.UseTheNewCastleSystemInsteadOfTheClunkyBuildList = parser.ParseBoolean() },
+                { "FilterValidOwnedEntries", (parser, x) => x.FilterValidOwnedEntries = ObjectFilter.Parse(parser) },
+                { "UseSecondaryBuildList", (parser, x) => x.UseSecondaryBuildList = parser.ParseBoolean() },
+                { "CastleToUnpackForFaction", (parser, x) => x.CastleToUnpackForFactions.Add(CastleEntry.Parse(parser)) },
+                { "MaxCastleRadius", (parser, x) => x.MaxCastleRadius = parser.ParseFloat() },
+                { "FadeTime", (parser, x) => x.FadeTime = parser.ParseFloat() },
+                { "ScanDistance", (parser, x) => x.ScanDistance = parser.ParseInteger() },
+                { "PreBuiltList", (parser, x) => x.PreBuiltList = PreBuildObject.Parse(parser) },
+                { "PreBuiltPlyr", (parser, x) => x.PreBuiltPlayer = parser.ParseString() },
+                { "FilterCrew", (parser, x) => x.FilterCrew = ObjectFilter.Parse(parser) },
+                { "CrewReleaseFX", (parser, x) => x.CrewReleaseFX = parser.ParseAssetReference() },
+                { "CrewPrepareFX", (parser, x) => x.CrewPrepareFX = parser.ParseAssetReference() },
+                { "CrewPrepareInterval", (parser, x) => x.CrewPrepareInterval = parser.ParseInteger() },
+                { "DisableStructureRotation", (parser, x) => x.DisableStructureRotation = parser.ParseBoolean() },
+                { "FactionDecal", (parser, x) => x.FactionDecals.Add(CastleEntry.Parse(parser)) },
+                { "InstantUnpack", (parser, x) => x.InstantUnpack = parser.ParseBoolean() },
+                { "KeepDeathKillsEverything", (parser, x) => x.KeepDeathKillsEverything = parser.ParseBoolean() },
+                { "EvaEnemyCastleSightedEvent", (parser, x) => x.EvaEnemyCastleSightedEvent = parser.ParseAssetReference() },
+                { "UnpackDelayTime", (parser, x) => x.UnpackDelayTime = parser.ParseFloat() },
+                { "Summoned", (parser, x) => x.Summoned = parser.ParseBoolean() }
+            });
 
         public List<Side> SidesAllowed { get; } = new List<Side>();
         public bool UseTheNewCastleSystemInsteadOfTheClunkyBuildList { get; private set; }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/GateOpenAndCloseBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/GateOpenAndCloseBehavior.cs
@@ -8,7 +8,7 @@ using SharpAudio;
 namespace OpenSage.Logic.Object
 {
     [AddedIn(SageGame.Bfme)]
-    public class GateOpenAndCloseBehavior : BehaviorModule
+    public class GateOpenAndCloseBehavior : UpdateModule
     {
         private GameObject _gameObject;
         private GateOpenAndCloseBehaviorModuleData _moduleData;

--- a/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
@@ -31,7 +31,7 @@ namespace OpenSage.Logic.Object
             }
 
             // todo: this is fine for now, but generals seems to have some way of making sure it doesn't immediately sap health on subsequent toggles
-            NextUpdateFrame.Frame = _context.GameLogic.CurrentFrame.Value;
+            SetNextUpdateFrame(_context.GameLogic.CurrentFrame);
         }
 
         public void Deactivate()
@@ -42,7 +42,7 @@ namespace OpenSage.Logic.Object
             foreach (var powerPlantUpdate in _gameObject.FindBehaviors<PowerPlantUpdate>())
             {
                 powerPlantUpdate.RetractRods();
-                NextUpdateFrame.Frame = uint.MaxValue;
+                SetNextUpdateFrame(new LogicFrame(uint.MaxValue));
             }
         }
 
@@ -56,7 +56,7 @@ namespace OpenSage.Logic.Object
             }
 
             _gameObject.DoDamage(DamageType.Penalty, _moduleData.HealthPercentToDrainPerSecond, DeathType.Normal, _gameObject);
-            NextUpdateFrame.Frame += (uint)Game.LogicFramesPerSecond;
+            SetNextUpdateFrame(new LogicFrame((uint)Game.LogicFramesPerSecond));
         }
 
         internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
@@ -27,6 +27,8 @@ namespace OpenSage.Logic.Object
         private byte _unknownByte1;
         private byte _unknownByte2;
 
+        protected override UpdateOrder UpdateOrder => UpdateOrder.Order1;
+
         public float Mass
         {
             get => _mass;

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
@@ -7,7 +7,7 @@ using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
-    internal sealed class SpawnBehavior : BehaviorModule
+    internal sealed class SpawnBehavior : BehaviorModule, IUpdateModule
     {
         GameObject _gameObject;
         private readonly GameContext _context;
@@ -123,7 +123,7 @@ namespace OpenSage.Logic.Object
             }
         }
 
-        internal override void Update(BehaviorUpdateContext context)
+        public void Update(BehaviorUpdateContext context)
         {
             if (_initial && !_gameObject.IsBeingConstructed())
             {

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -732,7 +732,10 @@ namespace OpenSage.Logic.Object
                 {
                     continue; // if we're dead, we should only update SlowDeathBehavior, LifetimeUpdate, or DeletionUpdate
                 }
-                behavior.Update(_behaviorUpdateContext);
+                if (behavior is IUpdateModule updateModule)
+                {
+                    updateModule.Update(_behaviorUpdateContext);
+                }
             }
         }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectFiringTrackerHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectFiringTrackerHelper.cs
@@ -5,6 +5,8 @@
         private uint _numShotsFiredAtLastTarget;
         private uint _lastTargetObjectId;
 
+        protected override UpdateOrder UpdateOrder => UpdateOrder.Order3;
+
         internal override void Load(StatePersister reader)
         {
             reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectWeaponStatusHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectWeaponStatusHelper.cs
@@ -3,6 +3,7 @@
     internal sealed class ObjectWeaponStatusHelper : ObjectHelperModule
     {
         // TODO
+        protected override UpdateOrder UpdateOrder => UpdateOrder.Order3;
 
         internal override void Load(StatePersister reader)
         {

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/CashHackSpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/CashHackSpecialPower.cs
@@ -6,7 +6,7 @@ using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class CashHackSpecialPower : SpecialPowerModule, IUpgradableScienceModule
+    public sealed class CashHackSpecialPower : SpecialPowerModule
     {
         private readonly CashHackSpecialPowerModuleData _moduleData;
 
@@ -38,8 +38,10 @@ namespace OpenSage.Logic.Object
             reader.EndObject();
         }
 
-        public void TryUpgrade(Science purchasedScience)
+        public override void TryUpgrade(Science purchasedScience)
         {
+            base.TryUpgrade(purchasedScience);
+
             foreach (var (science, amount) in _moduleData.UpgradeMoneyAmounts)
             {
                 if (science.Value == purchasedScience)

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/OCLSpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/OCLSpecialPower.cs
@@ -8,7 +8,7 @@ using OpenSage.Terrain;
 
 namespace OpenSage.Logic.Object
 {
-    public class OCLSpecialPowerModule : SpecialPowerModule, IUpgradableScienceModule
+    public class OCLSpecialPowerModule : SpecialPowerModule
     {
         private readonly OCLSpecialPowerModuleData _moduleData;
         private ObjectCreationList _activeOcl;
@@ -146,8 +146,10 @@ namespace OpenSage.Logic.Object
             reader.EndObject();
         }
 
-        public void TryUpgrade(Science purchasedScience)
+        public override void TryUpgrade(Science purchasedScience)
         {
+            base.TryUpgrade(purchasedScience);
+
             foreach (var (science, ocl) in _moduleData.UpgradeOCLs)
             {
                 if (science.Value == purchasedScience)

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialPower.cs
@@ -6,7 +6,7 @@ using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
-    public class SpecialPowerModule : BehaviorModule
+    public class SpecialPowerModule : BehaviorModule, IUpgradableScienceModule
     {
         /// <summary>
         /// The next frame when this special power can be used
@@ -88,7 +88,7 @@ namespace OpenSage.Logic.Object
             return progress;
         }
 
-        internal override void Update(BehaviorUpdateContext context)
+        public virtual void TryUpgrade(Science purchasedScience)
         {
             if (!_unlocked)
             {

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -84,6 +84,8 @@ namespace OpenSage.Logic.Object
         /// </summary>
         public List<Vector3> TargetPoints { get; set; }
 
+        protected override UpdateOrder UpdateOrder => UpdateOrder.Order0;
+
         internal AIUpdate(GameObject gameObject, GameContext context, AIUpdateModuleData moduleData)
         {
             GameObject = gameObject;

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
@@ -52,11 +52,11 @@ namespace OpenSage.Logic.Object
     }
 
 
-    public sealed class FoundationAIUpdateModuleData : AIUpdateModuleData
+    public class FoundationAIUpdateModuleData : AIUpdateModuleData
     {
         internal new static FoundationAIUpdateModuleData Parse(IniParser parser) => parser.ParseBlock(FieldParseTable);
 
-        private new static readonly IniParseTable<FoundationAIUpdateModuleData> FieldParseTable = AIUpdateModuleData.FieldParseTable
+        internal new static readonly IniParseTable<FoundationAIUpdateModuleData> FieldParseTable = AIUpdateModuleData.FieldParseTable
             .Concat(new IniParseTable<FoundationAIUpdateModuleData>
             {
                 { "BuildVariation", (parser, x) => x.BuildVariation = parser.ParseInteger() },

--- a/src/OpenSage.Game/Logic/Object/Update/AutoFindHealingUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoFindHealingUpdate.cs
@@ -11,19 +11,19 @@ namespace OpenSage.Logic.Object
             _moduleData = moduleData;
         }
 
-        private LogicFrameSpan _framesTillNextScan;
+        private LogicFrameSpan _framesUntilNextScan;
 
         private protected override void RunUpdate(BehaviorUpdateContext context)
         {
-            if (_framesTillNextScan == LogicFrameSpan.Zero)
+            if (_framesUntilNextScan == LogicFrameSpan.Zero)
             {
-                _framesTillNextScan = _moduleData.ScanRate;
+                _framesUntilNextScan = _moduleData.ScanRate;
 
                 // TODO: Find healing.
             }
             else
             {
-                _framesTillNextScan--;
+                _framesUntilNextScan--;
             }
         }
 
@@ -35,7 +35,7 @@ namespace OpenSage.Logic.Object
             base.Load(reader);
             reader.EndObject();
 
-            reader.PersistLogicFrameSpan(ref _framesTillNextScan);
+            reader.PersistLogicFrameSpan(ref _framesUntilNextScan);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AutoFindHealingUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoFindHealingUpdate.cs
@@ -4,7 +4,28 @@ namespace OpenSage.Logic.Object
 {
     public sealed class AutoFindHealingUpdate : UpdateModule
     {
-        private uint _unknown;
+        private readonly AutoFindHealingUpdateModuleData _moduleData;
+
+        public AutoFindHealingUpdate(AutoFindHealingUpdateModuleData moduleData)
+        {
+            _moduleData = moduleData;
+        }
+
+        private LogicFrameSpan _framesTillNextScan;
+
+        private protected override void RunUpdate(BehaviorUpdateContext context)
+        {
+            if (_framesTillNextScan == LogicFrameSpan.Zero)
+            {
+                _framesTillNextScan = _moduleData.ScanRate;
+
+                // TODO: Find healing.
+            }
+            else
+            {
+                _framesTillNextScan--;
+            }
+        }
 
         internal override void Load(StatePersister reader)
         {
@@ -14,7 +35,7 @@ namespace OpenSage.Logic.Object
             base.Load(reader);
             reader.EndObject();
 
-            reader.PersistUInt32(ref _unknown);
+            reader.PersistLogicFrameSpan(ref _framesTillNextScan);
         }
     }
 
@@ -27,20 +48,20 @@ namespace OpenSage.Logic.Object
 
         private static readonly IniParseTable<AutoFindHealingUpdateModuleData> FieldParseTable = new IniParseTable<AutoFindHealingUpdateModuleData>
         {
-            { "ScanRate", (parser, x) => x.ScanRate = parser.ParseInteger() },
+            { "ScanRate", (parser, x) => x.ScanRate = parser.ParseTimeMillisecondsToLogicFrames() },
             { "ScanRange", (parser, x) => x.ScanRange = parser.ParseInteger() },
             { "NeverHeal", (parser, x) => x.NeverHeal = parser.ParseFloat() },
             { "AlwaysHeal", (parser, x) => x.AlwaysHeal = parser.ParseFloat() }
         };
 
-        public int ScanRate { get; private set; }
+        public LogicFrameSpan ScanRate { get; private set; }
         public int ScanRange { get; private set; }
         public float NeverHeal { get; private set; }
         public float AlwaysHeal { get; private set; }
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
         {
-            return new AutoFindHealingUpdate();
+            return new AutoFindHealingUpdate(this);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/BaseRegenerateUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BaseRegenerateUpdate.cs
@@ -14,7 +14,7 @@ namespace OpenSage.Logic.Object
         {
             _gameObject = gameObject;
             _context = context;
-            NextUpdateFrame.Frame = uint.MaxValue;
+            SetNextUpdateFrame(new LogicFrame(uint.MaxValue));
         }
 
         /// <summary>
@@ -23,7 +23,7 @@ namespace OpenSage.Logic.Object
         public void OnDamage(in DamageData damageData)
         {
             var currentFrame = _context.GameLogic.CurrentFrame;
-            NextUpdateFrame = new UpdateFrame(currentFrame + _context.AssetLoadContext.AssetStore.GameData.Current.BaseRegenDelay);
+            SetNextUpdateFrame(currentFrame + _context.AssetLoadContext.AssetStore.GameData.Current.BaseRegenDelay);
         }
 
         private protected override void RunUpdate(BehaviorUpdateContext context)
@@ -32,7 +32,7 @@ namespace OpenSage.Logic.Object
 
             if (_gameObject.IsFullHealth)
             {
-                NextUpdateFrame.Frame = uint.MaxValue;
+                SetNextUpdateFrame(new LogicFrame(uint.MaxValue));
             }
         }
 

--- a/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
@@ -17,7 +17,7 @@ namespace OpenSage.Logic.Object
             _moduleData = moduleData;
 
             _frameToDelete = context.GameLogic.CurrentFrame + context.GetRandomLogicFrameSpan(_moduleData.MinLifetime, _moduleData.MaxLifetime);
-            NextUpdateFrame = new UpdateFrame(_frameToDelete);
+            SetNextUpdateFrame(_frameToDelete);
         }
 
         internal override void Update(BehaviorUpdateContext context)

--- a/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
@@ -12,6 +12,11 @@ namespace OpenSage.Logic.Object
 
         protected virtual UpdateOrder UpdateOrder => UpdateOrder.Order2;
 
+        protected UpdateModule()
+        {
+            _nextUpdateFrame.UpdateOrder = UpdateOrder;
+        }
+
         private protected virtual void RunUpdate(BehaviorUpdateContext context) { }
 
         void IUpdateModule.Update(BehaviorUpdateContext context)

--- a/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
@@ -2,25 +2,38 @@
 
 namespace OpenSage.Logic.Object
 {
-    public abstract class UpdateModule : BehaviorModule
+    public abstract class UpdateModule : BehaviorModule, IUpdateModule
     {
-        // it's also possible this is _last_ update, not next update
-        protected UpdateFrame NextUpdateFrame;
+        private UpdateFrame _nextUpdateFrame;
+
+        protected UpdateFrame NextUpdateFrame => _nextUpdateFrame;
 
         protected virtual LogicFrameSpan FramesBetweenUpdates { get; } = new(1);
 
+        protected virtual UpdateOrder UpdateOrder => UpdateOrder.Order2;
+
         private protected virtual void RunUpdate(BehaviorUpdateContext context) { }
 
-        // todo: seal this method?
-        internal override void Update(BehaviorUpdateContext context)
+        void IUpdateModule.Update(BehaviorUpdateContext context)
         {
-            if (context.LogicFrame.Value < NextUpdateFrame.Frame)
+            Update(context);
+        }
+
+        // todo: seal this method?
+        internal virtual void Update(BehaviorUpdateContext context)
+        {
+            if (context.LogicFrame.Value < _nextUpdateFrame.Frame)
             {
                 return;
             }
 
-            NextUpdateFrame = new UpdateFrame(context.LogicFrame + FramesBetweenUpdates);
+            SetNextUpdateFrame(context.LogicFrame + FramesBetweenUpdates);
             RunUpdate(context);
+        }
+
+        protected void SetNextUpdateFrame(LogicFrame frame)
+        {
+            _nextUpdateFrame = new UpdateFrame(frame, UpdateOrder);
         }
 
         internal override void Load(StatePersister reader)
@@ -31,12 +44,17 @@ namespace OpenSage.Logic.Object
             base.Load(reader);
             reader.EndObject();
 
-            reader.PersistUpdateFrame(ref NextUpdateFrame);
+            var currentUpdateOrder = _nextUpdateFrame.UpdateOrder;
+            reader.PersistUpdateFrame(ref _nextUpdateFrame);
+            if (reader.Mode == StatePersistMode.Read && _nextUpdateFrame.UpdateOrder != currentUpdateOrder)
+            {
+                throw new InvalidStateException();
+            }
         }
 
         internal override void DrawInspector()
         {
-            ImGui.LabelText("Next update frame", NextUpdateFrame.Frame.ToString());
+            ImGui.LabelText("Next update frame", _nextUpdateFrame.Frame.ToString());
         }
     }
 
@@ -44,9 +62,10 @@ namespace OpenSage.Logic.Object
     {
         public uint RawValue;
 
-        public UpdateFrame(LogicFrame frame)
+        public UpdateFrame(LogicFrame frame, UpdateOrder updateOrder)
         {
             Frame = frame.Value;
+            UpdateOrder = updateOrder;
         }
 
         public uint Frame
@@ -55,11 +74,24 @@ namespace OpenSage.Logic.Object
             set => RawValue = (value << 2) | (RawValue & 0x3);
         }
 
-        public byte Something
+        public UpdateOrder UpdateOrder
         {
-            get => (byte)(RawValue & 0x3);
-            set => RawValue = (RawValue & 0xFFFFFFFC) | (value);
+            get => (UpdateOrder)(RawValue & 0x3);
+            set => RawValue = (RawValue & 0xFFFFFFFC) | (byte)(value);
         }
+    }
+
+    public enum UpdateOrder : byte
+    {
+        Order0 = 0,
+        Order1 = 1,
+        Order2 = 2,
+        Order3 = 3,
+    }
+
+    internal interface IUpdateModule
+    {
+        void Update(BehaviorUpdateContext context);
     }
 
     public abstract class UpdateModuleData : ContainModuleData

--- a/src/OpenSage.Mathematics/BitArray`1.cs
+++ b/src/OpenSage.Mathematics/BitArray`1.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -171,17 +172,12 @@ namespace OpenSage.Mathematics
             return result;
         }
 
-        private static readonly Dictionary<Type, int> CachedNumValues = new Dictionary<Type, int>();
+        private static readonly ConcurrentDictionary<Type, int> CachedNumValues = new();
 
         private static int GetNumValues()
         {
             var key = typeof(TEnum);
-            if (!CachedNumValues.TryGetValue(key, out var result))
-            {
-                result = Enum.GetValues(key).Length;
-                CachedNumValues.Add(key, result);
-            }
-            return result;
+            return CachedNumValues.GetOrAdd(key, x => Enum.GetValues(x).Length);
         }
     }
 }

--- a/src/OpenSage.Tools.Sav2Json/JsonSaveWriter.cs
+++ b/src/OpenSage.Tools.Sav2Json/JsonSaveWriter.cs
@@ -150,8 +150,8 @@ internal sealed class JsonSaveWriter : StatePersister
         var frame = value.Frame;
         PersistUInt32(ref frame);
 
-        var something = value.Something;
-        PersistByte(ref something);
+        var updateOrder = value.UpdateOrder;
+        PersistEnum(ref updateOrder);
     }
 
     public override void SkipUnknownBytes(int numBytes)


### PR DESCRIPTION
Small refactoring of `UpdateModule` based on parsing `UpdateFrame.Something` as probably meaning the execution order that update modules are updated. This value is always constant for a given module type. It is always either 0, 1, 2, or 3. Almost all module types are 2. Some examples:

- AIUpdate and its subclasses: 0
- PhysicsBehavior: 1
- _every other update module that I've seen_: 2
- ObjectWeaponStatusHelper: 3
- ObjectFiringTrackerHelper: 3

The order makes some sense - `AIUpdate` does the majority of stuff, including applying physics forces etc. Then `PhysicsBehavior` updates object's position and angle. Then all the other `UpdateModule`s do their thing (although this would imply that any physics forces applied by these update modules don't get applied till the next frame, which would be an interesting way to confirm this theory). Then `ObjectWeaponStatusHelper` and `ObjectFiringTrackerHelper` (which, guessing from the state stored in it, takes care of continuous fire weapons) which respond to changes in weapon state caused by everything before them.

My guess is that it only happens to be persisted because it's bit-packed into the `NextUpdateFrame` value. If it wasn't, they probably wouldn't have bothered persisting it. But they also didn't bother to remove it from the bit-packed value before persisting.

And the value can't be any higher than 3, because it's bit-packed into the low 2 bits of `NextUpdateFrame`. Because of the way it's bit-packed, you could do a simple sort of the uint value for `NextUpdateFrame` for all update modules, and that would give you the correct order of `UpdateModule`s in frame order, and then in execution order for that frame. Perhaps that's what the original engine did.