### PR TITLE
Consolidate PersistBase

### DIFF
--- a/src/OpenSage.Game/Logic/AI/AIStates/AIState32.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/AIState32.cs
@@ -16,7 +16,7 @@ internal sealed class AIState32 : FollowWaypointsState
     {
         reader.PersistVersion(1);
 
-        base.Persist(reader);
+        reader.PersistBase(base.Persist);
 
         reader.PersistObject(_stateMachine);
     }
@@ -32,7 +32,7 @@ internal sealed class AIState32 : FollowWaypointsState
         {
             reader.PersistVersion(1);
 
-            base.Persist(reader);
+            reader.PersistBase(base.Persist);
         }
     }
 

--- a/src/OpenSage.Game/Logic/AI/AIStates/AIState6.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/AIState6.cs
@@ -16,7 +16,7 @@ internal sealed class AIState6 : MoveTowardsState
     {
         reader.PersistVersion(1);
 
-        base.Persist(reader);
+        reader.PersistBase(base.Persist);
 
         reader.PersistInt32(ref _unknownInt);
         reader.PersistBoolean(ref _unknownBool1);

--- a/src/OpenSage.Game/Logic/AI/AIStates/AttackAreaState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/AttackAreaState.cs
@@ -41,9 +41,7 @@ namespace OpenSage.Logic.AI.AIStates
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Persist(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Persist);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/AI/AIStates/AttackMoveState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/AttackMoveState.cs
@@ -18,7 +18,7 @@ namespace OpenSage.Logic.AI.AIStates
         {
             reader.PersistVersion(2);
 
-            base.Persist(reader);
+            reader.PersistBase(base.Persist);
 
             reader.PersistInt32(ref _unknownInt1);
             reader.PersistInt32(ref _unknownInt2);
@@ -37,7 +37,7 @@ namespace OpenSage.Logic.AI.AIStates
         {
             reader.PersistVersion(1);
 
-            base.Persist(reader);
+            reader.PersistBase(base.Persist);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/AI/AIStates/AttackState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/AttackState.cs
@@ -41,9 +41,7 @@ namespace OpenSage.Logic.AI.AIStates
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Persist(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Persist);
         }
 
         private sealed class AttackMoveTowardsTargetState : MoveTowardsState
@@ -63,9 +61,7 @@ namespace OpenSage.Logic.AI.AIStates
             {
                 reader.PersistVersion(1);
 
-                reader.BeginObject("Base");
-                base.Persist(reader);
-                reader.EndObject();
+                reader.PersistBase(base.Persist);
 
                 reader.PersistVector3(ref _unknownPosition);
                 reader.PersistFrame(ref _unknownFrame);

--- a/src/OpenSage.Game/Logic/AI/AIStates/DockState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/DockState.cs
@@ -46,9 +46,7 @@ namespace OpenSage.Logic.AI.AIStates
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Persist(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Persist);
 
             reader.PersistUInt32(ref _unknownInt);
         }
@@ -63,9 +61,7 @@ namespace OpenSage.Logic.AI.AIStates
             {
                 reader.PersistVersion(2);
 
-                reader.BeginObject("Base");
-                base.Persist(reader);
-                reader.EndObject();
+                reader.PersistBase(base.Persist);
             }
         }
 

--- a/src/OpenSage.Game/Logic/AI/AIStates/EnterContainerState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/EnterContainerState.cs
@@ -14,9 +14,7 @@ namespace OpenSage.Logic.AI.AIStates
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Persist(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Persist);
 
             reader.PersistObjectID(ref _containerObjectId);
         }

--- a/src/OpenSage.Game/Logic/AI/AIStates/FollowPathState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/FollowPathState.cs
@@ -16,7 +16,7 @@ namespace OpenSage.Logic.AI.AIStates
         {
             reader.PersistVersion(1);
 
-            base.Persist(reader);
+            reader.PersistBase(base.Persist);
 
             reader.PersistUInt32(ref _unknownInt1);
             reader.PersistBoolean(ref _unknownBool1);

--- a/src/OpenSage.Game/Logic/AI/AIStates/FollowWaypointsExactState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/FollowWaypointsExactState.cs
@@ -17,7 +17,7 @@ namespace OpenSage.Logic.AI.AIStates
         {
             reader.PersistVersion(1);
 
-            base.Persist(reader);
+            reader.PersistBase(base.Persist);
 
             reader.PersistUInt32(ref _waypointId);
         }

--- a/src/OpenSage.Game/Logic/AI/AIStates/FollowWaypointsState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/FollowWaypointsState.cs
@@ -23,7 +23,7 @@ namespace OpenSage.Logic.AI.AIStates
         {
             reader.PersistVersion(1);
 
-            base.Persist(reader);
+            reader.PersistBase(base.Persist);
 
             reader.PersistUInt32(ref _unknownInt1);
             reader.PersistUInt32(ref _unknownInt2);

--- a/src/OpenSage.Game/Logic/AI/AIStates/GuardInTunnelNetworkState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/GuardInTunnelNetworkState.cs
@@ -43,7 +43,7 @@ namespace OpenSage.Logic.AI.AIStates
         {
             reader.PersistVersion(2);
 
-            base.Persist(reader);
+            reader.PersistBase(base.Persist);
 
             reader.PersistObjectID(ref _guardObjectId);
             reader.PersistVector3(ref _guardPosition);
@@ -77,7 +77,7 @@ namespace OpenSage.Logic.AI.AIStates
             {
                 reader.PersistVersion(1);
 
-                base.Persist(reader);
+                reader.PersistBase(base.Persist);
 
                 reader.PersistUInt32(ref _unknownInt);
             }

--- a/src/OpenSage.Game/Logic/AI/AIStates/GuardState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/GuardState.cs
@@ -42,9 +42,7 @@ namespace OpenSage.Logic.AI.AIStates
         {
             reader.PersistVersion(2);
 
-            reader.BeginObject("Base");
-            base.Persist(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Persist);
 
             reader.PersistObjectID(ref _guardObjectId);
             reader.PersistObjectID(ref _guardObjectId2);

--- a/src/OpenSage.Game/Logic/AI/AIStates/PanicState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/PanicState.cs
@@ -17,7 +17,7 @@ namespace OpenSage.Logic.AI.AIStates
         {
             reader.PersistVersion(1);
 
-            base.Persist(reader);
+            reader.PersistBase(base.Persist);
 
             reader.PersistUInt32(ref _unknownInt1);
             reader.PersistUInt32(ref _unknownInt2);

--- a/src/OpenSage.Game/Logic/AI/AIStates/WanderInPlaceState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/WanderInPlaceState.cs
@@ -17,7 +17,7 @@ namespace OpenSage.Logic.AI.AIStates
         {
             reader.PersistVersion(1);
 
-            base.Persist(reader);
+            reader.PersistBase(base.Persist);
 
             reader.PersistVector3(ref _unknownPos);
             reader.PersistUInt32(ref _unknownInt);

--- a/src/OpenSage.Game/Logic/AI/AIStates/WanderState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/WanderState.cs
@@ -16,7 +16,7 @@ namespace OpenSage.Logic.AI.AIStates
         {
             reader.PersistVersion(1);
 
-            base.Persist(reader);
+            reader.PersistBase(base.Persist);
 
             reader.PersistUInt32(ref _unknownInt1);
             reader.PersistUInt32(ref _unknownInt2);

--- a/src/OpenSage.Game/Logic/AI/AIUpdateStateMachine.cs
+++ b/src/OpenSage.Game/Logic/AI/AIUpdateStateMachine.cs
@@ -79,9 +79,7 @@ namespace OpenSage.Logic.AI
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Persist(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Persist);
 
             reader.PersistListWithUInt32Count(
                 _targetPositions,

--- a/src/OpenSage.Game/Logic/AI/SkirmishAIPlayer.cs
+++ b/src/OpenSage.Game/Logic/AI/SkirmishAIPlayer.cs
@@ -17,9 +17,7 @@
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Persist(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Persist);
 
             reader.PersistInt32(ref _unknownInt1);
             reader.PersistInt32(ref _unknownInt2);

--- a/src/OpenSage.Game/Logic/AI/SupplyAIUpdateStateMachine.cs
+++ b/src/OpenSage.Game/Logic/AI/SupplyAIUpdateStateMachine.cs
@@ -24,8 +24,6 @@ internal sealed class SupplyAIUpdateStateMachine : StateMachineBase
     {
         reader.PersistVersion(1);
 
-        reader.BeginObject("Base");
-        base.Persist(reader);
-        reader.EndObject();
+        reader.PersistBase(base.Persist);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
+++ b/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
@@ -23,9 +23,7 @@ namespace OpenSage.Logic.Object
             // Since we don't have that at the moment, just read it here.
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.EndObject();
         }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/AutoHealBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/AutoHealBehavior.cs
@@ -140,9 +140,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistObject(_upgradeLogic);
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BezierProjectileBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BezierProjectileBehavior.cs
@@ -106,9 +106,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistObjectID(ref _launcherObjectId);
             reader.PersistObjectID(ref _targetObjectId);

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BridgeBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BridgeBehavior.cs
@@ -11,9 +11,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistArray(
                 _towerIds,
@@ -27,7 +25,7 @@ namespace OpenSage.Logic.Object
     }
 
     /// <summary>
-    /// Special-case logic allows for ParentObject to be specified as a bone name to allow other 
+    /// Special-case logic allows for ParentObject to be specified as a bone name to allow other
     /// objects to appear on the bridge.
     /// </summary>
     public sealed class BridgeBehaviorModuleData : BehaviorModuleData

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BridgeTowerBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BridgeTowerBehavior.cs
@@ -11,9 +11,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistInt32(ref _unknown1);
             reader.PersistInt32(ref _unknown2);

--- a/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDamagedBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDamagedBehavior.cs
@@ -116,7 +116,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
 
             reader.PersistObject(UpgradeLogic);
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDeadBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDeadBehavior.cs
@@ -62,9 +62,7 @@ public sealed class FireWeaponWhenDeadBehavior : BehaviorModule, IUpgradeableMod
     {
         reader.PersistVersion(1);
 
-        reader.BeginObject("Base");
-        base.Load(reader);
-        reader.EndObject();
+        reader.PersistBase(base.Load);
 
         reader.PersistObject(UpgradeLogic);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/GenerateMinefieldBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/GenerateMinefieldBehavior.cs
@@ -173,9 +173,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistObject(UpgradeLogic);
             reader.PersistBoolean(ref _generated);

--- a/src/OpenSage.Game/Logic/Object/Behaviors/HelicopterSlowDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/HelicopterSlowDeathBehavior.cs
@@ -14,9 +14,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             var unknown1 = true;
             reader.PersistBoolean(ref unknown1);

--- a/src/OpenSage.Game/Logic/Object/Behaviors/InstantDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/InstantDeathBehavior.cs
@@ -34,9 +34,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/MinefieldBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/MinefieldBehavior.cs
@@ -12,9 +12,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistUInt32(ref _numVirtualMachines);
             reader.PersistFrame(ref _unknownFrame);
@@ -40,7 +38,7 @@ namespace OpenSage.Logic.Object
     }
 
     /// <summary>
-    /// INI file comments indicate that this is not an accurate name; it's a really a 
+    /// INI file comments indicate that this is not an accurate name; it's a really a
     /// single mine behaviour.
     /// </summary>
     public sealed class MinefieldBehaviorModuleData : BehaviorModuleData

--- a/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
@@ -63,9 +63,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistBoolean(ref _enabled);
         }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/ParkingPlaceBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/ParkingPlaceBehavior.cs
@@ -544,9 +544,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(3);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistArrayWithByteLength(_parkingSlots, (StatePersister persister, ref ParkingSlot item) => persister.PersistObjectValue(ref item));
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
@@ -119,9 +119,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(2);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistVector3(ref _unknownVector1);
             reader.PersistVector3(ref _acceleration);

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PoisonedBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PoisonedBehavior.cs
@@ -10,9 +10,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(2);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.SkipUnknownBytes(12);
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PropagandaTowerBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PropagandaTowerBehavior.cs
@@ -121,7 +121,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
 
             reader.PersistFrame(ref _unknownFrame);
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/RailroadBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/RailroadBehavior.cs
@@ -30,9 +30,7 @@ namespace OpenSage.Logic.Object
         {
             var version = reader.PersistVersion(3);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.SkipUnknownBytes(4);
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
@@ -142,9 +142,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistFrame(ref _frameSinkStart);
             reader.PersistFrame(ref _frameMidpoint);

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
@@ -138,9 +138,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(2);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistBoolean(ref _unknownBool1);
             reader.PersistAsciiString(ref _templateName);

--- a/src/OpenSage.Game/Logic/Object/Behaviors/TechBuildingBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/TechBuildingBehavior.cs
@@ -8,9 +8,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Body/ActiveBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/ActiveBody.cs
@@ -129,9 +129,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistSingle(ref _currentHealth);
             reader.PersistSingle(ref _lastHealthBeforeDamage);

--- a/src/OpenSage.Game/Logic/Object/Body/BodyModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/BodyModule.cs
@@ -36,9 +36,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistSingle(ref _armorDamageScalar); // was roughly 0.9 after changing to hold the line
         }

--- a/src/OpenSage.Game/Logic/Object/Body/HighlanderBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/HighlanderBody.cs
@@ -35,9 +35,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Body/ImmortalBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/ImmortalBody.cs
@@ -13,9 +13,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Body/InactiveBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/InactiveBody.cs
@@ -26,9 +26,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Body/StructureBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/StructureBody.cs
@@ -15,9 +15,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistUInt32(ref _unknown);
         }

--- a/src/OpenSage.Game/Logic/Object/ClientUpdate/AnimatedParticleSysBoneClientUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/ClientUpdate/AnimatedParticleSysBoneClientUpdate.cs
@@ -9,14 +9,12 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 
     /// <summary>
-    /// Allows the object to have particle system effects dynamically attached to animated 
+    /// Allows the object to have particle system effects dynamically attached to animated
     /// sub objects or bones.
     /// </summary>
     public sealed class AnimatedParticleSysBoneClientUpdateModuleData : ClientUpdateModuleData

--- a/src/OpenSage.Game/Logic/Object/ClientUpdate/ClientUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/ClientUpdate/ClientUpdate.cs
@@ -11,9 +11,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/ClientUpdate/LaserUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/ClientUpdate/LaserUpdate.cs
@@ -27,9 +27,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistVector3(ref _flare1Position);
             reader.PersistVector3(ref _flare2Position);

--- a/src/OpenSage.Game/Logic/Object/ClientUpdate/SwayClientUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/ClientUpdate/SwayClientUpdate.cs
@@ -24,9 +24,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistSingle(ref _unknownFloat1);
             reader.PersistSingle(ref _unknownFloat2);

--- a/src/OpenSage.Game/Logic/Object/Collide/CollideModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/CollideModule.cs
@@ -11,9 +11,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Collide/ConvertToCarBombCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/ConvertToCarBombCrateCollide.cs
@@ -8,12 +8,12 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
         }
     }
 
     /// <summary>
-    /// Triggers use of CARBOMB WeaponSet Condition of the hijacked object and turns it to a 
+    /// Triggers use of CARBOMB WeaponSet Condition of the hijacked object and turns it to a
     /// suicide unit unless given with a different weapon.
     /// </summary>
     public sealed class ConvertToCarBombCrateCollideModuleData : CrateCollideModuleData

--- a/src/OpenSage.Game/Logic/Object/Collide/ConvertToHijackedVehicleCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/ConvertToHijackedVehicleCrateCollide.cs
@@ -8,9 +8,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Collide/CrateCollideModuleData.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/CrateCollideModuleData.cs
@@ -9,9 +9,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Collide/FireWeaponCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/FireWeaponCollide.cs
@@ -26,9 +26,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistBoolean(ref _unknown1);
             reader.PersistObject(_collideWeapon);

--- a/src/OpenSage.Game/Logic/Object/Collide/MoneyCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/MoneyCrateCollide.cs
@@ -11,7 +11,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Collide/SalvageCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/SalvageCrateCollide.cs
@@ -9,7 +9,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Collide/SquishCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/SquishCollide.cs
@@ -10,9 +10,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Contain/GarrisonContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/GarrisonContain.cs
@@ -70,9 +70,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistUInt32(ref _originalTeamId);
 

--- a/src/OpenSage.Game/Logic/Object/Contain/HealContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/HealContain.cs
@@ -42,9 +42,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
@@ -204,9 +204,7 @@ namespace OpenSage.Logic.Object
         {
             var version = reader.PersistVersion(2);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistListWithUInt32Count(
                 _containedObjectIds,

--- a/src/OpenSage.Game/Logic/Object/Contain/OverlordContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OverlordContain.cs
@@ -21,7 +21,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
 
             reader.SkipUnknownBytes(1);
         }

--- a/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
@@ -117,9 +117,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             var unknownInt1 = 1;
             reader.PersistInt32(ref unknownInt1);

--- a/src/OpenSage.Game/Logic/Object/Contain/TunnelContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TunnelContain.cs
@@ -61,7 +61,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
 
             reader.PersistBoolean(ref _unknown1);
             reader.PersistBoolean(ref _unknown2);

--- a/src/OpenSage.Game/Logic/Object/Create/CreateModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/CreateModule.cs
@@ -24,9 +24,7 @@
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistBoolean(ref _shouldCallOnBuildComplete);
         }

--- a/src/OpenSage.Game/Logic/Object/Create/GrantUpgradeCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/GrantUpgradeCreate.cs
@@ -8,9 +8,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Create/LockWeaponCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/LockWeaponCreate.cs
@@ -9,9 +9,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Create/PreorderCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/PreorderCreate.cs
@@ -8,15 +8,13 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 
     /// <summary>
-    /// Allows the use of the PREORDER ModelConditionState with this object which in turn is only 
-    /// triggered by the presence of registry key 'Preorder' set to '1' in 
+    /// Allows the use of the PREORDER ModelConditionState with this object which in turn is only
+    /// triggered by the presence of registry key 'Preorder' set to '1' in
     /// HKLM\Software\ElectronicArts\EAGames\Generals.
     /// </summary>
     public sealed class PreorderCreateModuleData : CreateModuleData

--- a/src/OpenSage.Game/Logic/Object/Create/SpecialPowerCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/SpecialPowerCreate.cs
@@ -23,9 +23,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Create/SupplyCenterCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/SupplyCenterCreate.cs
@@ -33,9 +33,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Create/SupplyWarehouseCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/SupplyWarehouseCreate.cs
@@ -33,9 +33,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Create/VeterancyGainCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/VeterancyGainCreate.cs
@@ -18,9 +18,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
 
         public override void OnCreate()

--- a/src/OpenSage.Game/Logic/Object/Damage/BoneFXDamage.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/BoneFXDamage.cs
@@ -8,14 +8,12 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 
     /// <summary>
-    /// Enables use of BoneFXUpdate module on this object where an additional dynamic FX logic can 
+    /// Enables use of BoneFXUpdate module on this object where an additional dynamic FX logic can
     /// be used.
     /// </summary>
     public sealed class BoneFXDamageModuleData : DamageModuleData

--- a/src/OpenSage.Game/Logic/Object/Damage/DamageModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/DamageModule.cs
@@ -8,9 +8,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Damage/TransitionDamageFX.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/TransitionDamageFX.cs
@@ -58,9 +58,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistArray(
                 _particleSystemIds,

--- a/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
@@ -80,9 +80,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
@@ -22,9 +22,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Die/CrushDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CrushDie.cs
@@ -12,9 +12,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Die/DamDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DamDie.cs
@@ -13,9 +13,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Die/DestroyDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DestroyDie.cs
@@ -21,9 +21,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Die/DieModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DieModule.cs
@@ -18,9 +18,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
 
         internal sealed override void OnDie(BehaviorUpdateContext context, DeathType deathType, BitArray<ObjectStatus> status)

--- a/src/OpenSage.Game/Logic/Object/Die/EjectPilotDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/EjectPilotDie.cs
@@ -40,9 +40,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Die/FXListDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/FXListDie.cs
@@ -26,9 +26,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Die/KeepObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/KeepObjectDie.cs
@@ -13,9 +13,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Die/RebuildHoleExposeDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/RebuildHoleExposeDie.cs
@@ -34,9 +34,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Die/UpgradeDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/UpgradeDie.cs
@@ -21,9 +21,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
 
         private protected override void Die(BehaviorUpdateContext context, DeathType deathType)

--- a/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
@@ -54,9 +54,7 @@ namespace OpenSage.Logic.Object
             // Since we don't have that at the moment, just read it here.
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.EndObject();
         }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dDebrisDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dDebrisDraw.cs
@@ -83,9 +83,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistAsciiString(ref _modelName);
 
@@ -98,8 +96,8 @@ namespace OpenSage.Logic.Object
     }
 
     /// <summary>
-    /// Special-case draw module used by ObjectCreationList.INI when using the CreateDebris code 
-    /// which defaults to calling the GenericDebris object definition as a template for each debris 
+    /// Special-case draw module used by ObjectCreationList.INI when using the CreateDebris code
+    /// which defaults to calling the GenericDebris object definition as a template for each debris
     /// object generated.
     /// </summary>
     public sealed class W3dDebrisDrawModuleData : DrawModuleData

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dDefaultDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dDefaultDraw.cs
@@ -44,25 +44,23 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
 
         internal override void SetWorldMatrix(in Matrix4x4 worldMatrix)
         {
-            
+
         }
 
         internal override void Update(in TimeInterval time)
         {
-            
+
         }
     }
 
     /// <summary>
-    /// All world objects should use a draw module. This module is used where an object should 
-    /// never actually be drawn due either to the nature or type of the object or because its 
+    /// All world objects should use a draw module. This module is used where an object should
+    /// never actually be drawn due either to the nature or type of the object or because its
     /// drawing is handled by other logic, e.g. bridges.
     /// </summary>
     public sealed class W3dDefaultDrawModuleData : DrawModuleData

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dLaserDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dLaserDraw.cs
@@ -49,9 +49,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
     /// <summary>

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -406,9 +406,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(2);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistArray(
                 _unknownSomething,

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dOverlordTankDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dOverlordTankDraw.cs
@@ -14,13 +14,13 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
         }
     }
 
     /// <summary>
     /// Special-case draw module which is interdependent with the W3DDependencyModelDraw module.
-    /// Allows other objects to be attached to this object through use of AttachToBoneInContainer 
+    /// Allows other objects to be attached to this object through use of AttachToBoneInContainer
     /// logic.
     /// </summary>
     public sealed class W3dOverlordTankDrawModuleData : W3dTankDrawModuleData

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dProjectileStreamDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dProjectileStreamDraw.cs
@@ -49,9 +49,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dRopeDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dRopeDraw.cs
@@ -58,9 +58,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistSingle(ref _unknownFloat1);
             reader.PersistSingle(ref _unknownFloat2);

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dScienceModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dScienceModelDraw.cs
@@ -14,7 +14,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dSupplyDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dSupplyDraw.cs
@@ -40,9 +40,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTankDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTankDraw.cs
@@ -65,14 +65,12 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 
     /// <summary>
-    /// Default Draw used by tanks. Hardcoded to call for the TrackDebrisDirtRight and 
+    /// Default Draw used by tanks. Hardcoded to call for the TrackDebrisDirtRight and
     /// TrackDebrisDirtLeft particle system definitions.
     /// </summary>
     public class W3dTankDrawModuleData : W3dModelDrawModuleData

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTracerDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTracerDraw.cs
@@ -36,9 +36,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
 
         internal override string GetWeaponFireFXBone(WeaponSlot slot)

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
@@ -86,9 +86,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectDefectionHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectDefectionHelper.cs
@@ -10,9 +10,7 @@
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistUInt32(ref _frameStart);
             reader.PersistUInt32(ref _frameEnd);

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectFiringTrackerHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectFiringTrackerHelper.cs
@@ -9,9 +9,7 @@
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistUInt32(ref _numShotsFiredAtLastTarget);
             reader.PersistObjectID(ref _lastTargetObjectId);

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectHelperModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectHelperModule.cs
@@ -6,9 +6,7 @@
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectRepulsorHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectRepulsorHelper.cs
@@ -8,7 +8,7 @@
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectSpecialModelConditionHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectSpecialModelConditionHelper.cs
@@ -13,9 +13,7 @@
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectWeaponStatusHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectWeaponStatusHelper.cs
@@ -8,9 +8,7 @@
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Helpers/StatusDamageHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/StatusDamageHelper.cs
@@ -6,9 +6,7 @@
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.SkipUnknownBytes(8);
         }

--- a/src/OpenSage.Game/Logic/Object/Helpers/SubdualDamageHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/SubdualDamageHelper.cs
@@ -6,9 +6,7 @@
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.SkipUnknownBytes(4);
         }

--- a/src/OpenSage.Game/Logic/Object/Helpers/TempWeaponBonusHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/TempWeaponBonusHelper.cs
@@ -8,9 +8,7 @@
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistInt32(ref _unknownInt);
             if (_unknownInt != -1 && _unknownInt != 0)

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/CashBountyPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/CashBountyPower.cs
@@ -13,7 +13,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/CashHackSpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/CashHackSpecialPower.cs
@@ -33,9 +33,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
 
         public void TryUpgrade(Science purchasedScience)

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/CleanupAreaPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/CleanupAreaPower.cs
@@ -12,9 +12,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             // no idea what these are for
             byte unknown1 = 0;

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/DefectorSpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/DefectorSpecialPower.cs
@@ -12,9 +12,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/OCLSpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/OCLSpecialPower.cs
@@ -141,9 +141,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
 
         public void TryUpgrade(Science purchasedScience)

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialAbility.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialAbility.cs
@@ -14,9 +14,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialPower.cs
@@ -161,9 +161,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistLogicFrame(ref _availableAtFrame);
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -310,9 +310,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(4);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistUInt32(ref _unknownInt1);
             reader.PersistUInt32(ref _unknownInt2);

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cs
@@ -21,7 +21,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
 
             reader.PersistListWithUInt32Count(
                 _members,

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/ChinookAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/ChinookAIUpdate.cs
@@ -32,9 +32,7 @@ namespace OpenSage.Logic.Object
         {
             var version = reader.PersistVersion(2);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             var hasQueuedCommand = _queuedCommand != null;
             reader.PersistBoolean(ref hasQueuedCommand);

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DeployStyleAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DeployStyleAIUpdate.cs
@@ -30,9 +30,7 @@ namespace OpenSage.Logic.Object
         {
             var version = reader.PersistVersion(4);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             if (version >= 4)
             {

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAIUpdate.cs
@@ -31,9 +31,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistObject(_state);
         }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAndWorkerState.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAndWorkerState.cs
@@ -215,9 +215,7 @@ internal sealed class DozerAndWorkerState : IPersistableObject
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Persist(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Persist);
         }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/HackInternetAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/HackInternetAIUpdate.cs
@@ -76,9 +76,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             var hasPackingUpData = _packingUpData != null;
             reader.PersistBoolean(ref hasPackingUpData);

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/JetAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/JetAIUpdate.cs
@@ -68,9 +68,7 @@ namespace OpenSage.Logic.Object
         internal override void Load(StatePersister reader)
         {
             reader.PersistVersion(2);
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistVector3(ref _positionSomething);
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/MissileAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/MissileAIUpdate.cs
@@ -92,9 +92,7 @@ namespace OpenSage.Logic.Object
         {
             var version = reader.PersistVersion(6);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistVector3(ref _unknownPosition);
             reader.PersistUInt32(ref _stateMaybe);

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cs
@@ -22,9 +22,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistObject(_stateMachine);
             reader.PersistObjectID(ref _dockId);

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TransportAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TransportAIUpdate.cs
@@ -16,9 +16,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WanderAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WanderAIUpdate.cs
@@ -16,9 +16,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
@@ -205,9 +205,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistObject(_state);
 
@@ -236,9 +234,7 @@ namespace OpenSage.Logic.Object
             {
                 reader.PersistVersion(1);
 
-                reader.BeginObject("Base");
-                base.Persist(reader);
-                reader.EndObject();
+                reader.PersistBase(base.Persist);
             }
         }
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AssistedTargetingUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AssistedTargetingUpdate.cs
@@ -8,7 +8,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
@@ -77,9 +77,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(2);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistLogicFrame(ref _nextAwardFrame);
             reader.PersistBoolean(ref _shouldGrantInitialCaptureBonus);

--- a/src/OpenSage.Game/Logic/Object/Update/AutoFindHealingUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoFindHealingUpdate.cs
@@ -10,9 +10,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistUInt32(ref _unknown);
         }

--- a/src/OpenSage.Game/Logic/Object/Update/BaseRegenerateUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BaseRegenerateUpdate.cs
@@ -40,9 +40,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/BattlePlanUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BattlePlanUpdate.cs
@@ -282,9 +282,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistEnum(ref _current);
             reader.PersistEnum(ref _desired);

--- a/src/OpenSage.Game/Logic/Object/Update/BoneFXUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BoneFXUpdate.cs
@@ -13,9 +13,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistList(
                 _particleSystemIds,

--- a/src/OpenSage.Game/Logic/Object/Update/CleanupHazardUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/CleanupHazardUpdate.cs
@@ -8,9 +8,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.SkipUnknownBytes(5);
             byte unknown = 0;

--- a/src/OpenSage.Game/Logic/Object/Update/CommandButtonHuntUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/CommandButtonHuntUpdate.cs
@@ -10,9 +10,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistAsciiString(ref _commandButtonName);
         }

--- a/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
@@ -32,7 +32,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
 
             reader.PersistLogicFrame(ref _frameToDelete);
         }

--- a/src/OpenSage.Game/Logic/Object/Update/DockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DockUpdate.cs
@@ -121,9 +121,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistVector3(ref _position1);
             reader.PersistVector3(ref _position2);

--- a/src/OpenSage.Game/Logic/Object/Update/DynamicShroudClearingRangeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DynamicShroudClearingRangeUpdate.cs
@@ -19,7 +19,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
 
             reader.PersistUInt32(ref _unknown1);
             reader.PersistUInt32(ref _unknown2);

--- a/src/OpenSage.Game/Logic/Object/Update/FireSpreadUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FireSpreadUpdate.cs
@@ -12,9 +12,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/FireWeaponUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FireWeaponUpdate.cs
@@ -26,9 +26,7 @@ namespace OpenSage.Logic.Object
         {
             var version = reader.PersistVersion(2);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistByte(ref _unknownByte);
             reader.PersistAsciiString(ref _weaponTemplate);

--- a/src/OpenSage.Game/Logic/Object/Update/FlammableUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FlammableUpdate.cs
@@ -24,9 +24,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistEnum(ref _state);
             reader.PersistFrame(ref _aflameEndFrame);

--- a/src/OpenSage.Game/Logic/Object/Update/HijackerUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/HijackerUpdate.cs
@@ -8,9 +8,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.SkipUnknownBytes(19);
         }

--- a/src/OpenSage.Game/Logic/Object/Update/HordeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/HordeUpdate.cs
@@ -94,9 +94,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistBoolean(ref _isInHorde);
 

--- a/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
@@ -43,9 +43,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistLogicFrame(ref _frameToDie);
         }

--- a/src/OpenSage.Game/Logic/Object/Update/OCLUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/OCLUpdate.cs
@@ -11,9 +11,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.SkipUnknownBytes(8);
 

--- a/src/OpenSage.Game/Logic/Object/Update/ParticleUplinkCannonUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ParticleUplinkCannonUpdate.cs
@@ -65,9 +65,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(2);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistEnum(ref _status);
 

--- a/src/OpenSage.Game/Logic/Object/Update/PowerPlantUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/PowerPlantUpdate.cs
@@ -56,9 +56,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistBoolean(ref _rodsExtended);
         }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/DefaultProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/DefaultProductionExitUpdate.cs
@@ -22,9 +22,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistObject(RallyPointManager);
         }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/QueueProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/QueueProductionExitUpdate.cs
@@ -28,9 +28,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistLogicFrameSpan(ref _framesUntilNextSpawn);
             reader.PersistObject(RallyPointManager);

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SupplyCenterProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SupplyCenterProductionExitUpdate.cs
@@ -22,9 +22,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistObject(RallyPointManager);
         }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -552,9 +552,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistList(_productionQueue, static (StatePersister persister, ref ProductionJob item) =>
             {

--- a/src/OpenSage.Game/Logic/Object/Update/ProjectileStreamUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProjectileStreamUpdate.cs
@@ -13,9 +13,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistArray(
                 _objectIds,

--- a/src/OpenSage.Game/Logic/Object/Update/RadarUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RadarUpdate.cs
@@ -12,9 +12,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistUInt32(ref _radarExtendEndFrame);
             reader.PersistBoolean(ref _isRadarExtended);
@@ -30,7 +28,7 @@ namespace OpenSage.Logic.Object
         {
             { "RadarExtendTime", (parser, x) => x.RadarExtendTime = parser.ParseInteger() }
         };
-        
+
         public int RadarExtendTime { get; private set; }
 
         internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)

--- a/src/OpenSage.Game/Logic/Object/Update/RebuildHoleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RebuildHoleUpdate.cs
@@ -156,9 +156,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(2);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistObjectID(ref _workerId);
             reader.PersistObjectID(ref _structureId);

--- a/src/OpenSage.Game/Logic/Object/Update/RepairDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RepairDockUpdate.cs
@@ -14,16 +14,14 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.SkipUnknownBytes(8);
         }
     }
 
     /// <summary>
-    /// Hardcoded to require DockWaitingN, DockEndN, DockActionN and DockStartN bones, where N 
+    /// Hardcoded to require DockWaitingN, DockEndN, DockActionN and DockStartN bones, where N
     /// should correspond to <see cref="NumberApproachPositions"/>.
     /// </summary>
     public sealed class RepairDockUpdateModuleData : DockUpdateModuleData

--- a/src/OpenSage.Game/Logic/Object/Update/SlavedUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SlavedUpdate.cs
@@ -187,9 +187,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistObjectID(ref _parentObjectId);
             reader.PersistVector3(ref _nextRelativePosition);

--- a/src/OpenSage.Game/Logic/Object/Update/SpecialAbilityUpdate/SpecialAbilityUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SpecialAbilityUpdate/SpecialAbilityUpdate.cs
@@ -17,9 +17,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistBoolean(ref _unknownBool1);
             reader.PersistUInt32(ref _unknownInt1);

--- a/src/OpenSage.Game/Logic/Object/Update/SpectreGunshipDeploymentUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SpectreGunshipDeploymentUpdate.cs
@@ -9,9 +9,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.SkipUnknownBytes(4);
         }

--- a/src/OpenSage.Game/Logic/Object/Update/StealthDetectorUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StealthDetectorUpdate.cs
@@ -32,9 +32,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistBoolean(ref Active);
         }

--- a/src/OpenSage.Game/Logic/Object/Update/StealthUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StealthUpdate.cs
@@ -14,9 +14,7 @@ namespace OpenSage.Logic.Object
         {
             var version = reader.PersistVersion(2);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistFrame(ref _unknownFrame1);
             reader.PersistFrame(ref _unknownFrame2);
@@ -48,8 +46,8 @@ namespace OpenSage.Logic.Object
     }
 
     /// <summary>
-    /// Allows the use of the <see cref="ObjectDefinition.SoundStealthOn"/> and 
-    /// <see cref="ObjectDefinition.SoundStealthOff"/> parameters on the object and is hardcoded to 
+    /// Allows the use of the <see cref="ObjectDefinition.SoundStealthOn"/> and
+    /// <see cref="ObjectDefinition.SoundStealthOff"/> parameters on the object and is hardcoded to
     /// display MESSAGE:StealthNeutralized when the object has been discovered.
     /// </summary>
     public sealed class StealthUpdateModuleData : BehaviorModuleData

--- a/src/OpenSage.Game/Logic/Object/Update/StickyBombUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StickyBombUpdate.cs
@@ -12,9 +12,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistUInt32(ref _unknown1);
             reader.PersistUInt32(ref _unknown2);

--- a/src/OpenSage.Game/Logic/Object/Update/StructureCollapseUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StructureCollapseUpdate.cs
@@ -22,7 +22,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
 
             reader.SkipUnknownBytes(20);
         }

--- a/src/OpenSage.Game/Logic/Object/Update/StructureToppleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StructureToppleUpdate.cs
@@ -11,7 +11,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
 
             reader.SkipUnknownBytes(20);
 

--- a/src/OpenSage.Game/Logic/Object/Update/SupplyCenterDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SupplyCenterDockUpdate.cs
@@ -45,9 +45,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/SupplyWarehouseDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SupplyWarehouseDockUpdate.cs
@@ -45,9 +45,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistInt32(ref _currentBoxes);
         }

--- a/src/OpenSage.Game/Logic/Object/Update/ToppleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ToppleUpdate.cs
@@ -123,9 +123,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistSingle(ref _toppleSpeed);
             reader.PersistSingle(ref _toppleAcceleration);

--- a/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
@@ -27,9 +27,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistUpdateFrame(ref NextUpdateFrame);
         }

--- a/src/OpenSage.Game/Logic/Object/Update/WaveGuideUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/WaveGuideUpdate.cs
@@ -10,15 +10,15 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            base.Load(reader);
+            reader.PersistBase(base.Load);
 
             reader.SkipUnknownBytes(2330);
         }
     }
 
     /// <summary>
-    /// Hardcoded to use the following particle system definitions: WaveSpray03, WaveSpray02, 
-    /// WaveSpray01, WaveSplashRight01, WaveSplashLeft01, WaveHit01, WaveSplash01 and also uses the 
+    /// Hardcoded to use the following particle system definitions: WaveSpray03, WaveSpray02,
+    /// WaveSpray01, WaveSplashRight01, WaveSplashLeft01, WaveHit01, WaveSplash01 and also uses the
     /// WaterWaveBridge object definition as a template when it collides with a bridge.
     /// Requires a WAVEGUIDE KindOf.
     /// </summary>

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ArmorUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ArmorUpgrade.cs
@@ -16,9 +16,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/CommandSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/CommandSetUpgrade.cs
@@ -23,9 +23,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ExperienceScalarUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ExperienceScalarUpgrade.cs
@@ -21,9 +21,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/GrantScienceUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/GrantScienceUpgrade.cs
@@ -13,9 +13,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/LocomotorSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/LocomotorSetUpgrade.cs
@@ -13,14 +13,12 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 
     /// <summary>
-    /// Triggers use of SET_NORMAL_UPGRADED locomotor on this object and allows the use of 
+    /// Triggers use of SET_NORMAL_UPGRADED locomotor on this object and allows the use of
     /// VoiceMoveUpgrade within the UnitSpecificSounds section of the object.
     /// </summary>
     public sealed class LocomotorSetUpgradeModuleData : UpgradeModuleData

--- a/src/OpenSage.Game/Logic/Object/Upgrade/MaxHealthUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/MaxHealthUpgrade.cs
@@ -35,9 +35,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
@@ -38,9 +38,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/PowerPlantUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/PowerPlantUpgrade.cs
@@ -23,14 +23,12 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 
     /// <summary>
-    /// Triggers use of the <see cref="ObjectDefinition.EnergyBonus"/> setting on this object to 
+    /// Triggers use of the <see cref="ObjectDefinition.EnergyBonus"/> setting on this object to
     /// provide extra power to the faction.
     /// </summary>
     public sealed class PowerPlantUpgradeModuleData : UpgradeModuleData

--- a/src/OpenSage.Game/Logic/Object/Upgrade/RadarUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/RadarUpgrade.cs
@@ -13,14 +13,12 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 
     /// <summary>
-    /// Triggers use of <see cref="RadarUpdateModuleData"/> module on this object if present and enables the 
+    /// Triggers use of <see cref="RadarUpdateModuleData"/> module on this object if present and enables the
     /// Radar in the command bar.
     /// </summary>
     public sealed class RadarUpgradeModuleData : UpgradeModuleData

--- a/src/OpenSage.Game/Logic/Object/Upgrade/StealthUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/StealthUpgrade.cs
@@ -13,15 +13,13 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 
     /// <summary>
-    /// Eenables use of <see cref="StealthUpdateModuleData"/> module on this object. Requires 
-    /// <see cref="StealthUpdateModuleData.InnateStealth"/> = No defined in the <see cref="StealthUpdateModuleData"/> 
+    /// Eenables use of <see cref="StealthUpdateModuleData"/> module on this object. Requires
+    /// <see cref="StealthUpdateModuleData.InnateStealth"/> = No defined in the <see cref="StealthUpdateModuleData"/>
     /// module.
     /// </summary>
     public sealed class StealthUpgradeModuleData : UpgradeModuleData

--- a/src/OpenSage.Game/Logic/Object/Upgrade/UnpauseSpecialPowerUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/UnpauseSpecialPowerUpgrade.cs
@@ -29,9 +29,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
@@ -30,9 +30,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
 
             reader.PersistObject(_upgradeLogic);
         }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/WeaponBonusUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/WeaponBonusUpgrade.cs
@@ -13,9 +13,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/WeaponSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/WeaponSetUpgrade.cs
@@ -20,9 +20,7 @@ namespace OpenSage.Logic.Object
         {
             reader.PersistVersion(1);
 
-            reader.BeginObject("Base");
-            base.Load(reader);
-            reader.EndObject();
+            reader.PersistBase(base.Load);
         }
     }
 

--- a/src/OpenSage.Game/StatePersister.cs
+++ b/src/OpenSage.Game/StatePersister.cs
@@ -233,6 +233,13 @@ namespace OpenSage
 
         protected record struct Segment(long Start, long End, string Name);
 
+        public void PersistBase(Action<StatePersister> persistAction)
+        {
+            BeginObject("Base");
+            persistAction(this);
+            EndObject();
+        }
+
         public void BeginObject(string name)
         {
             PersistFieldName(name);


### PR DESCRIPTION
This is used in a lot of places, and consequently BeginObject and EndObject are forgotten in a lot of places. I got tired of forgetting to add it myself, and also got tired of typing `reader.BeginObject("Base")` - hopefully this makes it more difficult to forget? 🤷 