### PR TITLE
Capture mouse scroll events over window controls

### DIFF
--- a/src/OpenSage.Game.Tests/GameWindowTests.cs
+++ b/src/OpenSage.Game.Tests/GameWindowTests.cs
@@ -1,0 +1,50 @@
+﻿using System.Reflection;
+using OpenSage.Input;
+using Veldrid.Sdl2;
+using Xunit;
+
+namespace OpenSage.Tests;
+
+public class GameWindowTests : StatePersisterTest
+{
+    [Fact]
+    public void GameWindow_Create()
+    {
+        var gameWindow = new GameWindow("Generals", 0, 0, 1024, 768, false);
+
+        Assert.NotNull(gameWindow);
+    }
+
+    [Fact]
+    public void GameWindow_HandleMouseWheel_When_NotZeroDelta()
+    {
+        var gameWindow = new GameWindow("Generals", 0, 0, 1024, 768, false);
+
+        var methodInfo = typeof(GameWindow).GetMethod("HandleMouseWheel", BindingFlags.NonPublic | BindingFlags.Instance);
+        methodInfo.Invoke(gameWindow, [buildMouseWheelEventArgs(x: 100, y: 50, wheelDelta: 5)]);
+
+        Assert.Single(gameWindow.MessageQueue);
+        var inputMessage = gameWindow.MessageQueue.Dequeue();
+        Assert.Equal(InputMessageType.MouseWheel, inputMessage.MessageType);
+        Assert.Equal(500, inputMessage.Value.ScrollWheel); // Mouse wheel delta is multiplied by 100
+        Assert.Equal(100, inputMessage.Value.MousePosition.X);
+        Assert.Equal(50, inputMessage.Value.MousePosition.Y);
+    }
+
+    [Fact]
+    public void GameWindow_HandleMouseWheel_When_ZeroDelta()
+    {
+        var gameWindow = new GameWindow("Generals", 0, 0, 1024, 768, false);
+
+        var methodInfo = typeof(GameWindow).GetMethod("HandleMouseWheel", BindingFlags.NonPublic | BindingFlags.Instance);
+        methodInfo.Invoke(gameWindow, [buildMouseWheelEventArgs(x: 100, y: 50, wheelDelta: 0)]);
+
+        Assert.Empty(gameWindow.MessageQueue);
+    }
+
+    private static MouseWheelEventArgs buildMouseWheelEventArgs(int x, int y, int wheelDelta)
+    {
+        var mouseState = new MouseState(x, y, false, false, false, false, false, false, false, false, false, false, false, false, false);
+        return new MouseWheelEventArgs(mouseState,wheelDelta);
+    }
+}

--- a/src/OpenSage.Game.Tests/GameWindowTests.cs
+++ b/src/OpenSage.Game.Tests/GameWindowTests.cs
@@ -7,7 +7,7 @@ namespace OpenSage.Tests;
 
 public class GameWindowTests : StatePersisterTest
 {
-    [Fact]
+    [WindowsOnlyFact]
     public void GameWindow_Create()
     {
         var gameWindow = new GameWindow("Generals", 0, 0, 1024, 768, false);
@@ -15,7 +15,7 @@ public class GameWindowTests : StatePersisterTest
         Assert.NotNull(gameWindow);
     }
 
-    [Fact]
+    [WindowsOnlyFact]
     public void GameWindow_HandleMouseWheel_When_NotZeroDelta()
     {
         var gameWindow = new GameWindow("Generals", 0, 0, 1024, 768, false);
@@ -31,7 +31,7 @@ public class GameWindowTests : StatePersisterTest
         Assert.Equal(50, inputMessage.Value.MousePosition.Y);
     }
 
-    [Fact]
+    [WindowsOnlyFact]
     public void GameWindow_HandleMouseWheel_When_ZeroDelta()
     {
         var gameWindow = new GameWindow("Generals", 0, 0, 1024, 768, false);

--- a/src/OpenSage.Game.Tests/Gui/Wnd/WndInputMessageHandlerTests.cs
+++ b/src/OpenSage.Game.Tests/Gui/Wnd/WndInputMessageHandlerTests.cs
@@ -1,0 +1,26 @@
+﻿using OpenSage.Input;
+using OpenSage.Gui.Wnd;
+using OpenSage.Mathematics;
+using OpenSage.Data.Wnd;
+using OpenSage.Gui.Wnd.Controls;
+using Xunit;
+
+namespace OpenSage.Tests.Gui.Wnd
+{
+    public class WndInputMessageHandlerTests(GameFixture fixture) : IClassFixture<GameFixture>
+    {
+        private readonly GameFixture _fixture = fixture;
+
+        [Fact]
+        public void HandleMessage_When_MouseWheelEventWithNoControlUnderMouse()
+        {
+            var game = _fixture.GetGame(SageGame.CncGenerals);
+            var windowManager = new WndWindowManager(game);
+            var handler = new WndInputMessageHandler(windowManager, game);
+
+            var inputMessage = InputMessage.CreateMouseWheel(500, new Point2D(100, 50));
+            var result = handler.HandleMessage(inputMessage);
+            Assert.Equal(InputMessageResult.NotHandled, result);
+        }
+    }
+}

--- a/src/OpenSage.Game.Tests/Gui/Wnd/WndInputMessageHandlerTests.cs
+++ b/src/OpenSage.Game.Tests/Gui/Wnd/WndInputMessageHandlerTests.cs
@@ -9,9 +9,13 @@ namespace OpenSage.Tests.Gui.Wnd
 {
     public class WndInputMessageHandlerTests(GameFixture fixture) : IClassFixture<GameFixture>
     {
+        // swap to the null skip message in order to run locally
+        private const string Skip = "game files required";
+        // private const string? Skip = null;
+
         private readonly GameFixture _fixture = fixture;
 
-        [Fact]
+        [Fact(Skip = Skip)]
         public void HandleMessage_When_MouseWheelEventWithNoControlUnderMouse()
         {
             var game = _fixture.GetGame(SageGame.CncGenerals);

--- a/src/OpenSage.Game.Tests/WindowsOnlyFact.cs
+++ b/src/OpenSage.Game.Tests/WindowsOnlyFact.cs
@@ -1,0 +1,16 @@
+using System.Runtime.InteropServices;
+using System;
+using Xunit;
+
+namespace OpenSage.Tests
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class WindowsOnlyFact : FactAttribute
+    {
+        public WindowsOnlyFact() {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                Skip = "Ignore on non-Windows platforms because there is an issue with loading NuGet packaged SDL2 library in tests";
+            }
+        }
+    }
+}

--- a/src/OpenSage.Game/GameWindow.cs
+++ b/src/OpenSage.Game/GameWindow.cs
@@ -190,7 +190,12 @@ namespace OpenSage
 
         private void HandleMouseWheel(MouseWheelEventArgs args)
         {
-            var message = InputMessage.CreateMouseWheel((int) (args.WheelDelta * 100));
+            if (args.WheelDelta == 0) {
+                return;
+            }
+
+            var point = new Point2D(args.State.X, args.State.Y);
+            var message = InputMessage.CreateMouseWheel((int) (args.WheelDelta * 100), point);
             MessageQueue.Enqueue(message);
         }
 

--- a/src/OpenSage.Game/Gui/Wnd/WndInputMessageHandler.cs
+++ b/src/OpenSage.Game/Gui/Wnd/WndInputMessageHandler.cs
@@ -143,9 +143,10 @@ namespace OpenSage.Gui.Wnd
                         break;
                     }
 
-                // For the time being, just consume middle click events so that they don't go through controls:
+                // For the time being, just consume middle click and wheel events so that they don't go through controls:
                 case InputMessageType.MouseMiddleButtonDown:
                 case InputMessageType.MouseMiddleButtonUp:
+                case InputMessageType.MouseWheel:
                     {
                         return GetControlAtPoint(message.Value.MousePosition, out var _, out var _)
                             ? InputMessageResult.Handled

--- a/src/OpenSage.Game/Input/InputMessage.cs
+++ b/src/OpenSage.Game/Input/InputMessage.cs
@@ -25,9 +25,9 @@ namespace OpenSage.Input
             return new InputMessage(InputMessageType.MouseMove, new InputMessageValue(position));
         }
 
-        public static InputMessage CreateMouseWheel(int value)
+        public static InputMessage CreateMouseWheel(int value, in Point2D position)
         {
-            return new InputMessage(InputMessageType.MouseWheel, new InputMessageValue(value));
+            return new InputMessage(InputMessageType.MouseWheel, new InputMessageValue(value, position));
         }
 
         public InputMessageType MessageType { get; }

--- a/src/OpenSage.Game/Input/InputMessageValue.cs
+++ b/src/OpenSage.Game/Input/InputMessageValue.cs
@@ -7,17 +7,19 @@ namespace OpenSage.Input
     [StructLayout(LayoutKind.Explicit)]
     public readonly struct InputMessageValue
     {
+        // Keyboard-related values
         [FieldOffset(0)]
         public readonly Key Key;
 
+        [FieldOffset(sizeof(Key))]
+        public readonly ModifierKeys Modifiers;
+
+        // Mouse-related values
         [FieldOffset(0)]
         public readonly Point2D MousePosition;
 
-        [FieldOffset(0)]
+        [FieldOffset(sizeof(int) * 2)] // Size of Point2D, because sizeof(Point2D) doesn't work
         public readonly int ScrollWheel;
-
-        [FieldOffset(sizeof(Key))]
-        public readonly ModifierKeys Modifiers;
 
         internal InputMessageValue(Key key, ModifierKeys modifiers)
         {
@@ -35,11 +37,11 @@ namespace OpenSage.Input
             MousePosition = mousePosition;
         }
 
-        internal InputMessageValue(int scrollWheel)
+        internal InputMessageValue(int scrollWheel, in Point2D mousePosition)
         {
             Key = 0;
-            MousePosition = Point2D.Zero;
             Modifiers = 0;
+            MousePosition = mousePosition;
             ScrollWheel = scrollWheel;
         }
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Numerics;
 using OpenSage.Data.Ini;
 using OpenSage.Logic.AI;
@@ -100,7 +100,7 @@ namespace OpenSage.Logic.Object
 
             SetLocomotor(LocomotorSetType.Normal);
 
-            if (ModuleData.Turret != null)
+            if (ModuleData != null && ModuleData.Turret != null)
             {
                 _turretAIUpdate = ModuleData.Turret.CreateTurretAIUpdate(GameObject);
             }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Numerics;
 using OpenSage.Data.Ini;
 using OpenSage.Logic.AI;
@@ -100,7 +100,7 @@ namespace OpenSage.Logic.Object
 
             SetLocomotor(LocomotorSetType.Normal);
 
-            if (ModuleData != null && ModuleData.Turret != null)
+            if (ModuleData.Turret != null)
             {
                 _turretAIUpdate = ModuleData.Turret.CreateTurretAIUpdate(GameObject);
             }


### PR DESCRIPTION
This adds mouse coordinates to mouse wheel events, so we can check if there is a window control under the mouse when scroll event occurs and handle that event on window level. This fixes ability to zoom map in main menu and also in-game when mouse is over controls like command bar and other windows. Fixes #698 