### PR TITLE
Port ArmorUpgrade from Generals OSS release

### DIFF
--- a/src/OpenSage.Game/Logic/Object/AnimationState.cs
+++ b/src/OpenSage.Game/Logic/Object/AnimationState.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.Mathematics;
@@ -6,7 +8,7 @@ using OpenSage.Mathematics;
 namespace OpenSage.Logic.Object
 {
     [AddedIn(SageGame.Bfme)]
-    public class AnimationState : IConditionState
+    public class AnimationState : IConditionState<ModelConditionFlag>
     {
         internal static AnimationState Parse(IniParser parser, ParseConditionStateType type)
         {
@@ -45,6 +47,8 @@ namespace OpenSage.Logic.Object
         };
 
         public List<BitArray<ModelConditionFlag>> ConditionFlags { get; } = new();
+
+        ReadOnlySpan<BitArray<ModelConditionFlag>> IConditionState<ModelConditionFlag>.ConditionFlags => CollectionsMarshal.AsSpan(ConditionFlags);
 
         public List<AnimationStateAnimation> Animations { get; private set; } = new List<AnimationStateAnimation>();
         public List<ParticleSysBone> ParticleSysBones { get; private set; } = new List<ParticleSysBone>();

--- a/src/OpenSage.Game/Logic/Object/ArmorTemplateSet.cs
+++ b/src/OpenSage.Game/Logic/Object/ArmorTemplateSet.cs
@@ -1,10 +1,11 @@
-﻿using OpenSage.Content;
+﻿using System;
+using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
-    public sealed class ArmorTemplateSet
+    public sealed class ArmorTemplateSet : IConditionState<ArmorSetCondition>
     {
         internal static ArmorTemplateSet Parse(IniParser parser)
         {
@@ -13,13 +14,15 @@ namespace OpenSage.Logic.Object
 
         private static readonly IniParseTable<ArmorTemplateSet> FieldParseTable = new IniParseTable<ArmorTemplateSet>
         {
-            { "Conditions", (parser, x) => x.Conditions = parser.ParseEnumBitArray<ArmorSetCondition>() },
+            { "Conditions", (parser, x) => x.Conditions.CopyFrom(parser.ParseEnumBitArray<ArmorSetCondition>()) },
             { "Armor", (parser, x) => x.Armor = parser.ParseArmorTemplateReference() },
             { "DamageFX", (parser, x) => x.DamageFX = parser.ParseDamageFXReference() },
         };
 
-        public BitArray<ArmorSetCondition> Conditions { get; private set; } = new BitArray<ArmorSetCondition>();
+        public readonly BitArray<ArmorSetCondition> Conditions = new BitArray<ArmorSetCondition>();
         public LazyAssetReference<ArmorTemplate> Armor { get; private set; }
         public LazyAssetReference<DamageFX> DamageFX { get; private set; }
+
+        public ReadOnlySpan<BitArray<ArmorSetCondition>> ConditionFlags => new(in Conditions);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Body/BodyModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/BodyModule.cs
@@ -32,6 +32,8 @@ namespace OpenSage.Logic.Object
 
         public virtual void Heal(Fix64 amount, GameObject healer) { }
 
+        public abstract void SetArmorSetFlag(ArmorSetCondition armorSetCondition);
+
         internal override void Load(StatePersister reader)
         {
             reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Body/InactiveBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/InactiveBody.cs
@@ -22,6 +22,8 @@ namespace OpenSage.Logic.Object
             internal set { }
         }
 
+        public override void SetArmorSetFlag(ArmorSetCondition armorSetCondition) { }
+
         internal override void Load(StatePersister reader)
         {
             reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
@@ -30,6 +30,11 @@ namespace OpenSage.Logic.Object
 
         public virtual void SetSupplyBoxesRemaining(float boxPercentage) { }
 
+        public virtual void SetTerrainDecal(ObjectDecalType decalType)
+        {
+            // TODO(Port): Implement this for subclasses.
+        }
+
         internal abstract void Update(in TimeInterval time);
 
         internal abstract void SetWorldMatrix(in Matrix4x4 worldMatrix);

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using ImGuiNET;
 using OpenSage.Client;
 using OpenSage.Content;
@@ -13,6 +14,7 @@ using OpenSage.Graphics.ParticleSystems;
 using OpenSage.Graphics.Rendering;
 using OpenSage.Graphics.Shaders;
 using OpenSage.Mathematics;
+using OpenSage.Utilities;
 
 namespace OpenSage.Logic.Object
 {
@@ -171,59 +173,13 @@ namespace OpenSage.Logic.Object
             SetActiveAnimationState(transitionState, _context.Random);
         }
 
-        internal static T FindBestFittingConditionState<T>(List<T> conditionStates, BitArray<ModelConditionFlag> flags)
-            where T : IConditionState
+        internal static T FindBestFittingConditionState<T, TFlag>(List<T> conditionStates, BitArray<TFlag> flags)
+            where T : IConditionState<TFlag>
+            where TFlag : Enum
         {
-            // prefer exact match
-            // if not, find the first one with the most number of matching bits
-            // this may be convoluted, but the unit tests pass!
-            T bestConditionState = default;
-            var bestIntersections = 0;
-            T bestContainedConditionState = default;
-            var leastMissing = int.MaxValue;
-            var leastMissingBestIntersections = 0;
-            T defaultConditionState = default;
-
-            foreach (var conditionState in conditionStates)
-            {
-                foreach (var conditionStateFlags in conditionState.ConditionFlags)
-                {
-                    // the default condition state has no bits set
-                    if (!conditionStateFlags.AnyBitSet)
-                    {
-                        defaultConditionState = conditionState;
-                    }
-
-                    var intersections = conditionStateFlags.CountIntersectionBits(flags);
-                    // we've found a state that matches everything we have, but it may have extra things we don't have that we don't want
-                    // the order of the condition states in the ini files is not guaranteed to be ideal
-                    if (intersections == flags.NumBitsSet)
-                    {
-                        var missing = conditionStateFlags.NumBitsSet - intersections;
-                        if (missing == 0)
-                        {
-                            // if we have an exact match, great! doesn't matter what else we've found
-                            return conditionState;
-                        }
-
-                        // otherwise, this state may have extra things we don't have. Cool, but less than ideal... let's keep searching?
-                        // this ensures we don't store the first least missing as better, even if a subsequent one has better best intersections (which should be a better "score")
-                        if (missing < leastMissing || missing == leastMissing && intersections > leastMissingBestIntersections)
-                        {
-                            bestContainedConditionState = conditionState;
-                            leastMissing = missing;
-                            leastMissingBestIntersections = intersections;
-                        }
-                    } else if (intersections > bestIntersections)
-                    {
-                        // not an exact match, but save this if we can't find an exact match
-                        bestIntersections = conditionStateFlags.NumBitsSet;
-                        bestConditionState = conditionState;
-                    }
-                }
-            }
-
-            return bestContainedConditionState ?? bestConditionState ?? defaultConditionState;
+            return BitArrayMatchFinder.FindBest(
+                CollectionsMarshal.AsSpan(conditionStates),
+                flags);
         }
 
         public override void UpdateConditionState(BitArray<ModelConditionFlag> flags, Random random)

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -224,6 +224,7 @@ namespace OpenSage.Logic.Object
         private FrozenDictionary<Type, List<object>> _behaviorCache;
 
         private readonly BodyModule _body;
+        public BodyModule BodyModule => _body;
         public bool HasActiveBody() => _body is ActiveBody;
 
         public bool TryGetLastDamage(out DamageData damageData)
@@ -427,9 +428,6 @@ namespace OpenSage.Logic.Object
         public int ExperienceRequiredForNextLevel { get; set; }
 
         public int EnergyProduction { get; internal set; }
-
-        // TODO
-        public ArmorTemplateSet CurrentArmorSet => Definition.ArmorSets.Values.First();
 
         public readonly Drawable Drawable;
 

--- a/src/OpenSage.Game/Logic/Object/IConditionState.cs
+++ b/src/OpenSage.Game/Logic/Object/IConditionState.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
-    public interface IConditionState
+    public interface IConditionState<T>
+        where T : Enum
     {
-        List<BitArray<ModelConditionFlag>> ConditionFlags { get; }
+        ReadOnlySpan<BitArray<T>> ConditionFlags { get; }
     }
 }

--- a/src/OpenSage.Game/Logic/Object/ModelConditionState.cs
+++ b/src/OpenSage.Game/Logic/Object/ModelConditionState.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.Graphics;
@@ -8,7 +9,7 @@ using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object
 {
-    public class ModelConditionState : IConditionState
+    public class ModelConditionState : IConditionState<ModelConditionFlag>
     {
         internal static void Parse(IniParser parser, ModelConditionState result)
         {
@@ -73,6 +74,8 @@ namespace OpenSage.Logic.Object
         }
 
         public List<BitArray<ModelConditionFlag>> ConditionFlags { get; private set; } = new();
+
+        ReadOnlySpan<BitArray<ModelConditionFlag>> IConditionState<ModelConditionFlag>.ConditionFlags => CollectionsMarshal.AsSpan(ConditionFlags);
 
         public LazyAssetReference<Model> Model;
 

--- a/src/OpenSage.Game/Logic/Object/Update/HordeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/HordeUpdate.cs
@@ -55,14 +55,14 @@ namespace OpenSage.Logic.Object
         private void AddToHorde()
         {
             _isInHorde = true;
-            _gameObject.Drawable.ObjectDecalType = GameObjectDecalType;
+            _gameObject.Drawable.SetTerrainDecal(GameObjectDecalType);
             _gameObject.AddWeaponBonusType(_moduleData.Action);
         }
 
         private void RemoveFromHorde()
         {
             _isInHorde = false;
-            _gameObject.Drawable.ObjectDecalType = ObjectDecalType.None;
+            _gameObject.Drawable.SetTerrainDecal(ObjectDecalType.None);
             _gameObject.RemoveWeaponBonusType(_moduleData.Action);
         }
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ArmorUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ArmorUpgrade.cs
@@ -1,4 +1,5 @@
-﻿using OpenSage.Data.Ini;
+﻿using OpenSage.Client;
+using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object
 {
@@ -10,6 +11,18 @@ namespace OpenSage.Logic.Object
             : base(gameObject, moduleData)
         {
             _moduleData = moduleData;
+        }
+
+        protected override void OnUpgrade()
+        {
+            GameObject.BodyModule?.SetArmorSetFlag(ArmorSetCondition.PlayerUpgrade);
+
+            // Added in Zero Hour. Seems like quite a big hack.
+            // Unique case for AMERICA to test for upgrade to set flag
+            if (IsTriggeredBy("Upgrade_AmericaChemicalSuits"))
+            {
+                GameObject.Drawable.SetTerrainDecal(ObjectDecalType.ChemSuit);
+            }
         }
 
         internal override void Load(StatePersister reader)
@@ -36,6 +49,7 @@ namespace OpenSage.Logic.Object
                 { "IgnoreArmorUpgrade", (parser, x) => x.IgnoreArmorUpgrade = parser.ParseBoolean() }
             });
 
+        [AddedIn(SageGame.Bfme)]
         public ArmorSetCondition ArmorSetFlag { get; private set; }
 
         [AddedIn(SageGame.Bfme)]

--- a/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using ImGuiNET;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
@@ -7,9 +7,12 @@ namespace OpenSage.Logic.Object
 {
     public abstract class UpgradeModule : BehaviorModule, IUpgradeableModule
     {
+        // TODO: Make this private.
         protected readonly GameObject _gameObject;
         private readonly UpgradeModuleData _moduleData;
         private UpgradeLogic _upgradeLogic;
+
+        protected GameObject GameObject => _gameObject;
 
         internal bool Triggered => _upgradeLogic.Triggered;
 
@@ -19,6 +22,8 @@ namespace OpenSage.Logic.Object
             _moduleData = moduleData;
             _upgradeLogic = new UpgradeLogic(moduleData.UpgradeData, OnUpgrade);
         }
+
+        public bool IsTriggeredBy(string upgradeName) => _upgradeLogic.IsTriggeredBy(upgradeName);
 
         public bool CanUpgrade(UpgradeSet existingUpgrades) => _upgradeLogic.CanUpgrade(existingUpgrades);
 
@@ -70,6 +75,19 @@ namespace OpenSage.Logic.Object
                 triggerUpgradeCallback();
                 _triggered = true;
             }
+        }
+
+        public bool IsTriggeredBy(string upgradeName)
+        {
+            foreach (var upgradeTemplate in _data.TriggeredByHashSet)
+            {
+                if (upgradeTemplate.Name == upgradeName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public void TryUpgrade(UpgradeSet completedUpgrades)

--- a/src/OpenSage.Game/Utilities/BitArrayMatchFinder.cs
+++ b/src/OpenSage.Game/Utilities/BitArrayMatchFinder.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using OpenSage.Logic.Object;
+using OpenSage.Mathematics;
+
+namespace OpenSage.Utilities;
+
+// TODO(Port): Check if the logic here matches SparseMatchFinder.h.
+
+internal static class BitArrayMatchFinder
+{
+    public static T FindBest<T, TFlag>(Span<T> set, BitArray<TFlag> flags)
+        where T : IConditionState<TFlag>
+        where TFlag : Enum
+    {
+        // prefer exact match
+        // if not, find the first one with the most number of matching bits
+        // this may be convoluted, but the unit tests pass!
+        T best = default;
+        var bestIntersections = 0;
+        T bestContained = default;
+        var leastMissing = int.MaxValue;
+        var leastMissingBestIntersections = 0;
+        T defaultItem = default;
+
+        foreach (var item in set)
+        {
+            foreach (var flagSet in item.ConditionFlags)
+            {
+                // the default condition state has no bits set
+                if (!flagSet.AnyBitSet)
+                {
+                    defaultItem = item;
+                }
+
+                var intersections = flagSet.CountIntersectionBits(flags);
+                // we've found a state that matches everything we have, but it may have extra things we don't have that we don't want
+                // the order of the condition states in the ini files is not guaranteed to be ideal
+                if (intersections == flags.NumBitsSet)
+                {
+                    var missing = flagSet.NumBitsSet - intersections;
+                    if (missing == 0)
+                    {
+                        // if we have an exact match, great! doesn't matter what else we've found
+                        return item;
+                    }
+
+                    // otherwise, this state may have extra things we don't have. Cool, but less than ideal... let's keep searching?
+                    // this ensures we don't store the first least missing as better, even if a subsequent one has better best intersections (which should be a better "score")
+                    if (missing < leastMissing || missing == leastMissing && intersections > leastMissingBestIntersections)
+                    {
+                        bestContained = item;
+                        leastMissing = missing;
+                        leastMissingBestIntersections = intersections;
+                    }
+                }
+                else if (intersections > bestIntersections)
+                {
+                    // not an exact match, but save this if we can't find an exact match
+                    bestIntersections = flagSet.NumBitsSet;
+                    best = item;
+                }
+            }
+        }
+
+        return bestContained ?? best ?? defaultItem;
+    }
+}


### PR DESCRIPTION
Resolves #1247.

* Extract `BitArrayMatchFinder` out of `W3dModelDraw` - this is used for armor sets as well as model condition states
* Store current armor in `ActiveBody`, not `GameObject`
* Add some upgrade and terrain decal stuff that got dragged in, even though that part of `ArmorUpgrade` seems like a huge hack (hopefully we can improve that later on)