### PR TITLE
Fix VS Code launch configurations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Generals",
             "type": "coreclr",
             "request": "launch",
-            "program": "${workspaceFolder}/src/OpenSage.Launcher/bin/Debug/net6.0/OpenSage.Launcher.dll",
+            "program": "${workspaceFolder}/src/OpenSage.Launcher/bin/Debug/net8.0/OpenSage.Launcher.dll",
             "args": [
                 "--developermode", "true",
                 "--game", "0"
@@ -18,7 +18,7 @@
           "name": "Generals (Alpine Assault)",
           "type": "coreclr",
           "request": "launch",
-          "program": "${workspaceFolder}/src/OpenSage.Launcher/bin/Debug/net6.0/OpenSage.Launcher.dll",
+          "program": "${workspaceFolder}/src/OpenSage.Launcher/bin/Debug/net8.0/OpenSage.Launcher.dll",
           "args": [
               "--developermode", "true",
               "--game", "0",
@@ -29,7 +29,7 @@
             "name": "Zero Hour",
             "type": "coreclr",
             "request": "launch",
-            "program": "${workspaceFolder}/src/OpenSage.Launcher/bin/Debug/net6.0/OpenSage.Launcher.dll",
+            "program": "${workspaceFolder}/src/OpenSage.Launcher/bin/Debug/net8.0/OpenSage.Launcher.dll",
             "args": [
                 "--developermode", "true",
                 "--game", "1"


### PR DESCRIPTION
Regression from #724 

Configurations in VS Code's `launch.json` still referenced versions built with `net6.0`. If you have an old OpenSAGE folder it might run some years old version, and otherwise it just didn't work.