### PR TITLE
Re-license from LGPL V3 to GPL V3

### DIFF
--- a/LICENSE-EA.md
+++ b/LICENSE-EA.md
@@ -1,10 +1,6 @@
-OpenSAGE code itself is licensed under the GPL V3 license; the full text can be found below.
-
-However, OpenSAGE includes code ported from EA's Command & Conquer Generals and 
-Command & Conquer Generals Zero Hour source code. That code was released under the GPL V3 license
-with some additional terms; the full text of that license and additional terms are in 
-[LICENSE-EA.md](LICENSE-EA.md). Since that is the most restrictive license, that is the one
-to pay attention to.
+Electronic Arts Inc. has released the source code for Command & Conquer Generals
+and Command & Conquer Generals Zero Hour under the GPL V3 license below, with
+additional terms at the bottom.
 
 GNU General Public License
 ==========================
@@ -601,3 +597,41 @@ more useful to permit linking proprietary applications with the library. If this
 what you want to do, use the GNU Lesser General Public License instead of this
 License. But first, please read
 &lt;<http://www.gnu.org/philosophy/why-not-lgpl.html>&gt;.
+
+## ADDITIONAL TERMS per GNU GPL Section 7
+
+No trademark or publicity rights are granted. This license does NOT give you
+any right, title or interest in "Command & Conquer" or any other Electronic Arts
+trademark. You may not distribute any modification of this program using any
+Electronic Arts trademark or claim any affiliation or association with
+Electronic Arts Inc. or its affiliates or their employees.
+
+Any propagation or conveyance of this program must include this copyright
+notice and these terms.
+
+If you convey this program (or any modifications of it) and assume
+contractual liability for the program to recipients of it, you agree to
+indemnify Electronic Arts for any liability that those contractual
+assumptions impose on Electronic Arts.
+
+You may not misrepresent the origins of this program; modified versions of
+the program must be marked as such and not identified as the original program.
+
+This disclaimer supplements the one included in the General Public License.
+TO THE FULLEST EXTENT PERMISSIBLE UNDER APPLICABLE LAW, THIS PROGRAM IS
+PROVIDED TO YOU "AS IS," WITH ALL FAULTS, WITHOUT WARRANTY OF ANY KIND, AND
+YOUR USE IS AT YOUR SOLE RISK. THE ENTIRE RISK OF SATISFACTORY QUALITY AND
+PERFORMANCE RESIDES WITH YOU. ELECTRONIC ARTS DISCLAIMS ANY AND ALL EXPRESS,
+IMPLIED OR STATUTORY WARRANTIES, INCLUDING IMPLIED WARRANTIES OF
+MERCHANTABILITY, SATISFACTORY QUALITY, FITNESS FOR A PARTICULAR PURPOSE,
+NONINFRINGEMENT OF THIRD PARTY RIGHTS, AND WARRANTIES (IF ANY) ARISING FROM A
+COURSE OF DEALING, USAGE, OR TRADE PRACTICE. ELECTRONIC ARTS DOES NOT WARRANT
+AGAINST INTERFERENCE WITH YOUR ENJOYMENT OF THE PROGRAM; THAT THE PROGRAM WILL
+MEET YOUR REQUIREMENTS; THAT OPERATION OF THE PROGRAM WILL BE UNINTERRUPTED OR
+ERROR-FREE, OR THAT THE PROGRAM WILL BE COMPATIBLE WITH THIRD PARTY SOFTWARE
+OR THAT ANY ERRORS IN THE PROGRAM WILL BE CORRECTED. NO ORAL OR WRITTEN ADVICE
+PROVIDED BY ELECTRONIC ARTS OR ANY AUTHORIZED REPRESENTATIVE SHALL CREATE A
+WARRANTY. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF OR LIMITATIONS ON
+IMPLIED WARRANTIES OR THE LIMITATIONS ON THE APPLICABLE STATUTORY RIGHTS OF A
+CONSUMER, SO SOME OR ALL OF THE ABOVE EXCLUSIONS AND LIMITATIONS MAY NOT APPLY
+TO YOU.


### PR DESCRIPTION
We plan to port some of EA's recently released [Cnc_Generals_Zero_Hour](https://github.com/electronicarts/CnC_Generals_Zero_Hour)  C++ code to C# code in OpenSAGE.

EA's code is licensed under GPL V3.

OpenSAGE has historically been licensed under LGPL V3.

In order to port EA's code, we need to re-license OpenSAGE from LGPL V3 to GPL V3. This is permitted by the terms of the LGPL V3 - [see here](https://www.gnu.org/licenses/gpl-faq.html#AllCompatibility) for more details.