### PR TITLE
Fixed nullability warnings.

### DIFF
--- a/src/OpenSage.Game/Logic/AI/AIStates/ChinookAIUpdate/ChinookCombatDropState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/ChinookAIUpdate/ChinookCombatDropState.cs
@@ -36,11 +36,13 @@ internal sealed class ChinookCombatDropState : State
     {
         reader.PersistVersion(2);
 
-        reader.PersistListWithUInt32Count(_ropes, (StatePersister persister, ref Rope? item) =>
+        #nullable disable // The callback is in a project with no nullability, but the Rope object is nullable.
+        reader.PersistListWithUInt32Count(_ropes, (StatePersister persister, ref Rope item) =>
         {
             item ??= new Rope();
             persister.PersistObjectValue(item);
         });
+        #nullable enable
     }
 
     private sealed class Rope : IPersistableObject

--- a/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using System.Diagnostics;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
 
@@ -20,6 +21,7 @@ namespace OpenSage.Logic.Object
 
         private protected override void Die(BehaviorUpdateContext context, DeathType deathType)
         {
+            Debug.Assert(_moduleData.CrateData is not null);
             var crateData = _moduleData.CrateData.Value;
 
             if (_gameObject.TryGetLastDamage(out var lastDamageData))
@@ -96,7 +98,7 @@ namespace OpenSage.Logic.Object
                 { "CrateData", (parser, x) => x.CrateData = parser.ParseCrateReference() }
             });
 
-        public LazyAssetReference<CrateData> CrateData { get; private set; }
+        public LazyAssetReference<CrateData>? CrateData { get; private set; }
 
         internal override CreateCrateDie CreateModule(GameObject gameObject, GameContext context)
         {

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 using ImGuiNET;
@@ -379,6 +380,8 @@ namespace OpenSage.Logic.Object
                     parkingPlace.ReportSpawn(producedUnit.ID);
                     producedUnit.AIUpdate.SetLocomotor(LocomotorSetType.Taxiing);
                     var jetAIUpdate = producedUnit.AIUpdate as JetAIUpdate;
+                    Debug.Assert(jetAIUpdate is not null); // Could also do an unsafe cast?
+                                                           // The effect of debug check is less destructive in release builds.
                     jetAIUpdate.Base = _gameObject;
                     jetAIUpdate.CurrentJetAIState = JetAIUpdate.JetAIState.Parked;
                 }
@@ -396,6 +399,8 @@ namespace OpenSage.Logic.Object
             if (ProductionExit is ParkingPlaceBehaviour && !ProducedAtHelipad(producedUnit.Definition))
             {
                 var jetAIUpdate = producedUnit.AIUpdate as JetAIUpdate;
+                Debug.Assert(jetAIUpdate is not null); // Could also do an unsafe cast?
+                                                       // The effect of debug check is less destructive in release builds.
                 jetAIUpdate.CurrentJetAIState = JetAIUpdate.JetAIState.JustCreated;
                 return;
             }

--- a/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
+++ b/src/OpenSage.Game/Logic/Orders/OrderProcessor.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 using OpenSage.Logic.Object;
@@ -127,6 +128,7 @@ namespace OpenSage.Logic.Orders
                             var buildTarget = _game.Scene3D.GameObjects.GetObjectById(buildTargetId);
 
                             var dozer = player.SelectedUnits.SingleOrDefault(u => u.IsKindOf(ObjectKinds.Dozer));
+                            Debug.Assert(buildTarget is not null);
                             (dozer?.AIUpdate as IBuilderAIUpdate)?.SetBuildTarget(buildTarget); // todo: I don't love this cast; it would be nice to get rid of it
 
                             _game.Audio.PlayAudioEvent(dozer, dozer?.Definition.UnitSpecificSounds?.VoiceBuildResponse?.Value);
@@ -140,7 +142,7 @@ namespace OpenSage.Logic.Orders
                             var gameObject = _game.Scene3D.GameObjects.GetObjectById((uint) objectDefinitionId);
                             var upgradeDefinition = _game.AssetStore.Upgrades.GetByInternalId(upgradeDefinitionId);
                             player.BankAccount.Withdraw((uint) upgradeDefinition.BuildCost);
-
+                            Debug.Assert(gameObject is not null);
                             gameObject.ProductionUpdate.QueueUpgrade(upgradeDefinition);
                         }
                         break;
@@ -225,6 +227,7 @@ namespace OpenSage.Logic.Orders
                             var repairTargetId = order.Arguments[0].Value.ObjectId;
                             var repairTarget =  _game.Scene3D.GameObjects.GetObjectById(repairTargetId);
 
+                            Debug.Assert(repairTarget is not null);
                             (repairer?.AIUpdate as IBuilderAIUpdate)?.SetRepairTarget(repairTarget);
 
                             _game.Audio.PlayAudioEvent(repairer, repairer?.Definition.UnitSpecificSounds?.VoiceRepair?.Value);
@@ -304,6 +307,7 @@ namespace OpenSage.Logic.Orders
                                 var obj = _game.Scene3D.GameObjects.GetObjectById(objId);
 
                                 var rallyPoint = order.Arguments[1].Value.Position;
+                                Debug.Assert(obj is not null);
                                 obj.RallyPoint = rallyPoint;
                             }
                             else
@@ -397,6 +401,7 @@ namespace OpenSage.Logic.Orders
                             var objectDefinitionId = order.Arguments[1].Value.Integer;
                             var gameObject = _game.Scene3D.GameObjects.GetObjectById((uint) objectDefinitionId);
 
+                            Debug.Assert(gameObject is not null);
                             var container = gameObject.FindBehavior<OpenContainModule>();
                             foreach (var unit in player.SelectedUnits)
                             {
@@ -427,7 +432,7 @@ namespace OpenSage.Logic.Orders
                                 continue;
                             }
 
-                            if (supplyPoint.IsKindOf(ObjectKinds.SupplySource))
+                            if (supplyPoint is not null && supplyPoint.IsKindOf(ObjectKinds.SupplySource))
                             {
                                 behavior.CurrentSupplySource = supplyPoint;
                                 behavior.SupplyGatherState = SupplyAIUpdate.SupplyGatherStates.SearchingForSupplySource;

--- a/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using OpenSage.Content;
 using OpenSage.Content.Translation;
@@ -461,6 +462,7 @@ namespace OpenSage.Mods.Generals.Gui
                                 {
                                     var unitId = container.ContainedObjectIds[exitCommandCount++];
                                     var unit = controlBar.Game.Scene3D.GameObjects.GetObjectById(unitId);
+                                    Debug.Assert(unit is not null);
                                     slotsUsed += container.SlotValueForUnit(unit);
                                     buttonControl.BackgroundImage = controlBar._window.ImageLoader.CreateFromMappedImageReference(unit.Definition.ButtonImage);
                                     buttonControl.OverlayImage = RankOverlaySmall(controlBar, unit.Rank);


### PR DESCRIPTION
Introduce Debug.Assert statements to ensure critical objects are not null before proceeding with operations.

These checks improve code safety and debugging, while minimizing the impact on release builds.

The aim of this merge request is **not** to improve or add, but to ensure code maintainability as the project moves forwards with its larger goals.