### PR TITLE
Refactor Data.Map.Player and Data.Map.Team

### DIFF
--- a/src/OpenSage.Game/Data/Map/AssetPropertyCollection.cs
+++ b/src/OpenSage.Game/Data/Map/AssetPropertyCollection.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 
@@ -34,14 +36,64 @@ namespace OpenSage.Data.Map
             Add(new AssetProperty(key, AssetPropertyType.AsciiString, value));
         }
 
+        public void AddNullableAsciiString(string key, string? value)
+        {
+            if (value != null)
+            {
+                AddAsciiString(key, value);
+            }
+        }
+
+        public void AddUnicodeString(string key, string value)
+        {
+            Add(new AssetProperty(key, AssetPropertyType.UnicodeString, value));
+        }
+
+        public void AddNullableUnicodeString(string key, string? value)
+        {
+            if (value != null)
+            {
+                AddUnicodeString(key, value);
+            }
+        }
+
         public void AddBoolean(string key, bool value)
         {
             Add(new AssetProperty(key, AssetPropertyType.Boolean, value));
         }
 
-        public void AddInteger(string key, uint value)
+        public void AddNullableBoolean(string key, bool? value)
+        {
+            if (value.HasValue)
+            {
+                AddBoolean(key, value.Value);
+            }
+        }
+
+        public void AddInteger(string key, int value)
         {
             Add(new AssetProperty(key, AssetPropertyType.Integer, value));
+        }
+
+        public void AddNullableInteger(string key, int? value)
+        {
+            if (value.HasValue)
+            {
+                AddInteger(key, value.Value);
+            }
+        }
+
+        public void AddReal(string key, float value)
+        {
+            Add(new AssetProperty(key, AssetPropertyType.RealNumber, value));
+        }
+
+        public void AddNullableReal(string key, float? value)
+        {
+            if (value.HasValue)
+            {
+                AddReal(key, value.Value);
+            }
         }
 
         protected override string GetKeyForItem(AssetProperty item)
@@ -49,14 +101,14 @@ namespace OpenSage.Data.Map
             return item.Key.Name;
         }
 
-        public AssetProperty GetPropOrNull(string key)
+        public AssetProperty? GetPropOrNull(string key)
         {
             return TryGetValue(key, out var value) ? value : null;
         }
 
         internal void WriteTo(BinaryWriter writer, AssetNameCollection assetNames)
         {
-            writer.Write((ushort) Count);
+            writer.Write((ushort)Count);
 
             foreach (var property in this)
             {

--- a/src/OpenSage.Game/Data/Map/SidesList.cs
+++ b/src/OpenSage.Game/Data/Map/SidesList.cs
@@ -84,7 +84,7 @@ namespace OpenSage.Data.Map
                     writer.Write(Unknown);
                 }
 
-                writer.Write((uint) Players.Length);
+                writer.Write((uint)Players.Length);
 
                 foreach (var player in Players)
                 {
@@ -96,7 +96,7 @@ namespace OpenSage.Data.Map
                     return;
                 }
 
-                writer.Write((uint) Teams.Length);
+                writer.Write((uint)Teams.Length);
 
                 foreach (var team in Teams)
                 {

--- a/src/OpenSage.Game/Data/Map/Team.cs
+++ b/src/OpenSage.Game/Data/Map/Team.cs
@@ -1,26 +1,416 @@
-﻿using System.Diagnostics;
+﻿#nullable enable
+
+using System.Diagnostics;
 using System.IO;
 
 namespace OpenSage.Data.Map
 {
-    [DebuggerDisplay("Team '{GetName()}'")]
+    [DebuggerDisplay("Team '{Name}'")]
     public sealed class Team
     {
-        public AssetPropertyCollection Properties { get; internal set; }
+        public Team(AssetPropertyCollection properties)
+        {
+            ParseProperties(properties);
+        }
+
+        public Team() { }
+
+        /// <summary>
+        /// name of team.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// name of the player-or-team that owns this team.
+        /// </summary>
+        public string Owner { get; set; } = string.Empty;
+
+        /// <summary>
+        /// if true, only one instance of this team can be made.
+        /// </summary>
+        public bool IsSingleton { get; set; }
+
+        /// <summary>
+        /// Name of waypoint where team spawns.
+        /// </summary>
+        public string Home { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Thing name of first batch of units.
+        /// </summary>
+        public string? UnitType1 { get; set; }
+
+        /// <summary>
+        /// Minimum number of units of type 1 to build.
+        /// </summary>
+        public int? UnitMinCount1 { get; set; }
+
+        /// <summary>
+        /// Maximum number of units of type 1 to build.
+        /// </summary>
+        public int? UnitMaxCount1 { get; set; }
+
+        /// <summary>
+        /// Thing name of second batch of units.
+        /// </summary>
+        public string? UnitType2 { get; set; }
+
+        /// <summary>
+        /// Minimum number of units of type 2 to build.
+        /// </summary>
+        public int? UnitMinCount2 { get; set; }
+
+        /// <summary>
+        /// Maximum number of units of type 2 to build.
+        /// </summary>
+        public int? UnitMaxCount2 { get; set; }
+
+        /// <summary>
+        /// Thing name of third batch of units.
+        /// </summary>
+        public string? UnitType3 { get; set; }
+
+        /// <summary>
+        /// Minimum number of units of type 3 to build.
+        /// </summary>
+        public int? UnitMinCount3 { get; set; }
+
+        /// <summary>
+        /// Maximum number of units of type 3 to build.
+        /// </summary>
+        public int? UnitMaxCount3 { get; set; }
+
+        /// <summary>
+        /// Thing name of fourth batch of units.
+        /// </summary>
+        public string? UnitType4 { get; set; }
+
+        /// <summary>
+        /// Minimum number of units of type 4 to build.
+        /// </summary>
+        public int? UnitMinCount4 { get; set; }
+
+        /// <summary>
+        /// Maximum number of units of type 4 to build.
+        /// </summary>
+        public int? UnitMaxCount4 { get; set; }
+
+        /// <summary>
+        /// Thing name of fifth batch of units.
+        /// </summary>
+        public string? UnitType5 { get; set; }
+
+        /// <summary>
+        /// Minimum number of units of type 5 to build.
+        /// </summary>
+        public int? UnitMinCount5 { get; set; }
+
+        /// <summary>
+        /// Maximum number of units of type 5 to build.
+        /// </summary>
+        public int? UnitMaxCount5 { get; set; }
+
+        /// <summary>
+        /// Thing name of sixth batch of units.
+        /// </summary>
+        public string? UnitType6 { get; set; }
+
+        /// <summary>
+        /// Minimum number of units of type 6 to build.
+        /// </summary>
+        public int? UnitMinCount6 { get; set; }
+
+        /// <summary>
+        /// Maximum number of units of type 6 to build.
+        /// </summary>
+        public int? UnitMaxCount6 { get; set; }
+
+        /// <summary>
+        /// Thing name of seventh batch of units.
+        /// </summary>
+        public string? UnitType7 { get; set; }
+
+        /// <summary>
+        /// Minimum number of units of type 7 to build.
+        /// </summary>
+        public int? UnitMinCount7 { get; set; }
+
+        /// <summary>
+        /// Maximum number of units of type 7 to build.
+        /// </summary>
+        public int? UnitMaxCount7 { get; set; }
+
+        /// <summary>
+        /// Name of script to execute when team is created for AI.
+        /// </summary>
+        public string? OnCreateScript { get; set; }
+
+        /// <summary>
+        /// Name of script to execute when AI team is in idle state.
+        /// </summary>
+        public string? OnIdleScript { get; set; }
+
+        /// <summary>
+        /// Number of frames to wait after achieving the minimum number of units to try to recruit up to the maximum number of units.
+        /// </summary>
+        public int? InitialIdleFrames { get; set; }
+
+        /// <summary>
+        /// Name of a script to run each time a member on this team is destroyed.
+        /// </summary>
+        public string? OnUnitDestroyedScript { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Name of script to execute when team is destroyed.
+        /// </summary>
+        public string? OnDestroyedScript { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Percent destroyed to trigger OnDamagedScript. 1.0 = 100% = trigger when team is all destroyed. 0 = 0% = trigger when first team member is destroyed.
+        /// </summary>
+        public float? DestroyedThreshold { get; set; }
+
+        /// <summary>
+        /// Name of script to execute when enemy is sighted.
+        /// </summary>
+        public string? EnemySightedScript { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Name of script to execute when all clear.
+        /// </summary>
+        public string? AllClearScript { get; set; } = string.Empty;
+
+        /// <summary>
+        /// True if team auto reinforces.
+        /// </summary>
+        public bool? AutoReinforce { get; set; }
+
+        /// <summary>
+        /// True if team can be recruited from by other ai teams.
+        /// </summary>
+        public bool? IsAIRecruitable { get; set; }
+
+        /// <summary>
+        /// True if team can be recruited from by other ai teams.
+        /// </summary>
+        public bool? IsBaseDefense { get; set; }
+
+        /// <summary>
+        /// True if team can be recruited from by other ai teams.
+        /// </summary>
+        public bool? IsPerimeterDefense { get; set; }
+
+        /// <summary>
+        /// The aggressiveness of the team: -2 Sleep, -1 Passive, 0 Normal, 1 Alert, 2 Aggressive
+        /// </summary>
+        public int? Aggressiveness { get; set; }
+
+        /// <summary>
+        /// True if transports return to base.
+        /// </summary>
+        public bool? TransportsReturn { get; set; }
+
+        /// <summary>
+        /// True if the team avoids threats.
+        /// </summary>
+        public bool? AvoidThreats { get; set; }
+
+        /// <summary>
+        /// True if the team attacks the same target when auto-acquiring targets.
+        /// </summary>
+        public bool? AttackCommonTarget { get; set; }
+
+        /// <summary>
+        /// If a team is not singleton, max number of this team at one time.
+        /// </summary>
+        public int? MaxInstances { get; set; }
+
+        /// <summary>
+        /// Description comment field.
+        /// </summary>
+        public string? Description { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Script that contains the conditions for team production.
+        /// </summary>
+        public string? ProductionCondition { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Team's production priority.
+        /// </summary>
+        public int? ProductionPriority { get; set; }
+
+        /// <summary>
+        /// Team's production priority increase on success amount.
+        /// </summary>
+        public int? ProductionPrioritySuccessIncrease { get; set; }
+
+        /// <summary>
+        /// Team's production priority decrease on failure amount.
+        /// </summary>
+        public int? ProductionPriorityFailureDecrease { get; set; }
+
+        /// <summary>
+        /// Team's transport unit for reinforcements.
+        /// </summary>
+        public string? Transport { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Team's origin for reinforcements.
+        /// </summary>
+        public string? ReinforcementOrigin { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Team's starts full flag (pack into transports) for reinforcement teams.
+        /// </summary>
+        public bool? StartsFull { get; set; }
+
+        /// <summary>
+        /// Team's transports exit (leave the map) flag for reinforcement teams.
+        /// </summary>
+        public bool? TransportsExit { get; set; }
+
+        /// <summary>
+        /// What veterancy does this object have: 0 green, 1 normal, 2 veteran, 3 elite
+        /// </summary>
+        public int? Veterancy { get; set; }
+
+        /// <summary>
+        /// Does the team execute the actions in
+        /// </summary>
+        public bool? ExecutesActionsOnCreate { get; set; }
+
+        /// <summary>
+        /// This key is used in the same way that objectGrantUpgrades is used. See it for an explanation.
+        /// </summary>
+        public string? GenericScriptHook { get; set; }
+
+        private void ParseProperties(AssetPropertyCollection properties)
+        {
+            Name = properties.GetPropOrNull("teamName")?.GetAsciiString() ?? string.Empty;
+            Owner = properties.GetPropOrNull("teamOwner")?.GetAsciiString() ?? string.Empty;
+            IsSingleton = properties.GetPropOrNull("teamIsSingleton")?.GetBoolean() ?? false;
+            Home = properties.GetPropOrNull("teamHome")?.GetAsciiString() ?? string.Empty;
+            UnitType1 = properties.GetPropOrNull("teamUnitType1")?.GetAsciiString();
+            UnitMinCount1 = properties.GetPropOrNull("teamUnitMinCount1")?.GetInteger();
+            UnitMaxCount1 = properties.GetPropOrNull("teamUnitMaxCount1")?.GetInteger();
+            UnitType2 = properties.GetPropOrNull("teamUnitType2")?.GetAsciiString();
+            UnitMinCount2 = properties.GetPropOrNull("teamUnitMinCount2")?.GetInteger();
+            UnitMaxCount2 = properties.GetPropOrNull("teamUnitMaxCount2")?.GetInteger();
+            UnitType3 = properties.GetPropOrNull("teamUnitType3")?.GetAsciiString();
+            UnitMinCount3 = properties.GetPropOrNull("teamUnitMinCount3")?.GetInteger();
+            UnitMaxCount3 = properties.GetPropOrNull("teamUnitMaxCount3")?.GetInteger();
+            UnitType4 = properties.GetPropOrNull("teamUnitType4")?.GetAsciiString();
+            UnitMinCount4 = properties.GetPropOrNull("teamUnitMinCount4")?.GetInteger();
+            UnitMaxCount4 = properties.GetPropOrNull("teamUnitMaxCount4")?.GetInteger();
+            UnitType5 = properties.GetPropOrNull("teamUnitType5")?.GetAsciiString();
+            UnitMinCount5 = properties.GetPropOrNull("teamUnitMinCount5")?.GetInteger();
+            UnitMaxCount5 = properties.GetPropOrNull("teamUnitMaxCount5")?.GetInteger();
+            UnitType6 = properties.GetPropOrNull("teamUnitType6")?.GetAsciiString();
+            UnitMinCount6 = properties.GetPropOrNull("teamUnitMinCount6")?.GetInteger();
+            UnitMaxCount6 = properties.GetPropOrNull("teamUnitMaxCount6")?.GetInteger();
+            UnitType7 = properties.GetPropOrNull("teamUnitType7")?.GetAsciiString();
+            UnitMinCount7 = properties.GetPropOrNull("teamUnitMinCount7")?.GetInteger();
+            UnitMaxCount7 = properties.GetPropOrNull("teamUnitMaxCount7")?.GetInteger();
+            OnCreateScript = properties.GetPropOrNull("teamOnCreateScript")?.GetAsciiString();
+            OnIdleScript = properties.GetPropOrNull("teamOnIdleScript")?.GetAsciiString();
+            InitialIdleFrames = properties.GetPropOrNull("teamInitialIdleFrames")?.GetInteger();
+            OnUnitDestroyedScript = properties.GetPropOrNull("teamOnUnitDestroyedScript")?.GetAsciiString();
+            OnDestroyedScript = properties.GetPropOrNull("teamOnDestroyedScript")?.GetAsciiString();
+            DestroyedThreshold = properties.GetPropOrNull("teamDestroyedThreshold")?.GetReal();
+            EnemySightedScript = properties.GetPropOrNull("teamEnemySightedScript")?.GetAsciiString();
+            AllClearScript = properties.GetPropOrNull("teamAllClearScript")?.GetAsciiString();
+            AutoReinforce = properties.GetPropOrNull("teamAutoReinforce")?.GetBoolean();
+            IsAIRecruitable = properties.GetPropOrNull("teamIsAIRecruitable")?.GetBoolean();
+            IsBaseDefense = properties.GetPropOrNull("teamIsBaseDefense")?.GetBoolean();
+            IsPerimeterDefense = properties.GetPropOrNull("teamIsPerimeterDefense")?.GetBoolean();
+            Aggressiveness = properties.GetPropOrNull("teamAggressiveness")?.GetInteger();
+            TransportsReturn = properties.GetPropOrNull("teamTransportsReturn")?.GetBoolean();
+            AvoidThreats = properties.GetPropOrNull("teamAvoidThreats")?.GetBoolean();
+            AttackCommonTarget = properties.GetPropOrNull("teamAttackCommonTarget")?.GetBoolean();
+            MaxInstances = properties.GetPropOrNull("teamMaxInstances")?.GetInteger();
+            Description = properties.GetPropOrNull("teamDescription")?.GetAsciiString();
+            ProductionCondition = properties.GetPropOrNull("teamProductionCondition")?.GetAsciiString();
+            ProductionPriority = properties.GetPropOrNull("teamProductionPriority")?.GetInteger();
+            ProductionPrioritySuccessIncrease = properties.GetPropOrNull("teamProductionPrioritySuccessIncrease")?.GetInteger();
+            ProductionPriorityFailureDecrease = properties.GetPropOrNull("teamProductionPriorityFailureDecrease")?.GetInteger();
+            Transport = properties.GetPropOrNull("teamTransport")?.GetAsciiString();
+            ReinforcementOrigin = properties.GetPropOrNull("teamReinforcementOrigin")?.GetAsciiString();
+            StartsFull = properties.GetPropOrNull("teamStartsFull")?.GetBoolean();
+            TransportsExit = properties.GetPropOrNull("teamTransportsExit")?.GetBoolean();
+            Veterancy = properties.GetPropOrNull("teamVeterancy")?.GetInteger();
+            ExecutesActionsOnCreate = properties.GetPropOrNull("teamExecutesActionsOnCreate")?.GetBoolean();
+            GenericScriptHook = properties.GetPropOrNull("teamGenericScriptHook")?.GetAsciiString();
+        }
+
+        private void SerializeProperties(AssetPropertyCollection properties)
+        {
+            properties.AddAsciiString("teamName", Name);
+            properties.AddAsciiString("teamOwner", Owner);
+            properties.AddBoolean("teamIsSingleton", IsSingleton);
+            properties.AddAsciiString("teamHome", Home);
+            properties.AddNullableAsciiString("teamUnitType1", UnitType1);
+            properties.AddNullableInteger("teamUnitMinCount1", UnitMinCount1);
+            properties.AddNullableInteger("teamUnitMaxCount1", UnitMaxCount1);
+            properties.AddNullableAsciiString("teamUnitType2", UnitType2);
+            properties.AddNullableInteger("teamUnitMinCount2", UnitMinCount2);
+            properties.AddNullableInteger("teamUnitMaxCount2", UnitMaxCount2);
+            properties.AddNullableAsciiString("teamUnitType3", UnitType3);
+            properties.AddNullableInteger("teamUnitMinCount3", UnitMinCount3);
+            properties.AddNullableInteger("teamUnitMaxCount3", UnitMaxCount3);
+            properties.AddNullableAsciiString("teamUnitType4", UnitType4);
+            properties.AddNullableInteger("teamUnitMinCount4", UnitMinCount4);
+            properties.AddNullableInteger("teamUnitMaxCount4", UnitMaxCount4);
+            properties.AddNullableAsciiString("teamUnitType5", UnitType5);
+            properties.AddNullableInteger("teamUnitMinCount5", UnitMinCount5);
+            properties.AddNullableInteger("teamUnitMaxCount5", UnitMaxCount5);
+            properties.AddNullableAsciiString("teamUnitType6", UnitType6);
+            properties.AddNullableInteger("teamUnitMinCount6", UnitMinCount6);
+            properties.AddNullableInteger("teamUnitMaxCount6", UnitMaxCount6);
+            properties.AddNullableAsciiString("teamUnitType7", UnitType7);
+            properties.AddNullableInteger("teamUnitMinCount7", UnitMinCount7);
+            properties.AddNullableInteger("teamUnitMaxCount7", UnitMaxCount7);
+            properties.AddNullableAsciiString("teamOnCreateScript", OnCreateScript);
+            properties.AddNullableAsciiString("teamOnIdleScript", OnIdleScript);
+            properties.AddNullableInteger("teamInitialIdleFrames", InitialIdleFrames);
+            properties.AddNullableAsciiString("teamOnUnitDestroyedScript", OnUnitDestroyedScript);
+            properties.AddNullableAsciiString("teamOnDestroyedScript", OnDestroyedScript);
+            properties.AddNullableReal("teamDestroyedThreshold", DestroyedThreshold);
+            properties.AddNullableAsciiString("teamEnemySightedScript", EnemySightedScript);
+            properties.AddNullableAsciiString("teamAllClearScript", AllClearScript);
+            properties.AddNullableBoolean("teamAutoReinforce", AutoReinforce);
+            properties.AddNullableBoolean("teamIsAIRecruitable", IsAIRecruitable);
+            properties.AddNullableBoolean("teamIsBaseDefense", IsBaseDefense);
+            properties.AddNullableBoolean("teamIsPerimeterDefense", IsPerimeterDefense);
+            properties.AddNullableInteger("teamAggressiveness", Aggressiveness);
+            properties.AddNullableBoolean("teamTransportsReturn", TransportsReturn);
+            properties.AddNullableBoolean("teamAvoidThreats", AvoidThreats);
+            properties.AddNullableBoolean("teamAttackCommonTarget", AttackCommonTarget);
+            properties.AddNullableInteger("teamMaxInstances", MaxInstances);
+            properties.AddNullableAsciiString("teamDescription", Description);
+            properties.AddNullableAsciiString("teamProductionCondition", ProductionCondition);
+            properties.AddNullableInteger("teamProductionPriority", ProductionPriority);
+            properties.AddNullableInteger("teamProductionPrioritySuccessIncrease", ProductionPrioritySuccessIncrease);
+            properties.AddNullableInteger("teamProductionPriorityFailureDecrease", ProductionPriorityFailureDecrease);
+            properties.AddNullableAsciiString("teamTransport", Transport);
+            properties.AddNullableAsciiString("teamReinforcementOrigin", ReinforcementOrigin);
+            properties.AddNullableBoolean("teamStartsFull", StartsFull);
+            properties.AddNullableBoolean("teamTransportsExit", TransportsExit);
+            properties.AddNullableInteger("teamVeterancy", Veterancy);
+            properties.AddNullableBoolean("teamExecutesActionsOnCreate", ExecutesActionsOnCreate);
+            properties.AddNullableAsciiString("teamGenericScriptHook", GenericScriptHook);
+        }
 
         internal static Team Parse(BinaryReader reader, MapParseContext context)
         {
-            return new Team
-            {
-                Properties = AssetPropertyCollection.Parse(reader, context)
-            };
+            return new Team(AssetPropertyCollection.Parse(reader, context));
         }
 
         internal void WriteTo(BinaryWriter writer, AssetNameCollection assetNames)
         {
-            Properties.WriteTo(writer, assetNames);
+            var properties = new AssetPropertyCollection();
+            SerializeProperties(properties);
+            properties.WriteTo(writer, assetNames);
         }
-
-        private string GetName() => (string)Properties["teamName"].Value;
     }
 }

--- a/src/OpenSage.Game/Data/Map/WaypointPath.cs
+++ b/src/OpenSage.Game/Data/Map/WaypointPath.cs
@@ -4,15 +4,15 @@ namespace OpenSage.Data.Map
 {
     public sealed class WaypointPath
     {
-        public uint StartWaypointID { get; private set; }
-        public uint EndWaypointID { get; private set; }
+        public int StartWaypointID { get; private set; }
+        public int EndWaypointID { get; private set; }
 
         internal static WaypointPath Parse(BinaryReader reader)
         {
             return new WaypointPath
             {
-                StartWaypointID = reader.ReadUInt32(),
-                EndWaypointID = reader.ReadUInt32()
+                StartWaypointID = reader.ReadInt32(),
+                EndWaypointID = reader.ReadInt32()
             };
         }
 

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -68,7 +68,7 @@ namespace OpenSage.Logic.Object
             if (_body != null)
             {
                 var healthMultiplier = mapObject.Properties.TryGetValue("objectInitialHealth", out var health)
-                    ? (uint) health.Value / 100.0f
+                    ? (int)health.Value / 100.0f
                     : 1.0f;
 
                 _body.SetInitialHealth(healthMultiplier);
@@ -76,12 +76,12 @@ namespace OpenSage.Logic.Object
 
             if (mapObject.Properties.TryGetValue("objectName", out var objectName))
             {
-                Name = (string) objectName.Value;
+                Name = (string)objectName.Value;
             }
 
             if (mapObject.Properties.TryGetValue("objectSelectable", out var selectable))
             {
-                IsSelectable = (bool) selectable.Value;
+                IsSelectable = (bool)selectable.Value;
             }
 
             // TODO: handle "align to terrain" property
@@ -367,7 +367,7 @@ namespace OpenSage.Logic.Object
         {
             get
             {
-                var healthPercentage = (float) _body.HealthPercentage;
+                var healthPercentage = (float)_body.HealthPercentage;
                 var damagedThreshold = _gameContext.AssetLoadContext.AssetStore.GameData.Current.UnitDamagedThreshold;
                 return healthPercentage <= damagedThreshold;
             }
@@ -399,7 +399,7 @@ namespace OpenSage.Logic.Object
 
         public int Rank
         {
-            get => (int) VeterancyHelper.VeterancyLevel;
+            get => (int)VeterancyHelper.VeterancyLevel;
             set
             {
                 var rank = (VeterancyLevel)value;
@@ -524,7 +524,7 @@ namespace OpenSage.Logic.Object
 
             foreach (var behaviorDataContainer in objectDefinition.Behaviors.Values)
             {
-                var behaviorModuleData = (BehaviorModuleData) behaviorDataContainer.Data;
+                var behaviorModuleData = (BehaviorModuleData)behaviorDataContainer.Data;
                 var module = AddDisposable(behaviorModuleData.CreateModule(this, gameContext));
 
                 // TODO: This will never be null once we've implemented all the behaviors.
@@ -1029,7 +1029,7 @@ namespace OpenSage.Logic.Object
 
             var oldDamageType = _bodyDamageType;
 
-            if (healthPercentage < (Fix64) _gameContext.AssetLoadContext.AssetStore.GameData.Current.UnitReallyDamagedThreshold)
+            if (healthPercentage < (Fix64)_gameContext.AssetLoadContext.AssetStore.GameData.Current.UnitReallyDamagedThreshold)
             {
                 if (takingDamage && !ModelConditionFlags.Get(ModelConditionFlag.ReallyDamaged))
                 {
@@ -1045,7 +1045,7 @@ namespace OpenSage.Logic.Object
 
                 ModelConditionFlags.Set(ModelConditionFlag.Damaged, false);
             }
-            else if (healthPercentage < (Fix64) _gameContext.AssetLoadContext.AssetStore.GameData.Current.UnitDamagedThreshold)
+            else if (healthPercentage < (Fix64)_gameContext.AssetLoadContext.AssetStore.GameData.Current.UnitDamagedThreshold)
             {
                 if (takingDamage && !ModelConditionFlags.Get(ModelConditionFlag.Damaged))
                 {
@@ -1803,7 +1803,7 @@ namespace OpenSage.Logic.Object
                 return false;
             }
 
-            ExperiencePoints += (int) (ExperienceScalar * experience);
+            ExperiencePoints += (int)(ExperienceScalar * experience);
             var nextRank = (int)VeterancyLevel + 1;
 
             if (_gameObject.Definition.ExperienceRequired == null || nextRank >= _gameObject.Definition.ExperienceRequired.Values.Length)
@@ -1811,10 +1811,10 @@ namespace OpenSage.Logic.Object
                 return false; // nothing left for us to gain
             }
 
-            var xpForNextRank =_gameObject.Definition.ExperienceRequired.Values[nextRank];
+            var xpForNextRank = _gameObject.Definition.ExperienceRequired.Values[nextRank];
             if (ExperiencePoints >= xpForNextRank)
             {
-                VeterancyLevel = (VeterancyLevel) nextRank;
+                VeterancyLevel = (VeterancyLevel)nextRank;
                 ShowRankUpAnimation = true;
                 return true;
             }

--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -247,9 +247,9 @@ namespace OpenSage.Logic
 
         public void CreateSelectionGroup(int idx)
         {
-            if(idx > _selectionGroups.Length)
+            if (idx > _selectionGroups.Length)
             {
-                Logger.Warn($"Do not support more than { _selectionGroups.Length} groups!");
+                Logger.Warn($"Do not support more than {_selectionGroups.Length} groups!");
                 return;
             }
 
@@ -261,7 +261,7 @@ namespace OpenSage.Logic
         {
             if (idx > _selectionGroups.Length)
             {
-                Logger.Warn($"Do not support more than { _selectionGroups.Length} groups!");
+                Logger.Warn($"Do not support more than {_selectionGroups.Length} groups!");
                 return;
             }
 
@@ -324,7 +324,7 @@ namespace OpenSage.Logic
                 return;
             }
 
-            SciencePurchasePoints -= (uint) science.SciencePurchasePointCost;
+            SciencePurchasePoints -= (uint)science.SciencePurchasePointCost;
             _sciences.Add(science);
             ApplyScienceUpgrades(science);
         }
@@ -635,7 +635,7 @@ namespace OpenSage.Logic
 
             var rankId = (uint)Rank.CurrentRank;
             reader.PersistUInt32(ref rankId);
-            Rank.SetRank((int) rankId);
+            Rank.SetRank((int)rankId);
 
             reader.PersistUInt32(ref SkillPointsTotal);
             reader.PersistUInt32(ref SkillPointsAvailable);
@@ -704,7 +704,7 @@ namespace OpenSage.Logic
 
         public static Player FromMapData(uint index, Data.Map.Player mapPlayer, IGame game, bool isSkirmish)
         {
-            var side = (string)mapPlayer.Properties["playerFaction"].Value;
+            var side = mapPlayer.Faction ?? throw new InvalidStateException($"Player {mapPlayer.Name} has no faction.");
 
             if (side.StartsWith("FactionAmerica", System.StringComparison.InvariantCultureIgnoreCase))
             {
@@ -725,19 +725,19 @@ namespace OpenSage.Logic
             // We need the template for default values
             var template = game.AssetStore.PlayerTemplates.GetByName(side);
 
-            var name = mapPlayer.Properties["playerName"].Value as string;
-            var displayName = mapPlayer.Properties["playerDisplayName"].Value as string;
+            var name = mapPlayer.Name;
+            var displayName = mapPlayer.DisplayName;
             var translatedDisplayName = displayName.Translate();
 
-            var isHuman = (bool) mapPlayer.Properties["playerIsHuman"].Value;
+            var isHuman = mapPlayer.IsHuman;
 
-            var colorRgb = mapPlayer.Properties.GetPropOrNull("playerColor")?.Value as uint?;
+            var colorRgb = mapPlayer.Color;
 
             ColorRgb color;
 
             if (colorRgb != null)
             {
-                color = ColorRgb.FromUInt32(colorRgb.Value);
+                color = ColorRgb.FromInt32(colorRgb.Value);
             }
             else if (template != null) // Template is null for the neutral faction
             {
@@ -764,7 +764,7 @@ namespace OpenSage.Logic
 
             if (template != null)
             {
-                result.BankAccount.Money = (uint) (template.StartMoney + game.AssetStore.GameData.Current.DefaultStartingCash);
+                result.BankAccount.Money = (uint)(template.StartMoney + game.AssetStore.GameData.Current.DefaultStartingCash);
             }
 
             return result;

--- a/src/OpenSage.Game/Logic/PlayerManager.cs
+++ b/src/OpenSage.Game/Logic/PlayerManager.cs
@@ -59,10 +59,10 @@ namespace OpenSage.Logic
                 var player = Player.FromMapData(id++, mapPlayer, _game, gameType != GameType.SinglePlayer);
                 players[player.Name] = player;
                 allies[player.Name] =
-                    (mapPlayer.Properties.GetPropOrNull("playerAllies")?.Value as string)?.Split(' ')
+                    mapPlayer.Allies?.Split(' ')
                     .Where(s => !string.IsNullOrEmpty(s)).ToArray() ?? []; // Neutral has a player name of "", so it's important not to add empty strings
                 enemies[player.Name] =
-                    (mapPlayer.Properties.GetPropOrNull("playerEnemies")?.Value as string)?.Split(' ')
+                    mapPlayer.Enemies?.Split(' ')
                     .Where(s => !string.IsNullOrEmpty(s)).ToArray() ?? []; // Neutral has a player name of "", so it's important not to add empty strings
             }
 

--- a/src/OpenSage.Game/Logic/TeamFactory.cs
+++ b/src/OpenSage.Game/Logic/TeamFactory.cs
@@ -32,12 +32,12 @@ namespace OpenSage.Logic
 
             foreach (var mapTeam in mapTeams)
             {
-                var name = mapTeam.Properties["teamName"].Value as string;
+                var name = mapTeam.Name;
 
-                var ownerName = mapTeam.Properties["teamOwner"].Value as string;
+                var ownerName = mapTeam.Owner;
                 var owner = _game.PlayerManager.GetPlayerByName(ownerName);
 
-                var isSingleton = (bool) mapTeam.Properties["teamIsSingleton"].Value;
+                var isSingleton = mapTeam.IsSingleton;
 
                 AddTeamTemplate(name, owner, isSingleton);
             }
@@ -45,7 +45,7 @@ namespace OpenSage.Logic
 
         private void AddTeamTemplate(string name, Player owner, bool isSingleton)
         {
-            var id = (uint) (_teamTemplatesById.Count + 1);
+            var id = (uint)(_teamTemplatesById.Count + 1);
 
             var teamTemplate = new TeamTemplate(
                 this,

--- a/src/OpenSage.Game/Scripting/Waypoints.cs
+++ b/src/OpenSage.Game/Scripting/Waypoints.cs
@@ -8,22 +8,22 @@ using OpenSage.Utilities.Extensions;
 
 namespace OpenSage.Scripting
 {
-    public sealed class WaypointCollection  
+    public sealed class WaypointCollection
     {
-        private readonly Dictionary<uint, Waypoint> _waypointsByID;
+        private readonly Dictionary<int, Waypoint> _waypointsByID;
         private readonly Dictionary<string, Waypoint> _waypointsByName;
         private readonly Dictionary<string, HashSet<Waypoint>> _waypointsByPathLabel;
 
         public Waypoint this[string name] => _waypointsByName[name];
-        public Waypoint this[uint id] => _waypointsByID[id];
+        public Waypoint this[int id] => _waypointsByID[id];
 
         public WaypointCollection()
         {
             // Note that we explicitly allow duplicate waypoint names.
 
-            _waypointsByName = new Dictionary<string, Waypoint>();
-            _waypointsByID = new Dictionary<uint, Waypoint>();
-            _waypointsByPathLabel = new Dictionary<string, HashSet<Waypoint>>();
+            _waypointsByName = [];
+            _waypointsByID = [];
+            _waypointsByPathLabel = [];
         }
 
         public WaypointCollection(IEnumerable<Waypoint> waypoints, IEnumerable<WaypointPath> paths)
@@ -38,7 +38,7 @@ namespace OpenSage.Scripting
                 {
                     if (!_waypointsByPathLabel.TryGetValue(pathLabel, out var collection))
                     {
-                        collection = new HashSet<Waypoint>();
+                        collection = [];
                         _waypointsByPathLabel.Add(pathLabel, collection);
                     }
 
@@ -63,9 +63,7 @@ namespace OpenSage.Scripting
 
         public IReadOnlyCollection<Waypoint> GetByPathLabel(string pathLabel)
         {
-            return _waypointsByPathLabel.TryGetValue(pathLabel, out var waypoints) ?
-                (IReadOnlyCollection<Waypoint>) waypoints :
-                Array.Empty<Waypoint>();
+            return _waypointsByPathLabel.TryGetValue(pathLabel, out var waypoints) ? waypoints : Array.Empty<Waypoint>();
         }
     }
 
@@ -76,7 +74,7 @@ namespace OpenSage.Scripting
 
         private List<Waypoint> _connectedWaypoints;
 
-        public uint ID { get; }
+        public int ID { get; }
         public string Name { get; }
         public Vector3 Position { get; }
 
@@ -84,8 +82,8 @@ namespace OpenSage.Scripting
 
         internal Waypoint(MapObject mapObject)
         {
-            ID = (uint) mapObject.Properties["waypointID"].Value;
-            Name = (string) mapObject.Properties["waypointName"].Value;
+            ID = (int)mapObject.Properties["waypointID"].Value;
+            Name = (string)mapObject.Properties["waypointName"].Value;
             Position = mapObject.Position;
 
             // It seems that if one of the label properties exists, all of them do
@@ -100,7 +98,7 @@ namespace OpenSage.Scripting
             }
             else
             {
-                PathLabels = Enumerable.Empty<string>();
+                PathLabels = [];
             }
         }
 
@@ -111,7 +109,7 @@ namespace OpenSage.Scripting
         }
 
         public IReadOnlyList<Waypoint> ConnectedWaypoints =>
-            (IReadOnlyList<Waypoint>) _connectedWaypoints ?? Array.Empty<Waypoint>();
+            (IReadOnlyList<Waypoint>)_connectedWaypoints ?? Array.Empty<Waypoint>();
 
         /// <summary>
         /// Follows a waypoint path starting with this waypoint.

--- a/src/OpenSage.Mathematics/ColorRgb.cs
+++ b/src/OpenSage.Mathematics/ColorRgb.cs
@@ -17,11 +17,16 @@ namespace OpenSage.Mathematics
 
         public static ColorRgb FromUInt32(uint rgb)
         {
-            var r = (byte) (rgb >> 16 & 0xFF);
-            var g = (byte) (rgb >> 8 & 0xFF);
-            var b = (byte) (rgb & 0xFF);
+            var r = (byte)(rgb >> 16 & 0xFF);
+            var g = (byte)(rgb >> 8 & 0xFF);
+            var b = (byte)(rgb & 0xFF);
 
             return new ColorRgb(r, g, b);
+        }
+
+        public static ColorRgb FromInt32(int rgb)
+        {
+            return FromUInt32((uint)rgb);
         }
 
         public uint ToUInt32()
@@ -31,6 +36,11 @@ namespace OpenSage.Mathematics
             result |= (G << 8);
             result |= (B << 0);
             return (uint)result;
+        }
+
+        public int ToInt32()
+        {
+            return (int)ToUInt32();
         }
 
         public ColorRgba ToColorRgba()


### PR DESCRIPTION
* Refactor Data.Map.Player and Data.Map.Team to expose properties instead of a dynamically typed collection
  * Using a dynamically typed dictionary is _technically_ closer to how SAGE actually works, but it's also really messy, a bit slow and hard to document. 
  * The properties were created based on the list of `Team` and `Player` keys in [`WellKnownKeys.h`](https://github.com/electronicarts/CnC_Generals_Zero_Hour/blob/0a05454d8574207440a5fb15241b98ad0b435590/GeneralsMD/Code/GameEngine/Include/Common/WellKnownKeys.h)
* `AssetPropertyType.Integer` is now treated as a signed integer, matching Generals / ZH implementation. Our implementation used to use uint, and there were a few places outside of player & team code where an integer property is incorrectly cast from boxed integer to boxed uint, causing an exception. There might still be more of these lurking around, but main menu and at least a few skirmish maps still load successfully.
* Minor refactoring to support other changes 