### PR TITLE
Port PolygonTrigger from Generals OSS release

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,6 +26,17 @@
           ]
         },
         {
+          "name": "Generals (Tournament Island)",
+          "type": "coreclr",
+          "request": "launch",
+          "program": "${workspaceFolder}/src/OpenSage.Launcher/bin/Debug/net8.0/OpenSage.Launcher.dll",
+          "args": [
+              "--developermode", "true",
+              "--game", "0",
+              "--map", "maps\\Tournament Island\\Tournament Island.map"
+          ]
+        },
+        {
             "name": "Zero Hour",
             "type": "coreclr",
             "request": "launch",

--- a/src/OpenSage.FileFormats/BinaryReaderExtensions.cs
+++ b/src/OpenSage.FileFormats/BinaryReaderExtensions.cs
@@ -13,17 +13,13 @@ namespace OpenSage.FileFormats
         {
             var value = reader.ReadByte();
 
-            switch (value)
+            return value switch
             {
-                case 0:
-                    return false;
+                0 => false,
+                1 => true,
+                _ => throw new InvalidDataException(),
+            };
 
-                case 1:
-                    return true;
-
-                default:
-                    throw new InvalidDataException();
-            }
         }
 
         public static bool ReadBooleanUInt32Checked(this BinaryReader reader)
@@ -52,7 +48,7 @@ namespace OpenSage.FileFormats
             var result = 0u;
             for (var i = 0; i < 3; i++)
             {
-                result |= ((uint) reader.ReadByte() << (i * 8));
+                result |= (uint)reader.ReadByte() << (i * 8);
             }
             return result;
         }
@@ -97,7 +93,7 @@ namespace OpenSage.FileFormats
         public static string ReadUInt32PrefixedAsciiString(this BinaryReader reader)
         {
             var length = reader.ReadUInt32();
-            return BinaryUtility.AnsiEncoding.GetString(reader.ReadBytes((int) length));
+            return BinaryUtility.AnsiEncoding.GetString(reader.ReadBytes((int)length));
         }
 
         public static string ReadBytePrefixedUnicodeString(this BinaryReader reader)
@@ -115,11 +111,11 @@ namespace OpenSage.FileFormats
         public static string ReadUInt32PrefixedNegatedUnicodeString(this BinaryReader reader)
         {
             var length = reader.ReadUInt32();
-            var bytes = reader.ReadBytes((int) length * 2);
+            var bytes = reader.ReadBytes((int)length * 2);
             var negatedBytes = new byte[bytes.Length];
             for (var i = 0; i < negatedBytes.Length; i++)
             {
-                negatedBytes[i] = (byte) ~bytes[i];
+                negatedBytes[i] = (byte)~bytes[i];
             }
             return Encoding.Unicode.GetString(negatedBytes);
         }
@@ -136,10 +132,7 @@ namespace OpenSage.FileFormats
             var result = new string(chars);
 
             // There might be garbage after the \0 character, so we can't just do TrimEnd('\0').
-            if (result.Contains('\0'))
-                return result.Substring(0, result.IndexOf('\0'));
-            else
-                return result;
+            return result.Contains('\0') ? result[..result.IndexOf('\0')] : result;
         }
 
         public static ushort[,] ReadUInt16Array2D(this BinaryReader reader, uint width, uint height)
@@ -165,21 +158,12 @@ namespace OpenSage.FileFormats
             {
                 for (var x = 0; x < width; x++)
                 {
-                    uint value;
-                    switch (bitSize)
+                    var value = bitSize switch
                     {
-                        case 16:
-                            value = reader.ReadUInt16();
-                            break;
-
-                        case 32:
-                            value = reader.ReadUInt32();
-                            break;
-
-                        default:
-                            throw new ArgumentOutOfRangeException(nameof(bitSize));
-                    }
-
+                        16 => reader.ReadUInt16(),
+                        32 => reader.ReadUInt32(),
+                        _ => throw new ArgumentOutOfRangeException(nameof(bitSize)),
+                    };
                     result[x, y] = value;
                 }
             }
@@ -224,7 +208,7 @@ namespace OpenSage.FileFormats
 
             for (var y = 0; y < height; y++)
             {
-                var temp = (byte) 0;
+                var temp = (byte)0;
                 for (var x = 0; x < width; x++)
                 {
                     if (x % 8 == 0)
@@ -242,7 +226,7 @@ namespace OpenSage.FileFormats
         {
             var result = new bool[count];
 
-            var temp = (byte) 0;
+            var temp = (byte)0;
             for (var i = 0; i < count; i++)
             {
                 if (i % 8 == 0)
@@ -499,7 +483,7 @@ namespace OpenSage.FileFormats
         public static uint Align(this BinaryReader reader, uint aligment)
         {
             var pos = reader.BaseStream.Position;
-            var calign = ((uint) pos % aligment);
+            var calign = (uint)pos % aligment;
             if (calign == 0)
             {
                 return 0;
@@ -530,7 +514,7 @@ namespace OpenSage.FileFormats
             var oldOffset = reader.BaseStream.Position;
 
             reader.BaseStream.Seek(stringOffset, SeekOrigin.Begin);
-            var str = Encoding.ASCII.GetString(reader.ReadBytes((int) length));
+            var str = Encoding.ASCII.GetString(reader.ReadBytes((int)length));
             reader.BaseStream.Seek(oldOffset, SeekOrigin.Begin);
 
             return str;
@@ -711,14 +695,14 @@ namespace OpenSage.FileFormats
 
         public static string ReadFourCc(this BinaryReader reader, bool bigEndian = false)
         {
-            var a = (char) reader.ReadByte();
-            var b = (char) reader.ReadByte();
-            var c = (char) reader.ReadByte();
-            var d = (char) reader.ReadByte();
+            var a = (char)reader.ReadByte();
+            var b = (char)reader.ReadByte();
+            var c = (char)reader.ReadByte();
+            var d = (char)reader.ReadByte();
 
             return bigEndian
-                ? new string(new[] { d, c, b, a })
-                : new string(new[] { a, b, c, d });
+                ? new string([d, c, b, a])
+                : new string([a, b, c, d]);
         }
 
         public static TEnum ReadByteAsEnumFlags<TEnum>(this BinaryReader reader)
@@ -736,7 +720,7 @@ namespace OpenSage.FileFormats
             var value = reader.ReadUInt16();
             VerifyEnumFlags<TEnum>(value, 16);
 
-            var enumValue = (TEnum) Enum.ToObject(typeof(TEnum), value);
+            var enumValue = (TEnum)Enum.ToObject(typeof(TEnum), value);
             return enumValue;
         }
 
@@ -746,14 +730,14 @@ namespace OpenSage.FileFormats
             var value = reader.ReadUInt32();
             VerifyEnumFlags<TEnum>(value, 32);
 
-            var enumValue = (TEnum) Enum.ToObject(typeof(TEnum), value);
+            var enumValue = (TEnum)Enum.ToObject(typeof(TEnum), value);
             return enumValue;
         }
 
         private static void VerifyEnumFlags<TEnum>(uint value, int sizeOfTValue)
             where TEnum : struct
         {
-            if (value == 0 && !EnumUtility.IsValueDefined((TEnum) Enum.ToObject(typeof(TEnum), value)))
+            if (value == 0 && !EnumUtility.IsValueDefined((TEnum)Enum.ToObject(typeof(TEnum), value)))
             {
                 throw new InvalidDataException($"Undefined value for flags enum {typeof(TEnum).Name}: 0");
             }
@@ -765,7 +749,7 @@ namespace OpenSage.FileFormats
                 {
                     continue;
                 }
-                var enumBitValue = (TEnum) Enum.ToObject(typeof(TEnum), maskedValue);
+                var enumBitValue = (TEnum)Enum.ToObject(typeof(TEnum), maskedValue);
                 if (!EnumUtility.IsValueDefined(enumBitValue))
                 {
                     throw new InvalidDataException($"Undefined value for flags enum {typeof(TEnum).Name}: {enumBitValue}");

--- a/src/OpenSage.FileFormats/BinaryWriterExtensions.cs
+++ b/src/OpenSage.FileFormats/BinaryWriterExtensions.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text;
 using OpenSage.Mathematics;
 
@@ -13,48 +12,66 @@ namespace OpenSage.FileFormats
         public static void WriteBooleanUInt32(this BinaryWriter writer, bool value)
         {
             writer.Write(value);
-            writer.Write((byte) 0);
-            writer.Write((byte) 0);
-            writer.Write((byte) 0);
+            writer.Write((byte)0);
+            writer.Write((byte)0);
+            writer.Write((byte)0);
         }
 
         public static void WriteUInt24(this BinaryWriter writer, uint value)
         {
             for (var i = 0; i < 3; i++)
             {
-                writer.Write((byte) ((value >> (i * 8)) & 0xFF));
+                writer.Write((byte)((value >> (i * 8)) & 0xFF));
             }
         }
 
-        public static void WriteBytePrefixedAsciiString(this BinaryWriter writer, string value)
+        public static void WriteBytePrefixedAsciiString(this BinaryWriter writer, string? value)
         {
-            if (value.Length > byte.MaxValue)
+            if (value?.Length > byte.MaxValue)
             {
-                throw new ArgumentException();
+                throw new ArgumentException($"String is too long to fit length in 1 byte: {value.Length}", nameof(value));
             }
 
-            writer.Write((byte) value.Length);
+            if (value == null)
+            {
+                writer.Write((byte)0);
+                return;
+            }
+
+            writer.Write((byte)value.Length);
 
             writer.Write(BinaryUtility.AnsiEncoding.GetBytes(value));
         }
 
-        public static void WriteUInt16PrefixedAsciiString(this BinaryWriter writer, string value)
+        public static void WriteUInt16PrefixedAsciiString(this BinaryWriter writer, string? value)
         {
-            if (value.Length > ushort.MaxValue)
+            if (value?.Length > ushort.MaxValue)
             {
-                throw new ArgumentException();
+                throw new ArgumentException($"String is too long to fit length in 2 bytes: {value.Length}", nameof(value));
             }
 
-            writer.Write((ushort) value.Length);
+            if (value == null)
+            {
+                writer.Write((ushort)0);
+                return;
+            }
+
+            writer.Write((ushort)value.Length);
 
             writer.Write(BinaryUtility.AnsiEncoding.GetBytes(value));
         }
 
-        public static void WriteBytePrefixedUnicodeString(this BinaryWriter writer, string value)
+        public static void WriteBytePrefixedUnicodeString(this BinaryWriter writer, string? value)
         {
-            if (value.Length > byte.MaxValue)
+            if (value?.Length > byte.MaxValue)
             {
-                throw new ArgumentException();
+                throw new ArgumentException($"String is too long to fit length in 1 byte: {value.Length}", nameof(value));
+            }
+
+            if (value == null)
+            {
+                writer.Write((byte)0);
+                return;
             }
 
             writer.Write((byte)value.Length);
@@ -62,14 +79,20 @@ namespace OpenSage.FileFormats
             writer.Write(Encoding.Unicode.GetBytes(value));
         }
 
-        public static void WriteUInt16PrefixedUnicodeString(this BinaryWriter writer, string value)
+        public static void WriteUInt16PrefixedUnicodeString(this BinaryWriter writer, string? value)
         {
-            if (value.Length > ushort.MaxValue)
+            if (value?.Length > ushort.MaxValue)
             {
-                throw new ArgumentException();
+                throw new ArgumentException($"String is too long to fit length in 2 bytes: {value.Length}", nameof(value));
             }
 
-            writer.Write((ushort) value.Length);
+            if (value == null)
+            {
+                writer.Write((ushort)0);
+                return;
+            }
+
+            writer.Write((ushort)value.Length);
 
             writer.Write(Encoding.Unicode.GetBytes(value));
         }
@@ -81,7 +104,7 @@ namespace OpenSage.FileFormats
 
             for (var i = value.Length + 1; i < count; i++)
             {
-                writer.Write((char) 0);
+                writer.Write((char)0);
             }
         }
 
@@ -112,7 +135,7 @@ namespace OpenSage.FileFormats
                     switch (bitSize)
                     {
                         case 16:
-                            writer.Write((ushort) value);
+                            writer.Write((ushort)value);
                             break;
 
                         case 32:
@@ -162,18 +185,18 @@ namespace OpenSage.FileFormats
 
             for (var y = 0; y < height; y++)
             {
-                byte value = width < 8 ? padValue : (byte) 0;
+                byte value = width < 8 ? padValue : (byte)0;
                 for (var x = 0; x < width; x++)
                 {
                     if (x > 0 && x % 8 == 0)
                     {
                         writer.Write(value);
-                        value = (x > width - 8) ? padValue : (byte) 0;
+                        value = (x > width - 8) ? padValue : (byte)0;
                     }
 
                     var boolValue = values[x, y];
 
-                    value |= (byte) ((boolValue ? 1 : 0) << (x % 8));
+                    value |= (byte)((boolValue ? 1 : 0) << (x % 8));
                 }
 
                 // Write last value.
@@ -195,7 +218,7 @@ namespace OpenSage.FileFormats
 
                 var boolValue = values[i];
 
-                value |= (byte) ((boolValue ? 1 : 0) << (i % 8));
+                value |= (byte)((boolValue ? 1 : 0) << (i % 8));
             }
 
             // Write last value.
@@ -314,7 +337,7 @@ namespace OpenSage.FileFormats
 
             if (extraBytePadding)
             {
-                writer.Write((byte) 0);
+                writer.Write((byte)0);
             }
         }
 
@@ -386,7 +409,7 @@ namespace OpenSage.FileFormats
         {
             if (string.IsNullOrEmpty(fourCc) || fourCc.Length != 4)
             {
-                throw new ArgumentException();
+                throw new ArgumentException($"Invalid FourCC: {fourCc}", nameof(fourCc));
             }
 
             if (bigEndian)
@@ -407,7 +430,7 @@ namespace OpenSage.FileFormats
 
         public static void WriteNullTerminatedString(this BinaryWriter writer, in string content)
         {
-            foreach(var b in Encoding.UTF8.GetBytes(content))
+            foreach (var b in Encoding.UTF8.GetBytes(content))
             {
                 writer.Write(b);
             }
@@ -419,7 +442,9 @@ namespace OpenSage.FileFormats
         {
             var array = BitConverter.GetBytes(num);
             if (BitConverter.IsLittleEndian)
+            {
                 Array.Reverse(array);
+            }
             writer.Write(array);
         }
 

--- a/src/OpenSage.Game/Data/Map/HeightMapData.cs
+++ b/src/OpenSage.Game/Data/Map/HeightMapData.cs
@@ -11,6 +11,7 @@ namespace OpenSage.Data.Map
         // Gathered from heights in World Builder's status bar compared to heightmap data.
         // In Generals, heights are stored as uint8 (max 255), and scaled by 0.625 (max 159.375)
         // In BFME, BFME2, C&C3, heights are stored in uint16 (max 65536), and scaled by 0.0390625 (max 2560)
+        // Corresponds to MAP_XY_FACTOR in ZH
         public float VerticalScale => ElevationsAre16Bit ? 0.0390625f : 0.625f;
 
         public uint Width { get; private set; }
@@ -91,7 +92,7 @@ namespace OpenSage.Data.Map
 
                 writer.Write(BorderWidth);
 
-                writer.Write((uint) Borders.Length);
+                writer.Write((uint)Borders.Length);
 
                 foreach (var border in Borders)
                 {
@@ -110,7 +111,7 @@ namespace OpenSage.Data.Map
                         }
                         else
                         {
-                            writer.Write((byte) Elevations[x, y]);
+                            writer.Write((byte)Elevations[x, y]);
                         }
                     }
                 }

--- a/src/OpenSage.Game/Logic/GameLogic.cs
+++ b/src/OpenSage.Game/Logic/GameLogic.cs
@@ -265,16 +265,16 @@ namespace OpenSage.Logic
                 throw new InvalidStateException();
             }
 
-            reader.PersistArrayWithUInt32Length(
+            reader.PersistListWithUInt32Count(
                 _game.Scene3D.MapFile.PolygonTriggers.Triggers,
                 static (StatePersister persister, ref PolygonTrigger item) =>
                 {
                     persister.BeginObject();
 
-                    var id = item.UniqueId;
+                    var id = item.TriggerId;
                     persister.PersistUInt32(ref id);
 
-                    if (id != item.UniqueId)
+                    if (id != item.TriggerId)
                     {
                         throw new InvalidStateException();
                     }

--- a/src/OpenSage.Game/Terrain/HeightMap.cs
+++ b/src/OpenSage.Game/Terrain/HeightMap.cs
@@ -8,7 +8,8 @@ namespace OpenSage.Terrain
 {
     public sealed class HeightMap
     {
-        internal const int HorizontalScale = 10;
+        // Corresponds to MAP_XY_FACTOR in ZH
+        public const int HorizontalScale = 10;
 
         private readonly float _verticalScale;
 
@@ -16,8 +17,8 @@ namespace OpenSage.Terrain
 
         public int Width { get; }
         public int Height { get; }
-        public int MaxXCoordinate => (Width - 2 * (int) _heightMapData.BorderWidth) * HorizontalScale;
-        public int MaxYCoordinate => (Height - 2 * (int) _heightMapData.BorderWidth) * HorizontalScale;
+        public int MaxXCoordinate => (Width - 2 * (int)_heightMapData.BorderWidth) * HorizontalScale;
+        public int MaxYCoordinate => (Height - 2 * (int)_heightMapData.BorderWidth) * HorizontalScale;
 
 
         public float GetHeight(int x, int y) => _heightMapData.Elevations[x, y] * _verticalScale;
@@ -138,7 +139,7 @@ namespace OpenSage.Terrain
         {
             x += _heightMapData.BorderWidth;
             y += _heightMapData.BorderWidth;
-            var result = (X: (int) x, Y: (int) y);
+            var result = (X: (int)x, Y: (int)y);
 
             if (result.X < 0 || result.X >= _heightMapData.Width
                 || result.Y < 0 || result.Y >= _heightMapData.Height)
@@ -164,8 +165,8 @@ namespace OpenSage.Terrain
 
             _verticalScale = heightMapData.VerticalScale;
 
-            Width = (int) heightMapData.Width - 1; //last colum is not rendered (in worldbuilder)
-            Height = (int) heightMapData.Height - 1;//last row is not rendered (in worldbuilder)
+            Width = (int)heightMapData.Width - 1; //last colum is not rendered (in worldbuilder)
+            Height = (int)heightMapData.Height - 1;//last row is not rendered (in worldbuilder)
 
             Normals = new Vector3[Width, Height];
             RefreshNormals();

--- a/src/OpenSage.Game/Terrain/Terrain.cs
+++ b/src/OpenSage.Game/Terrain/Terrain.cs
@@ -123,13 +123,13 @@ namespace OpenSage.Terrain
 
         private int GetCausticsTextureIndex(in TimeInterval time)
         {
-            var deltaTime = (float) time.DeltaTime.TotalSeconds;
+            var deltaTime = (float)time.DeltaTime.TotalSeconds;
             _causticsIndex += 10f * deltaTime;
             if (_causticsIndex >= NumOfCausticsAnimation)
             {
                 _causticsIndex = 0;
             }
-            return (int) _causticsIndex;
+            return (int)_causticsIndex;
         }
 
         private Texture BuildCausticsTextureArray(AssetStore assetStore)
@@ -210,26 +210,26 @@ namespace OpenSage.Terrain
             var aaBounds = collider.AxisAlignedBoundingArea;
 
             // this seems like the easiest (read: laziest) way to pick up all the coordinates within the bounds?
-            for (var x = (int) aaBounds.Left; x < aaBounds.Right; x++)
-            for (var y = (int) aaBounds.Top; y < aaBounds.Bottom; y++) // top to bottom is correct
-            {
-                var testCoords = new Vector2(x, y);
-                if (!collider.Contains(testCoords))
+            for (var x = (int)aaBounds.Left; x < aaBounds.Right; x++)
+                for (var y = (int)aaBounds.Top; y < aaBounds.Bottom; y++) // top to bottom is correct
                 {
-                    continue;
-                }
+                    var testCoords = new Vector2(x, y);
+                    if (!collider.Contains(testCoords))
+                    {
+                        continue;
+                    }
 
-                // get current tile coords
-                var tilePosition = HeightMap.GetTilePosition(testCoords); // z doesn't matter
-                if (tilePosition == null)
-                {
-                    continue; // area is outside map bounds
-                }
+                    // get current tile coords
+                    var tilePosition = HeightMap.GetTilePosition(testCoords); // z doesn't matter
+                    if (tilePosition == null)
+                    {
+                        continue; // area is outside map bounds
+                    }
 
-                // set tile height
-                var (tileX, tileY) = tilePosition.Value;
-                HeightMap.LowerHeight(tileX, tileY, newHeight);
-            }
+                    // set tile height
+                    var (tileX, tileY) = tilePosition.Value;
+                    HeightMap.LowerHeight(tileX, tileY, newHeight);
+                }
 
             // update terrain patches in affected area
             OnHeightMapChanged(collider.AxisAlignedBoundingArea);
@@ -333,23 +333,23 @@ namespace OpenSage.Terrain
             {
                 for (var x = 0; x < heightMap.Width; x++)
                 {
-                    var baseTextureIndex = (byte) mapFile.BlendTileData.TextureIndices[mapFile.BlendTileData.Tiles[x, y]].TextureIndex;
+                    var baseTextureIndex = (byte)mapFile.BlendTileData.TextureIndices[mapFile.BlendTileData.Tiles[x, y]].TextureIndex;
 
                     var blendData1 = GetBlendData(mapFile, mapFile.BlendTileData.Blends[x, y], baseTextureIndex);
                     var blendData2 = GetBlendData(mapFile, mapFile.BlendTileData.ThreeWayBlends[x, y], baseTextureIndex);
 
                     uint packedTextureIndices = 0;
                     packedTextureIndices |= baseTextureIndex;
-                    packedTextureIndices |= (uint) (blendData1.TextureIndex << 8);
-                    packedTextureIndices |= (uint) (blendData2.TextureIndex << 16);
+                    packedTextureIndices |= (uint)(blendData1.TextureIndex << 8);
+                    packedTextureIndices |= (uint)(blendData2.TextureIndex << 16);
 
                     tileData[tileDataIndex++] = packedTextureIndices;
 
                     var packedBlendInfo = 0u;
                     packedBlendInfo |= blendData1.BlendDirection;
-                    packedBlendInfo |= (uint) (blendData1.Flags << 8);
-                    packedBlendInfo |= (uint) (blendData2.BlendDirection << 16);
-                    packedBlendInfo |= (uint) (blendData2.Flags << 24);
+                    packedBlendInfo |= (uint)(blendData1.Flags << 8);
+                    packedBlendInfo |= (uint)(blendData2.BlendDirection << 16);
+                    packedBlendInfo |= (uint)(blendData2.Flags << 24);
 
                     tileData[tileDataIndex++] = packedBlendInfo;
 
@@ -362,18 +362,18 @@ namespace OpenSage.Terrain
             var textureIDsByteArray = new byte[tileData.Length * sizeof(float)];
             Buffer.BlockCopy(tileData, 0, textureIDsByteArray, 0, tileData.Length * sizeof(float));
 
-            var rowPitch = (uint) heightMap.Width * sizeof(float) * 4;
+            var rowPitch = (uint)heightMap.Width * sizeof(float) * 4;
 
             return graphicsDevice.CreateStaticTexture2D(
-                (uint) heightMap.Width,
-                (uint) heightMap.Height,
+                (uint)heightMap.Width,
+                (uint)heightMap.Height,
                 1u,
                 new TextureMipMapData(
                     textureIDsByteArray,
                     rowPitch,
-                    rowPitch * (uint) heightMap.Height,
-                    (uint) heightMap.Width,
-                    (uint) heightMap.Height),
+                    rowPitch * (uint)heightMap.Height,
+                    (uint)heightMap.Width,
+                    (uint)heightMap.Height),
                 PixelFormat.R32_G32_B32_A32_UInt);
         }
 
@@ -386,15 +386,15 @@ namespace OpenSage.Terrain
             {
                 var blendDescription = mapFile.BlendTileData.BlendDescriptions[blendIndex - 1];
                 var flipped = blendDescription.Flags.HasFlag(BlendFlags.Flipped);
-                var flags = (byte) (flipped ? 1 : 0);
+                var flags = (byte)(flipped ? 1 : 0);
                 if (blendDescription.TwoSided)
                 {
                     flags |= 2;
                 }
                 return new BlendData
                 {
-                    TextureIndex = (byte) mapFile.BlendTileData.TextureIndices[(int) blendDescription.SecondaryTextureTile].TextureIndex,
-                    BlendDirection = (byte) blendDescription.BlendDirection,
+                    TextureIndex = (byte)mapFile.BlendTileData.TextureIndices[(int)blendDescription.SecondaryTextureTile].TextureIndex,
+                    BlendDirection = (byte)blendDescription.BlendDirection,
                     Flags = flags
                 };
             }
@@ -446,7 +446,7 @@ namespace OpenSage.Terrain
         {
             var graphicsDevice = loadContext.GraphicsDevice;
 
-            var numTextures = (uint) blendTileData.Textures.Length;
+            var numTextures = (uint)blendTileData.Textures.Length;
 
             var textureInfo = new (uint size, FileSystemEntry entry)[numTextures];
             var largestTextureSize = uint.MinValue;
@@ -461,7 +461,7 @@ namespace OpenSage.Terrain
                 var texturePath = Path.Combine("Art", "Terrain", terrainType.Texture);
                 var entry = loadContext.FileSystem.GetFile(texturePath);
 
-                var size = (uint) TgaFile.GetSquareTextureSize(entry);
+                var size = (uint)TgaFile.GetSquareTextureSize(entry);
 
                 textureInfo[i] = (size, entry);
 
@@ -472,7 +472,7 @@ namespace OpenSage.Terrain
 
                 textureDetails[i] = new TerrainShaderResources.TextureInfo
                 {
-                    TextureIndex = (uint) i,
+                    TextureIndex = (uint)i,
                     CellSize = mapTexture.CellSize * 2
                 };
             }
@@ -503,7 +503,7 @@ namespace OpenSage.Terrain
                 {
                     if (tgaFile.Header.Width != largestTextureSize)
                     {
-                        tgaImage.Mutate(x => x.Resize((int) largestTextureSize, (int) largestTextureSize, LanczosResampler.Lanczos3));
+                        tgaImage.Mutate(x => x.Resize((int)largestTextureSize, (int)largestTextureSize, LanczosResampler.Lanczos3));
                     }
 
                     var imageSharpTexture = new ImageSharpTexture(tgaImage);
@@ -526,8 +526,8 @@ namespace OpenSage.Terrain
                             0, 0, 0,
                             mipLevel,
                             i,
-                            (uint) imageSharpTexture.Images[mipLevel].Width,
-                            (uint) imageSharpTexture.Images[mipLevel].Height,
+                            (uint)imageSharpTexture.Images[mipLevel].Width,
+                            (uint)imageSharpTexture.Images[mipLevel].Height,
                             1,
                             1);
                     }
@@ -571,17 +571,17 @@ namespace OpenSage.Terrain
                 using (var pin = pixelSpan.Pin())
                 {
                     var map = gd.Map(staging, MapMode.Write, level);
-                    var rowWidth = (uint) (image.Width * 4);
+                    var rowWidth = (uint)(image.Width * 4);
                     if (rowWidth == map.RowPitch)
                     {
-                        Unsafe.CopyBlock(map.Data.ToPointer(), pin.Pointer, (uint) (image.Width * image.Height * 4));
+                        Unsafe.CopyBlock(map.Data.ToPointer(), pin.Pointer, (uint)(image.Width * image.Height * 4));
                     }
                     else
                     {
                         for (uint y = 0; y < image.Height; y++)
                         {
-                            var dstStart = (byte*) map.Data.ToPointer() + y * map.RowPitch;
-                            var srcStart = (byte*) pin.Pointer + y * rowWidth;
+                            var dstStart = (byte*)map.Data.ToPointer() + y * map.RowPitch;
+                            var srcStart = (byte*)pin.Pointer + y * rowWidth;
                             Unsafe.CopyBlock(dstStart, srcStart, rowWidth);
                         }
                     }
@@ -611,6 +611,18 @@ namespace OpenSage.Terrain
             }
 
             return ray.Position + (ray.Direction * closestIntersection.Value);
+        }
+
+        public float? GetGroundHeight(Vector2 worldPosition)
+        {
+            var tilePosition = HeightMap.GetTilePosition(worldPosition);
+            if (tilePosition == null)
+            {
+                return null;
+            }
+
+            var (x, y) = tilePosition.Value;
+            return HeightMap.GetHeight(x, y);
         }
 
         internal void Update(WaterSettings waterSettings, in TimeInterval time)

--- a/src/OpenSage.Game/Terrain/WaterAreaCollection.cs
+++ b/src/OpenSage.Game/Terrain/WaterAreaCollection.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using OpenSage.Content;
+using System.Linq;
 using OpenSage.Content.Loaders;
 using OpenSage.Data.Map;
 using OpenSage.Graphics.Rendering;
@@ -21,18 +21,12 @@ namespace OpenSage.Terrain
         {
             if (polygonTriggers != null)
             {
-                foreach (var polygonTrigger in polygonTriggers.Triggers)
+                // TODO: Handle rivers differently. Water texture should be animated "downstream".
+                foreach (var polygonTrigger in polygonTriggers.Triggers.Where(t => t.IsWater || t.IsRiver))
                 {
-                    switch (polygonTrigger.TriggerType)
+                    if (WaterArea.TryCreate(loadContext, polygonTrigger, out var waterArea))
                     {
-                        case PolygonTriggerType.Water:
-                        case PolygonTriggerType.River: // TODO: Handle this differently. Water texture should be animated "downstream".
-                        case PolygonTriggerType.WaterAndRiver:
-                            if (WaterArea.TryCreate(loadContext, polygonTrigger, out var waterArea))
-                            {
-                                _waterAreas.Add(AddDisposable(waterArea));
-                            }
-                            break;
+                        _waterAreas.Add(AddDisposable(waterArea));
                     }
                 }
             }

--- a/src/OpenSage.Mathematics/Point3D.cs
+++ b/src/OpenSage.Mathematics/Point3D.cs
@@ -1,4 +1,10 @@
 ﻿namespace OpenSage.Mathematics
 {
-    public readonly record struct Point3D(int X, int Y, int Z);
+    public readonly record struct Point3D(int X, int Y, int Z)
+    {
+        public Point2D ToPoint2D()
+        {
+            return new Point2D(X, Y);
+        }
+    }
 }


### PR DESCRIPTION
Resolves #1038

- Simplify and reformat BinaryReaderExtensions
- Improve null handling & reformat BinaryWriterExtensions
- Add VS Code launch configuration for Tournament Island
  - Alpine Assault and Generals' shell map don't have any water 
- Update PolygonTrigger & related code based on Generals OSS release
  - https://github.com/electronicarts/CnC_Generals_Zero_Hour/blob/0a05454d8574207440a5fb15241b98ad0b435590/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp 

Almost everything was ported from `PolygonTrigger.cpp`, exceptions:
- Methods that mutate the polygon trigger were not implemented, because in the original they only exist for World Builder.
- `getWaterHandle` was not implemented, because the vast majority of functionality related to it is in `TerrainLogic.cpp`. Revisit this in #1040?
