### PR TITLE
Move SidesList, BuildListInfo and PolygonTrigger to OpenSage.Logic.Map

### DIFF
--- a/src/OpenSage.Game/Data/Map/BuildList.cs
+++ b/src/OpenSage.Game/Data/Map/BuildList.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using OpenSage.FileFormats;
+using OpenSage.Logic.Map;
 
 namespace OpenSage.Data.Map;
 

--- a/src/OpenSage.Game/Data/Map/MapFile.cs
+++ b/src/OpenSage.Game/Data/Map/MapFile.cs
@@ -8,6 +8,7 @@ using OpenSage.Data.Utilities.Extensions;
 using OpenSage.FileFormats;
 using OpenSage.FileFormats.RefPack;
 using OpenSage.IO;
+using OpenSage.Logic.Map;
 using OpenSage.Scripting;
 
 namespace OpenSage.Data.Map;

--- a/src/OpenSage.Game/Data/Map/Player.cs
+++ b/src/OpenSage.Game/Data/Map/Player.cs
@@ -2,6 +2,7 @@
 
 using System.Diagnostics;
 using System.IO;
+using OpenSage.Logic.Map;
 using OpenSage.Scripting;
 
 namespace OpenSage.Data.Map;

--- a/src/OpenSage.Game/Data/Map/PolygonTriggers.cs
+++ b/src/OpenSage.Game/Data/Map/PolygonTriggers.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using OpenSage.Logic.Map;
 
 namespace OpenSage.Data.Map;
 

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -26,6 +26,7 @@ using OpenSage.Input;
 using OpenSage.Input.Cursors;
 using OpenSage.IO;
 using OpenSage.Logic;
+using OpenSage.Logic.Map;
 using OpenSage.Mathematics;
 using OpenSage.Network;
 using OpenSage.Rendering;

--- a/src/OpenSage.Game/Logic/AI/AIData.cs
+++ b/src/OpenSage.Game/Logic/AI/AIData.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using OpenSage.Data.Ini;
-using OpenSage.Data.Map;
+using OpenSage.Logic.Map;
 
 namespace OpenSage.Logic.AI;
 

--- a/src/OpenSage.Game/Logic/GameLogic.cs
+++ b/src/OpenSage.Game/Logic/GameLogic.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using OpenSage.Content;
-using OpenSage.Data.Map;
+using OpenSage.Logic.Map;
 using OpenSage.Logic.Object;
 
 namespace OpenSage.Logic;

--- a/src/OpenSage.Game/Logic/Map/BuildListInfo.cs
+++ b/src/OpenSage.Game/Logic/Map/BuildListInfo.cs
@@ -4,11 +4,8 @@ using System.Numerics;
 using OpenSage.Data.Ini;
 using OpenSage.FileFormats;
 
-namespace OpenSage.Data.Map;
+namespace OpenSage.Logic.Map;
 
-// TODO: Does this belong under Data.Map anymore?
-// This exists in all three: map data, INI and persisted gameplay data.
-// In Generals it's under /GameLogic/Map/SidesList.cpp/h
 public sealed class BuildListInfo : IPersistableObject
 {
     public const uint MaxResourceGatherers = 10;

--- a/src/OpenSage.Game/Logic/Map/PolygonTrigger.cs
+++ b/src/OpenSage.Game/Logic/Map/PolygonTrigger.cs
@@ -6,10 +6,8 @@ using System.Numerics;
 using NLog;
 using OpenSage.FileFormats;
 using OpenSage.Mathematics;
-using OpenSage.Terrain;
-using Vulkan;
 
-namespace OpenSage.Data.Map;
+namespace OpenSage.Logic.Map;
 
 public sealed class PolygonTrigger : IPersistableObject
 {
@@ -303,7 +301,7 @@ public sealed class PolygonTrigger : IPersistableObject
             var dy = pt2.Y - pt1.Y;
             var dx = pt2.X - pt1.X;
 
-            var intersectionX = pt1.X + (dx * (point.Y - pt1.Y) / (float)dy);
+            var intersectionX = pt1.X + dx * (point.Y - pt1.Y) / (float)dy;
             if (intersectionX >= point.X)
             {
                 inside = !inside;

--- a/src/OpenSage.Game/Logic/Map/SidesList.cs
+++ b/src/OpenSage.Game/Logic/Map/SidesList.cs
@@ -5,11 +5,15 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenSage.Content.Translation;
+using OpenSage.Data.Map;
 using OpenSage.Data.Scb;
 using OpenSage.FileFormats;
 using OpenSage.Scripting;
 
-namespace OpenSage.Data.Map;
+namespace OpenSage.Logic.Map;
+
+using Player = Data.Map.Player;
+using Team = Data.Map.Team;
 
 public sealed class SidesList : Asset, IPersistableObject
 {

--- a/src/OpenSage.Game/Logic/Map/SidesListUtility.cs
+++ b/src/OpenSage.Game/Logic/Map/SidesListUtility.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenSage.Data.Map;
 using OpenSage.Data.Scb;
-using OpenSage.Logic;
 using OpenSage.Scripting;
 
-namespace OpenSage.Data.Map;
+namespace OpenSage.Logic.Map;
+
+using Player = Data.Map.Player;
+using Team = Data.Map.Team;
 
 internal static class SidesListUtility
 {

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -18,6 +18,7 @@ using OpenSage.Graphics.Rendering;
 using OpenSage.Graphics.Shaders;
 using OpenSage.Gui.ControlBar;
 using OpenSage.Gui.InGame;
+using OpenSage.Logic.Map;
 using OpenSage.Logic.Object.Damage;
 using OpenSage.Logic.Object.Helpers;
 using OpenSage.Mathematics;

--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -3,8 +3,8 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using OpenSage.Content.Translation;
-using OpenSage.Data.Map;
 using OpenSage.Logic.AI;
+using OpenSage.Logic.Map;
 using OpenSage.Logic.Object;
 using OpenSage.Mathematics;
 

--- a/src/OpenSage.Game/Terrain/WaterArea.cs
+++ b/src/OpenSage.Game/Terrain/WaterArea.cs
@@ -4,6 +4,7 @@ using OpenSage.Content.Loaders;
 using OpenSage.Data.Map;
 using OpenSage.Graphics.Rendering;
 using OpenSage.Graphics.Shaders;
+using OpenSage.Logic.Map;
 using OpenSage.Mathematics;
 using OpenSage.Rendering;
 using OpenSage.Utilities;


### PR DESCRIPTION
Move these to `OpenSage.Logic.Map` to match the structure of the C++ code more closely (as mentioned in #1295).