### PR TITLE
Adjust Behavior constructors to use common pattern

### DIFF
--- a/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
+++ b/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
@@ -11,9 +11,6 @@ public abstract class ObjectModule : ModuleBase
 
     protected GameContext Context { get; }
 
-    // TODO: Remove this once all subclasses use the other constructor.
-    protected ObjectModule() { }
-
     protected ObjectModule(GameObject gameObject, GameContext context)
     {
         GameObject = gameObject;
@@ -32,9 +29,6 @@ public abstract class ObjectModule : ModuleBase
 
 public abstract class BehaviorModule : ObjectModule
 {
-    // TODO: Remove this once all subclasses use the other constructor.
-    protected BehaviorModule() { }
-
     protected BehaviorModule(GameObject gameObject, GameContext context)
         : base(gameObject, context)
     {

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BezierProjectileBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BezierProjectileBehavior.cs
@@ -8,7 +8,6 @@ namespace OpenSage.Logic.Object;
 
 public class BezierProjectileBehavior : UpdateModule
 {
-    private readonly GameObject _gameObject;
     private readonly BezierProjectileBehaviorData _moduleData;
 
     private uint _launcherObjectId;
@@ -20,16 +19,16 @@ public class BezierProjectileBehavior : UpdateModule
 
     internal FXList DetonationFX { get; set; }
 
-    internal BezierProjectileBehavior(GameObject gameObject, BezierProjectileBehaviorData moduleData)
+    internal BezierProjectileBehavior(GameObject gameObject, GameContext context, BezierProjectileBehaviorData moduleData)
+        : base(gameObject, context)
     {
-        _gameObject = gameObject;
         _moduleData = moduleData;
     }
 
     internal override void Update(BehaviorUpdateContext context)
     {
         // TODO: Bezier implementation.
-        if (!_gameObject.IsProjectile)
+        if (!GameObject.IsProjectile)
         {
             return;
         }
@@ -37,7 +36,7 @@ public class BezierProjectileBehavior : UpdateModule
         var direction = Vector3.TransformNormal(Vector3.UnitX, context.GameObject.TransformMatrix);
         var velocity = direction * context.GameObject.Speed;
 
-        _gameObject.SetTranslation(_gameObject.Translation + velocity * ((float)Game.LogicUpdateInterval / 1000.0f));
+        GameObject.SetTranslation(GameObject.Translation + velocity * ((float)Game.LogicUpdateInterval / 1000.0f));
 
         CheckForHit(
             context,
@@ -211,6 +210,6 @@ public class BezierProjectileBehaviorData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new BezierProjectileBehavior(gameObject, this);
+        return new BezierProjectileBehavior(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BridgeBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BridgeBehavior.cs
@@ -7,6 +7,10 @@ public sealed class BridgeBehavior : UpdateModule
 {
     private readonly uint[] _towerIds = new uint[4];
 
+    public BridgeBehavior(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -27,7 +31,7 @@ public sealed class BridgeBehavior : UpdateModule
 }
 
 /// <summary>
-/// Special-case logic allows for ParentObject to be specified as a bone name to allow other 
+/// Special-case logic allows for ParentObject to be specified as a bone name to allow other
 /// objects to appear on the bridge.
 /// </summary>
 public sealed class BridgeBehaviorModuleData : BehaviorModuleData
@@ -51,7 +55,7 @@ public sealed class BridgeBehaviorModuleData : BehaviorModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new BridgeBehavior();
+        return new BridgeBehavior(gameObject, context);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BridgeTowerBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BridgeTowerBehavior.cs
@@ -7,6 +7,10 @@ public sealed class BridgeTowerBehavior : BehaviorModule
     private int _unknown1;
     private int _unknown2;
 
+    public BridgeTowerBehavior(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -31,6 +35,6 @@ public sealed class BridgeTowerBehaviorModuleData : BehaviorModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new BridgeTowerBehavior();
+        return new BridgeTowerBehavior(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BuildingBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BuildingBehavior.cs
@@ -7,19 +7,15 @@ namespace OpenSage.Logic.Object;
 public class BuildingBehavior : UpdateModule
 {
     private readonly BuildingBehaviorModuleData _moduleData;
-    private readonly GameObject _gameObject;
-    private readonly GameContext _gameContext;
-
     private bool _initial;
     private bool _isNight;
     private bool _fire;
     private bool _isGlowing;
 
-    internal BuildingBehavior(BuildingBehaviorModuleData moduleData, GameObject gameObject, GameContext context)
+    internal BuildingBehavior(GameObject gameObject, GameContext context, BuildingBehaviorModuleData moduleData)
+        : base(gameObject, context)
     {
         _moduleData = moduleData;
-        _gameObject = gameObject;
-        _gameContext = context;
 
         _initial = true;
         _isNight = false;
@@ -39,11 +35,11 @@ public class BuildingBehavior : UpdateModule
             var nightWindow = _moduleData.NightWindowName;
             if (night)
             {
-                _gameObject.Drawable.ShowSubObject(nightWindow);
+                GameObject.Drawable.ShowSubObject(nightWindow);
             }
             else
             {
-                _gameObject.Drawable.HideSubObject(nightWindow);
+                GameObject.Drawable.HideSubObject(nightWindow);
             }
 
             _isNight = night;
@@ -54,19 +50,19 @@ public class BuildingBehavior : UpdateModule
             var fireWindow = _moduleData.FireWindowName;
             if (fire)
             {
-                _gameObject.Drawable.ShowSubObject(fireWindow);
+                GameObject.Drawable.ShowSubObject(fireWindow);
                 foreach (var fireName in _moduleData.FireNames)
                 {
-                    _gameObject.Drawable.ShowSubObject(fireName);
+                    GameObject.Drawable.ShowSubObject(fireName);
                 }
             }
             else
             {
-                _gameObject.Drawable.HideSubObject(fireWindow);
+                GameObject.Drawable.HideSubObject(fireWindow);
 
                 foreach (var fireName in _moduleData.FireNames)
                 {
-                    _gameObject.Drawable.HideSubObject(fireName);
+                    GameObject.Drawable.HideSubObject(fireName);
                 }
             }
 
@@ -78,11 +74,11 @@ public class BuildingBehavior : UpdateModule
             var glowWindow = _moduleData.GlowWindowName;
             if (glowing)
             {
-                _gameObject.Drawable.ShowSubObject(glowWindow);
+                GameObject.Drawable.ShowSubObject(glowWindow);
             }
             else
             {
-                _gameObject.Drawable.HideSubObject(glowWindow);
+                GameObject.Drawable.HideSubObject(glowWindow);
             }
 
             _isGlowing = glowing;
@@ -115,6 +111,6 @@ public sealed class BuildingBehaviorModuleData : BehaviorModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new BuildingBehavior(this, gameObject, context);
+        return new BuildingBehavior(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDamagedBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDamagedBehavior.cs
@@ -15,8 +15,6 @@ public sealed class FireWeaponWhenDamagedBehavior : UpdateModule, IUpgradeableMo
         Debug.Assert(Enum.GetValues<BodyDamageType>().Length == 4, "Expected 4 values in BodyDamageType enum.");
     }
 
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
     private readonly FireWeaponWhenDamagedBehaviorModuleData _moduleData;
 
     private readonly Weapon?[] _reactionWeapons = new Weapon?[4];
@@ -28,9 +26,8 @@ public sealed class FireWeaponWhenDamagedBehavior : UpdateModule, IUpgradeableMo
     internal UpgradeLogic UpgradeLogic { get; }
 
     public FireWeaponWhenDamagedBehavior(GameObject gameObject, GameContext context, FireWeaponWhenDamagedBehaviorModuleData moduleData)
+        : base(gameObject, context)
     {
-        _gameObject = gameObject;
-        _context = context;
         _moduleData = moduleData;
 
         UpgradeLogic = new UpgradeLogic(moduleData.UpgradeData, OnUpgrade);
@@ -56,10 +53,10 @@ public sealed class FireWeaponWhenDamagedBehavior : UpdateModule, IUpgradeableMo
         }
 
         return new Weapon(
-            _gameObject,
+            GameObject,
             weaponTemplate,
             WeaponSlot.Primary,
-            _context);
+            Context);
     }
 
     public bool CanUpgrade(UpgradeSet existingUpgrades) => UpgradeLogic.CanUpgrade(existingUpgrades);
@@ -100,14 +97,14 @@ public sealed class FireWeaponWhenDamagedBehavior : UpdateModule, IUpgradeableMo
 
     private void FireWeaponIfPresentAndReady(Weapon?[] weapons)
     {
-        var weapon = weapons[(int)_gameObject.BodyDamageType];
+        var weapon = weapons[(int)GameObject.BodyDamageType];
 
         if (weapon == null || !weapon.IsInactive)
         {
             return;
         }
 
-        weapon.SetTarget(new WeaponTarget(_gameObject.Translation));
+        weapon.SetTarget(new WeaponTarget(GameObject.Translation));
         weapon.Fire();
     }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDeadBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDeadBehavior.cs
@@ -9,16 +9,13 @@ namespace OpenSage.Logic.Object;
 
 public sealed class FireWeaponWhenDeadBehavior : BehaviorModule, IUpgradeableModule
 {
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
     private readonly FireWeaponWhenDeadBehaviorModuleData _moduleData;
 
     internal UpgradeLogic UpgradeLogic { get; }
 
     internal FireWeaponWhenDeadBehavior(GameObject gameObject, GameContext context, FireWeaponWhenDeadBehaviorModuleData moduleData)
+        : base(gameObject, context)
     {
-        _gameObject = gameObject;
-        _context = context;
         _moduleData = moduleData;
         UpgradeLogic = new UpgradeLogic(moduleData.UpgradeData, OnUpgrade);
     }
@@ -48,12 +45,12 @@ public sealed class FireWeaponWhenDeadBehavior : BehaviorModule, IUpgradeableMod
         if (deathWeaponTemplate != null)
         {
             var deathWeapon = new Weapon(
-                _gameObject,
+                GameObject,
                 deathWeaponTemplate,
                 WeaponSlot.Primary,
-                _context);
+                Context);
 
-            deathWeapon.SetTarget(new WeaponTarget(_gameObject.Translation));
+            deathWeapon.SetTarget(new WeaponTarget(GameObject.Translation));
             deathWeapon.Fire();
         }
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/GateOpenAndCloseBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/GateOpenAndCloseBehavior.cs
@@ -10,7 +10,6 @@ namespace OpenSage.Logic.Object;
 [AddedIn(SageGame.Bfme)]
 public class GateOpenAndCloseBehavior : UpdateModule
 {
-    private GameObject _gameObject;
     private GateOpenAndCloseBehaviorModuleData _moduleData;
     private bool _open;
     private bool _playedFinishedSound = false;
@@ -27,10 +26,10 @@ public class GateOpenAndCloseBehavior : UpdateModule
     private AudioSource _openingSoundLoop;
     private AudioSource _closingSoundLoop;
 
-    internal GateOpenAndCloseBehavior(GameObject gameObject, GateOpenAndCloseBehaviorModuleData moduleData)
+    internal GateOpenAndCloseBehavior(GameObject gameObject, GameContext context, GateOpenAndCloseBehaviorModuleData moduleData)
+        : base(gameObject, context)
     {
         _moduleData = moduleData;
-        _gameObject = gameObject;
 
         _open = false; // _moduleData.OpenByDefault;
         _state = DoorState.Idle;
@@ -65,12 +64,12 @@ public class GateOpenAndCloseBehavior : UpdateModule
 
             case DoorState.StartOpening:
                 audioSystem.DisposeSource(_closingSoundLoop);
-                _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Door1Closing, false);
-                _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Door1Opening, true);
+                GameObject.ModelConditionFlags.Set(ModelConditionFlag.Door1Closing, false);
+                GameObject.ModelConditionFlags.Set(ModelConditionFlag.Door1Opening, true);
                 _toggleFinishedTime = context.LogicFrame + _moduleData.ResetTime;
                 _pathingToggleTime = context.LogicFrame + (_moduleData.ResetTime * _moduleData.PercentOpenForPathing);
 
-                _openingSoundLoop = audioSystem.PlayAudioEvent(_gameObject, _moduleData.SoundOpeningGateLoop?.Value, true);
+                _openingSoundLoop = audioSystem.PlayAudioEvent(GameObject, _moduleData.SoundOpeningGateLoop?.Value, true);
                 _finishedSoundTime = context.LogicFrame + _moduleData.TimeBeforePlayingOpenSound;
 
                 _state = DoorState.Opening;
@@ -81,17 +80,17 @@ public class GateOpenAndCloseBehavior : UpdateModule
             case DoorState.Opening:
                 if (!_toggledColliders && context.LogicFrame >= _pathingToggleTime)
                 {
-                    _gameObject.HideCollider(_closedGeometry);
+                    GameObject.HideCollider(_closedGeometry);
                     foreach (var openCollider in _openGeometries)
                     {
-                        _gameObject.ShowCollider(openCollider);
+                        GameObject.ShowCollider(openCollider);
                     }
                     _toggledColliders = true;
                 }
                 if (!_playedFinishedSound && context.LogicFrame >= _finishedSoundTime)
                 {
                     audioSystem.DisposeSource(_openingSoundLoop);
-                    audioSystem.PlayAudioEvent(_gameObject, _moduleData.SoundFinishedOpeningGate?.Value);
+                    audioSystem.PlayAudioEvent(GameObject, _moduleData.SoundFinishedOpeningGate?.Value);
                     _playedFinishedSound = true;
                 }
                 if (context.LogicFrame >= _toggleFinishedTime)
@@ -103,12 +102,12 @@ public class GateOpenAndCloseBehavior : UpdateModule
 
             case DoorState.StartClosing:
                 audioSystem.DisposeSource(_openingSoundLoop);
-                _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Door1Opening, false);
-                _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Door1Closing, true);
+                GameObject.ModelConditionFlags.Set(ModelConditionFlag.Door1Opening, false);
+                GameObject.ModelConditionFlags.Set(ModelConditionFlag.Door1Closing, true);
                 _toggleFinishedTime = context.LogicFrame + _moduleData.ResetTime;
                 _pathingToggleTime = context.LogicFrame + (_moduleData.ResetTime * _moduleData.PercentOpenForPathing);
 
-                _closingSoundLoop = audioSystem.PlayAudioEvent(_gameObject, _moduleData.SoundClosingGateLoop?.Value, true);
+                _closingSoundLoop = audioSystem.PlayAudioEvent(GameObject, _moduleData.SoundClosingGateLoop?.Value, true);
                 _finishedSoundTime = context.LogicFrame + _moduleData.TimeBeforePlayingClosedSound;
 
                 _state = DoorState.Closing;
@@ -119,17 +118,17 @@ public class GateOpenAndCloseBehavior : UpdateModule
             case DoorState.Closing:
                 if (!_toggledColliders && context.LogicFrame >= _pathingToggleTime)
                 {
-                    _gameObject.ShowCollider(_closedGeometry);
+                    GameObject.ShowCollider(_closedGeometry);
                     foreach (var openCollider in _openGeometries)
                     {
-                        _gameObject.HideCollider(openCollider);
+                        GameObject.HideCollider(openCollider);
                     }
                     _toggledColliders = true;
                 }
                 if (!_playedFinishedSound && context.LogicFrame >= _finishedSoundTime)
                 {
                     audioSystem.DisposeSource(_closingSoundLoop);
-                    audioSystem.PlayAudioEvent(_gameObject, _moduleData.SoundFinishedClosingGate?.Value);
+                    audioSystem.PlayAudioEvent(GameObject, _moduleData.SoundFinishedClosingGate?.Value);
                     _playedFinishedSound = true;
                 }
                 if (context.LogicFrame >= _toggleFinishedTime)
@@ -186,6 +185,6 @@ public sealed class GateOpenAndCloseBehaviorModuleData : BehaviorModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new GateOpenAndCloseBehavior(gameObject, this);
+        return new GateOpenAndCloseBehavior(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/HelicopterSlowDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/HelicopterSlowDeathBehavior.cs
@@ -5,8 +5,8 @@ namespace OpenSage.Logic.Object;
 
 public sealed class HelicopterSlowDeathBehavior : SlowDeathBehavior
 {
-    internal HelicopterSlowDeathBehavior(HelicopterSlowDeathBehaviorModuleData moduleData)
-        : base(moduleData)
+    internal HelicopterSlowDeathBehavior(GameObject gameObject, GameContext context, HelicopterSlowDeathBehaviorModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
     }
 
@@ -91,6 +91,6 @@ public sealed class HelicopterSlowDeathBehaviorModuleData : SlowDeathBehaviorMod
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new HelicopterSlowDeathBehavior(this);
+        return new HelicopterSlowDeathBehavior(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/InstantDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/InstantDeathBehavior.cs
@@ -7,20 +7,17 @@ namespace OpenSage.Logic.Object;
 
 public sealed class InstantDeathBehavior : DieModule
 {
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
     private readonly InstantDeathBehaviorModuleData _moduleData;
 
-    internal InstantDeathBehavior(GameObject gameObject, GameContext context, InstantDeathBehaviorModuleData moduleData) : base(moduleData)
+    internal InstantDeathBehavior(GameObject gameObject, GameContext context, InstantDeathBehaviorModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
-        _gameObject = gameObject;
-        _context = context;
         _moduleData = moduleData;
     }
 
     private protected override void Die(BehaviorUpdateContext context, DeathType deathType)
     {
-        _context.GameLogic.DestroyObject(_gameObject);
+        Context.GameLogic.DestroyObject(GameObject);
 
         Matrix4x4.Decompose(context.GameObject.TransformMatrix, out _, out var rotation, out var translation);
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/MinefieldBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/MinefieldBehavior.cs
@@ -8,6 +8,10 @@ public sealed class MinefieldBehavior : UpdateModule
     private uint _numVirtualMachines;
     private uint _unknownFrame;
 
+    public MinefieldBehavior(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -40,7 +44,7 @@ public sealed class MinefieldBehavior : UpdateModule
 }
 
 /// <summary>
-/// INI file comments indicate that this is not an accurate name; it's a really a 
+/// INI file comments indicate that this is not an accurate name; it's a really a
 /// single mine behaviour.
 /// </summary>
 public sealed class MinefieldBehaviorModuleData : BehaviorModuleData
@@ -70,7 +74,7 @@ public sealed class MinefieldBehaviorModuleData : BehaviorModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new MinefieldBehavior();
+        return new MinefieldBehavior(gameObject, context);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/ParkingPlaceBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/ParkingPlaceBehavior.cs
@@ -17,8 +17,6 @@ public sealed class ParkingPlaceBehaviour : UpdateModule, IHasRallyPoint, IProdu
     internal IReadOnlyList<ParkingPlaceHealingData> HealingData => _healingData;
     internal LogicFrame NextHealFrame => _nextHealFrame;
 
-    private readonly GameObject _gameObject;
-    private readonly GameContext _gameContext;
     private readonly ParkingPlaceBehaviorModuleData _moduleData;
 
     private readonly ParkingSlot[] _parkingSlots;
@@ -31,9 +29,8 @@ public sealed class ParkingPlaceBehaviour : UpdateModule, IHasRallyPoint, IProdu
     private static readonly LogicFrameSpan HealUpdateRate = new((uint)(Game.LogicFramesPerSecond / HealsPerSecond));
 
     internal ParkingPlaceBehaviour(GameObject gameObject, GameContext context, ParkingPlaceBehaviorModuleData moduleData)
+        : base(gameObject, context)
     {
-        _gameObject = gameObject;
-        _gameContext = context;
         _moduleData = moduleData;
 
         _parkingSlots = new ParkingSlot[_moduleData.NumRows * _moduleData.NumCols];
@@ -92,8 +89,8 @@ public sealed class ParkingPlaceBehaviour : UpdateModule, IHasRallyPoint, IProdu
                 _nextHealFrame += HealUpdateRate;
                 foreach (var objectToHeal in _healingData)
                 {
-                    var gameObject = _gameContext.GameLogic.GetObjectById(objectToHeal.ObjectId);
-                    gameObject?.Heal(_healAmountPerHealTick, _gameObject);
+                    var gameObject = Context.GameLogic.GetObjectById(objectToHeal.ObjectId);
+                    gameObject?.Heal(_healAmountPerHealTick, GameObject);
                 }
             }
         }
@@ -527,7 +524,7 @@ public sealed class ParkingPlaceBehaviour : UpdateModule, IHasRallyPoint, IProdu
 
     private Transform GetBoneTransform(string name)
     {
-        var (_, bone) = _gameObject.Drawable.FindBone(name);
+        var (_, bone) = GameObject.Drawable.FindBone(name);
         if (bone == null)
         {
             throw new InvalidOperationException("Could not find runway start point bone");

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PassiveAreaEffectBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PassiveAreaEffectBehavior.cs
@@ -9,14 +9,13 @@ namespace OpenSage.Logic.Object;
 [AddedIn(SageGame.Bfme)]
 public class PassiveAreaEffectBehavior : UpdateModule
 {
-    private readonly GameObject _gameObject;
     private readonly PassiveAreaEffectBehaviorModuleData _moduleData;
     private LogicFrame _nextPing;
 
-    public PassiveAreaEffectBehavior(GameObject gameObject, PassiveAreaEffectBehaviorModuleData moduleData)
+    public PassiveAreaEffectBehavior(GameObject gameObject, GameContext context, PassiveAreaEffectBehaviorModuleData moduleData)
+        : base(gameObject, context)
     {
         _moduleData = moduleData;
-        _gameObject = gameObject;
     }
 
     internal override void Update(BehaviorUpdateContext context)
@@ -28,8 +27,8 @@ public class PassiveAreaEffectBehavior : UpdateModule
         _nextPing = context.LogicFrame + _moduleData.PingDelay;
 
         var nearbyObjects = context.GameContext.Game.PartitionCellManager.QueryObjects(
-            _gameObject,
-            _gameObject.Translation,
+            GameObject,
+            GameObject.Translation,
             _moduleData.EffectRadius,
             new PartitionQueries.ObjectFilterQuery(_moduleData.AllowFilter));
 
@@ -83,6 +82,6 @@ public sealed class PassiveAreaEffectBehaviorModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new PassiveAreaEffectBehavior(gameObject, this);
+        return new PassiveAreaEffectBehavior(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PoisonedBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PoisonedBehavior.cs
@@ -6,6 +6,10 @@ public sealed class PoisonedBehavior : UpdateModule
 {
     private uint _unknown;
 
+    public PoisonedBehavior(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(2);
@@ -42,6 +46,6 @@ public sealed class PoisonedBehaviorModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new PoisonedBehavior();
+        return new PoisonedBehavior(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
@@ -30,7 +30,8 @@ public class SlowDeathBehavior : UpdateModule
 
     public int ProbabilityModifier => _moduleData.ProbabilityModifier;
 
-    internal SlowDeathBehavior(SlowDeathBehaviorModuleData moduleData)
+    internal SlowDeathBehavior(GameObject gameObject, GameContext context, SlowDeathBehaviorModuleData moduleData)
+        : base(gameObject, context)
     {
         _moduleData = moduleData;
     }
@@ -236,7 +237,7 @@ public class SlowDeathBehaviorModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new SlowDeathBehavior(this);
+        return new SlowDeathBehavior(gameObject, context, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/TechBuildingBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/TechBuildingBehavior.cs
@@ -4,6 +4,10 @@ namespace OpenSage.Logic.Object;
 
 public sealed class TechBuildingBehavior : UpdateModule
 {
+    public TechBuildingBehavior(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -25,6 +29,6 @@ public sealed class TechBuildingBehaviorModuleData : BehaviorModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new TechBuildingBehavior();
+        return new TechBuildingBehavior(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Body/ActiveBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/ActiveBody.cs
@@ -10,7 +10,6 @@ namespace OpenSage.Logic.Object;
 
 public class ActiveBody : BodyModule
 {
-    private readonly GameContext _context;
     private readonly ActiveBodyModuleData _moduleData;
     private readonly List<uint> _particleSystemIds = new();
 
@@ -41,9 +40,8 @@ public class ActiveBody : BodyModule
 
     public DamageData LastDamage => _lastDamage;
 
-    internal ActiveBody(GameObject gameObject, GameContext context, ActiveBodyModuleData moduleData) : base(gameObject)
+    internal ActiveBody(GameObject gameObject, GameContext context, ActiveBodyModuleData moduleData) : base(gameObject, context)
     {
-        _context = context;
         _moduleData = moduleData;
 
         MaxHealth = (Fix64)moduleData.MaxHealth;
@@ -98,14 +96,14 @@ public class ActiveBody : BodyModule
 
         SetHealth(newHealth);
 
-        var damager = _context.GameLogic.GetObjectById(damageInfo.Request.DamageDealer);
+        var damager = Context.GameLogic.GetObjectById(damageInfo.Request.DamageDealer);
         damageInfo.Request.AttackerName = damager?.Definition.Name ?? string.Empty;
 
         damageInfo.Result.DamageAfterArmorCalculation = (float)actualDamage;
         damageInfo.Result.ActualDamageApplied = _lastHealthBeforeDamage - _currentHealth;
 
         _lastDamage = damageInfo;
-        _lastDamagedAt = _context.GameLogic.CurrentFrame;
+        _lastDamagedAt = Context.GameLogic.CurrentFrame;
 
         // TODO: DamageFX
         if (_currentDamageFX != null) //e.g. AmericaJetRaptor's ArmorSet has no DamageFX (None)
@@ -118,7 +116,7 @@ public class ActiveBody : BodyModule
                 new FXListExecutionContext(
                     GameObject.Rotation,
                     GameObject.Translation,
-                    _context));
+                    Context));
         }
 
         if (Health <= Fix64.Zero)

--- a/src/OpenSage.Game/Logic/Object/Body/BodyModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/BodyModule.cs
@@ -11,11 +11,8 @@ public abstract class BodyModule : BehaviorModule
 {
     private float _armorDamageScalar;
 
-    protected GameObject GameObject { get; }
-
-    protected BodyModule(GameObject gameObject)
+    protected BodyModule(GameObject gameObject, GameContext context) : base(gameObject, context)
     {
-        GameObject = gameObject;
     }
 
     public Fix64 Health { get; internal set; }

--- a/src/OpenSage.Game/Logic/Object/Body/InactiveBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/InactiveBody.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class InactiveBody : BodyModule
 {
-    internal InactiveBody(GameObject gameObject) : base(gameObject)
+    internal InactiveBody(GameObject gameObject, GameContext context) : base(gameObject, context)
     {
     }
 
@@ -45,6 +45,6 @@ public sealed class InactiveBodyModuleData : BodyModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new InactiveBody(gameObject);
+        return new InactiveBody(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Collide/CollideModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/CollideModule.cs
@@ -4,6 +4,10 @@ namespace OpenSage.Logic.Object;
 
 public abstract class CollideModule : BehaviorModule, ICollideModule
 {
+    protected CollideModule(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     // TODO: Make this abstract.
     public virtual void OnCollide(GameObject other, in Vector3 location, in Vector3 normal) { }
 

--- a/src/OpenSage.Game/Logic/Object/Collide/ConvertToCarBombCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/ConvertToCarBombCrateCollide.cs
@@ -4,6 +4,10 @@ namespace OpenSage.Logic.Object;
 
 public sealed class ConvertToCarBombCrateCollide : CrateCollide
 {
+    public ConvertToCarBombCrateCollide(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -13,7 +17,7 @@ public sealed class ConvertToCarBombCrateCollide : CrateCollide
 }
 
 /// <summary>
-/// Triggers use of CARBOMB WeaponSet Condition of the hijacked object and turns it to a 
+/// Triggers use of CARBOMB WeaponSet Condition of the hijacked object and turns it to a
 /// suicide unit unless given with a different weapon.
 /// </summary>
 public sealed class ConvertToCarBombCrateCollideModuleData : CrateCollideModuleData
@@ -25,6 +29,6 @@ public sealed class ConvertToCarBombCrateCollideModuleData : CrateCollideModuleD
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new ConvertToCarBombCrateCollide();
+        return new ConvertToCarBombCrateCollide(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Collide/ConvertToHijackedVehicleCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/ConvertToHijackedVehicleCrateCollide.cs
@@ -4,6 +4,10 @@ namespace OpenSage.Logic.Object;
 
 public sealed class ConvertToHijackedVehicleCrateCollide : CrateCollide
 {
+    public ConvertToHijackedVehicleCrateCollide(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -27,6 +31,6 @@ public sealed class ConvertToHijackedVehicleCrateCollideModuleData : CrateCollid
 
     internal override ConvertToHijackedVehicleCrateCollide CreateModule(GameObject gameObject, GameContext context)
     {
-        return new ConvertToHijackedVehicleCrateCollide();
+        return new ConvertToHijackedVehicleCrateCollide(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Collide/CrateCollideModuleData.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/CrateCollideModuleData.cs
@@ -5,6 +5,10 @@ namespace OpenSage.Logic.Object;
 
 public abstract class CrateCollide : CollideModule
 {
+    protected CrateCollide(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Collide/FireWeaponCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/FireWeaponCollide.cs
@@ -11,7 +11,7 @@ public sealed class FireWeaponCollide : CollideModule
     private readonly Weapon _collideWeapon;
     private bool _unknown2;
 
-    internal FireWeaponCollide(GameObject gameObject, GameContext context, FireWeaponCollideModuleData moduleData)
+    internal FireWeaponCollide(GameObject gameObject, GameContext context, FireWeaponCollideModuleData moduleData) : base(gameObject, context)
     {
         _moduleData = moduleData;
 

--- a/src/OpenSage.Game/Logic/Object/Collide/MoneyCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/MoneyCrateCollide.cs
@@ -7,6 +7,10 @@ namespace OpenSage.Logic.Object;
 
 public sealed class MoneyCrateCollide : CrateCollide
 {
+    public MoneyCrateCollide(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -33,7 +37,7 @@ public sealed class MoneyCrateCollideModuleData : CrateCollideModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new MoneyCrateCollide();
+        return new MoneyCrateCollide(gameObject, context);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Collide/SalvageCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/SalvageCrateCollide.cs
@@ -5,6 +5,10 @@ namespace OpenSage.Logic.Object;
 
 public sealed class SalvageCrateCollide : CrateCollide
 {
+    public SalvageCrateCollide(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -74,6 +78,6 @@ public sealed class SalvageCrateCollideModuleData : CrateCollideModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new SalvageCrateCollide();
+        return new SalvageCrateCollide(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Collide/SquishCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/SquishCollide.cs
@@ -5,6 +5,9 @@ namespace OpenSage.Logic.Object;
 public sealed class SquishCollide : CollideModule
 {
     // TODO
+    public SquishCollide(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
 
     internal override void Load(StatePersister reader)
     {
@@ -24,6 +27,6 @@ public sealed class SquishCollideModuleData : CollideModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new SquishCollide();
+        return new SquishCollide(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Contain/GarrisonContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/GarrisonContain.cs
@@ -46,8 +46,8 @@ public sealed class GarrisonContain : OpenContainModule
             }
             else
             {
-                var owner = GameContext.Game.TeamFactory.FindTeamById(_originalTeamId)?.Template.Owner;
-                owner ??= GameContext.Game.PlayerManager.GetCivilianPlayer(); // todo: this behavior can be removed when DefaultTeam is set properly
+                var owner = Context.Game.TeamFactory.FindTeamById(_originalTeamId)?.Template.Owner;
+                owner ??= Context.Game.PlayerManager.GetCivilianPlayer(); // todo: this behavior can be removed when DefaultTeam is set properly
 
                 GameObject.Owner = owner;
             }

--- a/src/OpenSage.Game/Logic/Object/Contain/HordeContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/HordeContain.cs
@@ -9,8 +9,6 @@ namespace OpenSage.Logic.Object;
 [AddedIn(SageGame.Bfme)]
 public sealed class HordeContainBehavior : UpdateModule
 {
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
     private readonly HordeContainModuleData _moduleData;
 
     private Dictionary<int, List<HordeMemberPosition>> _formation;
@@ -20,10 +18,9 @@ public sealed class HordeContainBehavior : UpdateModule
     private int _pendingRegistrations;
 
     public HordeContainBehavior(GameObject gameObject, GameContext context, HordeContainModuleData moduleData)
+        : base(gameObject, context)
     {
         _moduleData = moduleData;
-        _gameObject = gameObject;
-        _context = context;
 
         _payload = new List<GameObject>();
         _formation = CreateFormationOffsets();
@@ -31,7 +28,7 @@ public sealed class HordeContainBehavior : UpdateModule
 
     public List<GameObject> SelectAll(bool value)
     {
-        _gameObject.IsSelected = value;
+        GameObject.IsSelected = value;
         foreach (var obj in _payload)
         {
             obj.IsSelected = value;
@@ -66,12 +63,12 @@ public sealed class HordeContainBehavior : UpdateModule
         {
             foreach (var position in rank)
             {
-                var createdObject = _context.GameLogic.CreateObject(position.Definition, _gameObject.Owner);
-                createdObject.ParentHorde = _gameObject;
+                var createdObject = Context.GameLogic.CreateObject(position.Definition, GameObject.Owner);
+                createdObject.ParentHorde = GameObject;
                 position.Object = createdObject;
                 _payload.Add(createdObject);
 
-                createdObject.UpdateTransform(_gameObject.Translation + position.Position, _gameObject.Rotation);
+                createdObject.UpdateTransform(GameObject.Translation + position.Position, GameObject.Rotation);
             }
         }
     }
@@ -125,7 +122,7 @@ public sealed class HordeContainBehavior : UpdateModule
 
     public Vector3 GetFormationOffset(GameObject obj)
     {
-        var hordeYaw = _gameObject.Yaw;
+        var hordeYaw = GameObject.Yaw;
         foreach (var rank in _formation.Values)
         {
             foreach (var position in rank)

--- a/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
@@ -16,8 +16,6 @@ public abstract class OpenContainModule : UpdateModule, IHasRallyPoint
     public RallyPointManager RallyPointManager { get; } = new();
 
     private readonly OpenContainModuleData _moduleData;
-    protected GameObject GameObject { get; }
-    private protected GameContext GameContext { get; }
 
     private readonly List<uint> _containedObjectIds = new();
     private uint _unknownFrame1;
@@ -41,11 +39,10 @@ public abstract class OpenContainModule : UpdateModule, IHasRallyPoint
     protected const string ExitBoneStartName = "ExitStart";
     protected const string ExitBoneEndName = "ExitEnd";
 
-    private protected OpenContainModule(GameObject gameObject, GameContext gameContext, OpenContainModuleData moduleData)
+    private protected OpenContainModule(GameObject gameObject, GameContext context, OpenContainModuleData moduleData)
+        : base(gameObject, context)
     {
         _moduleData = moduleData;
-        GameObject = gameObject;
-        GameContext = gameContext;
     }
 
     public bool CanAddUnit(GameObject unit)
@@ -82,7 +79,7 @@ public abstract class OpenContainModule : UpdateModule, IHasRallyPoint
         unit.AddToContainer(GameObject.ID);
         if (!initial)
         {
-            GameContext.AudioSystem.PlayAudioEvent(unit, GetEnterVoiceLine(unit.Definition.UnitSpecificSounds));
+            Context.AudioSystem.PlayAudioEvent(unit, GetEnterVoiceLine(unit.Definition.UnitSpecificSounds));
         }
     }
 
@@ -107,7 +104,7 @@ public abstract class OpenContainModule : UpdateModule, IHasRallyPoint
 
     public void Evacuate()
     {
-        GameContext.AudioSystem.PlayAudioEvent(GameObject,
+        Context.AudioSystem.PlayAudioEvent(GameObject,
             GameObject.Definition.UnitSpecificSounds.VoiceUnload?.Value);
         foreach (var id in ContainedObjectIds)
         {
@@ -179,7 +176,7 @@ public abstract class OpenContainModule : UpdateModule, IHasRallyPoint
         }
         else
         {
-            GameContext.AudioSystem.PlayAudioEvent(GameObject.Definition.SoundExit?.Value);
+            Context.AudioSystem.PlayAudioEvent(GameObject.Definition.SoundExit?.Value);
         }
 
         unit.RemoveFromContainer();
@@ -197,7 +194,7 @@ public abstract class OpenContainModule : UpdateModule, IHasRallyPoint
 
     protected GameObject GameObjectForId(uint unitId)
     {
-        return GameContext.GameLogic.GetObjectById(unitId);
+        return Context.GameLogic.GetObjectById(unitId);
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
@@ -59,7 +59,7 @@ public class TransportContain : OpenContainModule
                 // testing with a humvee, evacuating individually, the units never use the same exit path
                 // using the evac command, two pairs of rangers will share an exit path, and the 5th ranger will use a 3rd exit path
                 // todo: this doesn't seem to be strictly random, but it's unclear how this works at the moment
-                var pathToChoose = GameContext.Random.Next(1, _moduleData.NumberOfExitPaths + 1);
+                var pathToChoose = Context.Random.Next(1, _moduleData.NumberOfExitPaths + 1);
                 startBoneName = $"{startBoneName}{pathToChoose:00}";
                 endBoneName = $"{endBoneName}{pathToChoose:00}";
             }

--- a/src/OpenSage.Game/Logic/Object/Contain/TunnelContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TunnelContain.cs
@@ -7,7 +7,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class TunnelContain : OpenContainModule
 {
-    public override int TotalSlots => GameContext.Game.AssetStore.GameData.Current.MaxTunnelCapacity;
+    public override int TotalSlots => Context.Game.AssetStore.GameData.Current.MaxTunnelCapacity;
     public override IList<uint> ContainedObjectIds => GameObject.Owner.TunnelManager!.ContainedObjectIds;
 
     private readonly TunnelContainModuleData _moduleData;

--- a/src/OpenSage.Game/Logic/Object/Create/CreateModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/CreateModule.cs
@@ -4,6 +4,10 @@ public abstract class CreateModule : BehaviorModule, ICreateModule
 {
     private bool _shouldCallOnBuildComplete = true;
 
+    protected CreateModule(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     public virtual void OnCreate() { }
 
     public void OnBuildComplete()

--- a/src/OpenSage.Game/Logic/Object/Create/ExperienceLevelCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/ExperienceLevelCreate.cs
@@ -5,18 +5,17 @@ namespace OpenSage.Logic.Object;
 [AddedIn(SageGame.Bfme)]
 internal sealed class ExperienceLevelCreateBehavior : CreateModule
 {
-    GameObject _gameObject;
     ExperienceLevelCreateModuleData _moduleData;
 
-    internal ExperienceLevelCreateBehavior(GameObject gameObject, ExperienceLevelCreateModuleData moduleData)
+    internal ExperienceLevelCreateBehavior(GameObject gameObject, GameContext context, ExperienceLevelCreateModuleData moduleData)
+        : base(gameObject, context)
     {
         _moduleData = moduleData;
-        _gameObject = gameObject;
     }
 
     public override void OnCreate()
     {
-        _gameObject.Rank = _moduleData.LevelToGrant;
+        GameObject.Rank = _moduleData.LevelToGrant;
     }
 }
 
@@ -35,6 +34,6 @@ public sealed class ExperienceLevelCreateModuleData : CreateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new ExperienceLevelCreateBehavior(gameObject, this);
+        return new ExperienceLevelCreateBehavior(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Create/GrantUpgradeCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/GrantUpgradeCreate.cs
@@ -4,6 +4,10 @@ namespace OpenSage.Logic.Object;
 
 public sealed class GrantUpgradeCreate : CreateModule
 {
+    public GrantUpgradeCreate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -33,6 +37,6 @@ public sealed class GrantUpgradeCreateModuleData : CreateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new GrantUpgradeCreate();
+        return new GrantUpgradeCreate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Create/LockWeaponCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/LockWeaponCreate.cs
@@ -5,6 +5,10 @@ namespace OpenSage.Logic.Object;
 [AddedIn(SageGame.CncGeneralsZeroHour)]
 public sealed class LockWeaponCreate : CreateModule
 {
+    public LockWeaponCreate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -32,6 +36,6 @@ public sealed class LockWeaponCreateModuleData : CreateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new LockWeaponCreate();
+        return new LockWeaponCreate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Create/PreorderCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/PreorderCreate.cs
@@ -4,6 +4,10 @@ namespace OpenSage.Logic.Object;
 
 public sealed class PreorderCreate : CreateModule
 {
+    public PreorderCreate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -15,8 +19,8 @@ public sealed class PreorderCreate : CreateModule
 }
 
 /// <summary>
-/// Allows the use of the PREORDER ModelConditionState with this object which in turn is only 
-/// triggered by the presence of registry key 'Preorder' set to '1' in 
+/// Allows the use of the PREORDER ModelConditionState with this object which in turn is only
+/// triggered by the presence of registry key 'Preorder' set to '1' in
 /// HKLM\Software\ElectronicArts\EAGames\Generals.
 /// </summary>
 public sealed class PreorderCreateModuleData : CreateModuleData
@@ -27,6 +31,6 @@ public sealed class PreorderCreateModuleData : CreateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new PreorderCreate();
+        return new PreorderCreate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Create/SpecialPowerCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/SpecialPowerCreate.cs
@@ -4,16 +4,13 @@ namespace OpenSage.Logic.Object;
 
 public class SpecialPowerCreate : CreateModule
 {
-    private readonly GameObject _gameObject;
-
-    public SpecialPowerCreate(GameObject gameObject)
+    public SpecialPowerCreate(GameObject gameObject, GameContext context) : base(gameObject, context)
     {
-        _gameObject = gameObject;
     }
 
     protected override void OnBuildCompleteImpl()
     {
-        foreach (var specialPowerModule in _gameObject.FindBehaviors<SpecialPowerModule>())
+        foreach (var specialPowerModule in GameObject.FindBehaviors<SpecialPowerModule>())
         {
             specialPowerModule.ResetCountdown();
         }
@@ -41,6 +38,6 @@ public sealed class SpecialPowerCreateModuleData : CreateModuleData
 
     internal override SpecialPowerCreate CreateModule(GameObject gameObject, GameContext context)
     {
-        return new SpecialPowerCreate(gameObject);
+        return new SpecialPowerCreate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Create/SupplyCenterCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/SupplyCenterCreate.cs
@@ -4,28 +4,23 @@ namespace OpenSage.Logic.Object;
 
 public sealed class SupplyCenterCreate : CreateModule, IDestroyModule
 {
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
-
-    public SupplyCenterCreate(GameObject gameObject, GameContext context)
+    public SupplyCenterCreate(GameObject gameObject, GameContext context) : base(gameObject, context)
     {
-        _gameObject = gameObject;
-        _context = context;
     }
 
     protected override void OnBuildCompleteImpl()
     {
-        foreach (var player in _context.Scene3D.Players)
+        foreach (var player in Context.Scene3D.Players)
         {
-            player.SupplyManager.AddSupplyCenter(_gameObject);
+            player.SupplyManager.AddSupplyCenter(GameObject);
         }
     }
 
     public void OnDestroy()
     {
-        foreach (var player in _context.Scene3D.Players)
+        foreach (var player in Context.Scene3D.Players)
         {
-            player.SupplyManager.RemoveSupplyCenter(_gameObject);
+            player.SupplyManager.RemoveSupplyCenter(GameObject);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Create/SupplyWarehouseCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/SupplyWarehouseCreate.cs
@@ -4,28 +4,23 @@ namespace OpenSage.Logic.Object;
 
 public sealed class SupplyWarehouseCreate : CreateModule, IDestroyModule
 {
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
-
-    public SupplyWarehouseCreate(GameObject gameObject, GameContext context)
+    public SupplyWarehouseCreate(GameObject gameObject, GameContext context) : base(gameObject, context)
     {
-        _gameObject = gameObject;
-        _context = context;
     }
 
     public override void OnCreate()
     {
-        foreach (var player in _context.Scene3D.Players)
+        foreach (var player in Context.Scene3D.Players)
         {
-            player.SupplyManager.AddSupplyWarehouse(_gameObject);
+            player.SupplyManager.AddSupplyWarehouse(GameObject);
         }
     }
 
     public void OnDestroy()
     {
-        foreach (var player in _context.Scene3D.Players)
+        foreach (var player in Context.Scene3D.Players)
         {
-            player.SupplyManager.RemoveSupplyWarehouse(_gameObject);
+            player.SupplyManager.RemoveSupplyWarehouse(GameObject);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Create/VeterancyGainCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/VeterancyGainCreate.cs
@@ -5,12 +5,11 @@ namespace OpenSage.Logic.Object;
 
 public sealed class VeterancyGainCreate : CreateModule
 {
-    private readonly GameObject _gameObject;
     private readonly VeterancyGainCreateModuleData _moduleData;
 
-    public VeterancyGainCreate(GameObject gameObject, VeterancyGainCreateModuleData moduleData)
+    public VeterancyGainCreate(GameObject gameObject, GameContext context, VeterancyGainCreateModuleData moduleData)
+        : base(gameObject, context)
     {
-        _gameObject = gameObject;
         _moduleData = moduleData;
     }
 
@@ -25,16 +24,16 @@ public sealed class VeterancyGainCreate : CreateModule
 
     public override void OnCreate()
     {
-        if (_moduleData.ScienceRequired != null && !_gameObject.Owner.HasScience(_moduleData.ScienceRequired.Value))
+        if (_moduleData.ScienceRequired != null && !GameObject.Owner.HasScience(_moduleData.ScienceRequired.Value))
         {
             return;
         }
 
         // units like the minigunner or tank battlemaster can start at vet 1 and be upgraded to vet 2, and so have two VeterancyGainCreate modules
         var level = (int)_moduleData.StartingLevel;
-        if (level > _gameObject.Rank)
+        if (level > GameObject.Rank)
         {
-            _gameObject.Rank = level;
+            GameObject.Rank = level;
         }
     }
 }
@@ -54,6 +53,6 @@ public sealed class VeterancyGainCreateModuleData : CreateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new VeterancyGainCreate(gameObject, this);
+        return new VeterancyGainCreate(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Damage/BoneFXDamage.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/BoneFXDamage.cs
@@ -4,6 +4,10 @@ namespace OpenSage.Logic.Object;
 
 public sealed class BoneFXDamage : DamageModule
 {
+    public BoneFXDamage(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -15,7 +19,7 @@ public sealed class BoneFXDamage : DamageModule
 }
 
 /// <summary>
-/// Enables use of BoneFXUpdate module on this object where an additional dynamic FX logic can 
+/// Enables use of BoneFXUpdate module on this object where an additional dynamic FX logic can
 /// be used.
 /// </summary>
 public sealed class BoneFXDamageModuleData : DamageModuleData
@@ -26,6 +30,6 @@ public sealed class BoneFXDamageModuleData : DamageModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new BoneFXDamage();
+        return new BoneFXDamage(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Damage/DamageModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/DamageModule.cs
@@ -2,6 +2,10 @@
 
 public abstract class DamageModule : BehaviorModule
 {
+    protected DamageModule(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Damage/TransitionDamageFX.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/TransitionDamageFX.cs
@@ -16,7 +16,8 @@ public sealed class TransitionDamageFX : DamageModule
     private const int NumParticleSystemsPerDamageType = 12;
     private readonly uint[] _particleSystemIds = new uint[EnumUtility.GetEnumCount<BodyDamageType>() * NumParticleSystemsPerDamageType];
 
-    public TransitionDamageFX(TransitionDamageFXModuleData moduleData)
+    public TransitionDamageFX(GameObject gameObject, GameContext context, TransitionDamageFXModuleData moduleData)
+        : base(gameObject, context)
     {
         _moduleData = moduleData;
     }
@@ -159,7 +160,7 @@ public sealed class TransitionDamageFXModuleData : DamageModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new TransitionDamageFX(this);
+        return new TransitionDamageFX(gameObject, context, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
@@ -7,14 +7,11 @@ namespace OpenSage.Logic.Object;
 
 public sealed class CreateCrateDie : DieModule
 {
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
     private readonly CreateCrateDieModuleData _moduleData;
 
-    internal CreateCrateDie(GameObject gameObject, GameContext context, CreateCrateDieModuleData moduleData) : base(moduleData)
+    internal CreateCrateDie(GameObject gameObject, GameContext context, CreateCrateDieModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
-        _gameObject = gameObject;
-        _context = context;
         _moduleData = moduleData;
     }
 
@@ -22,17 +19,17 @@ public sealed class CreateCrateDie : DieModule
     {
         var crateData = _moduleData.CrateData.Value;
 
-        if (_gameObject.TryGetLastDamage(out var lastDamageData))
+        if (GameObject.TryGetLastDamage(out var lastDamageData))
         {
-            var killer = _context.GameLogic.GetObjectById(lastDamageData.Request.DamageDealer);
+            var killer = Context.GameLogic.GetObjectById(lastDamageData.Request.DamageDealer);
 
             if (KillerCanSpawnCrate(killer, crateData))
             {
-                if (_context.Random.NextSingle() < crateData.CreationChance)
+                if (Context.Random.NextSingle() < crateData.CreationChance)
                 {
                     // actually create the crate
                     float totalProbability = 0;
-                    var selection = _context.Random.NextSingle();
+                    var selection = Context.Random.NextSingle();
                     foreach (var crate in crateData.CrateObjects)
                     {
                         totalProbability += crate.Probability;
@@ -57,8 +54,8 @@ public sealed class CreateCrateDie : DieModule
         }
 
         return (!crateData.KilledByType.HasValue || killer.Definition.KindOf.Get(crateData.KilledByType.Value)) && // killer type ok
-               killer.Team != _gameObject.Team && // we can't generate our own salvage
-               (crateData.VeterancyLevel is not { } v || v != _gameObject.VeterancyHelper.VeterancyLevel) && // killer meets veterancy requirements
+               killer.Team != GameObject.Team && // we can't generate our own salvage
+               (crateData.VeterancyLevel is not { } v || v != GameObject.VeterancyHelper.VeterancyLevel) && // killer meets veterancy requirements
                (crateData.KillerScience is null || killer.Owner.HasScience(crateData.KillerScience.Value)); // killer owner meets science requirements
     }
 
@@ -66,12 +63,12 @@ public sealed class CreateCrateDie : DieModule
     {
         if (crate.Object is not null)
         {
-            var newCrate = _context.GameLogic.CreateObject(crate.Object.Value, _gameObject.Owner);
-            newCrate.SetTransformMatrix(_gameObject.TransformMatrix);
+            var newCrate = Context.GameLogic.CreateObject(crate.Object.Value, GameObject.Owner);
+            newCrate.SetTransformMatrix(GameObject.TransformMatrix);
 
             if (crateData.OwnedByMaker)
             {
-                newCrate.Team = _gameObject.Team;
+                newCrate.Team = GameObject.Team;
             }
         }
     }

--- a/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
@@ -7,8 +7,8 @@ public sealed class CreateObjectDie : DieModule
 {
     private readonly CreateObjectDieModuleData _moduleData;
 
-    internal CreateObjectDie(CreateObjectDieModuleData moduleData)
-        : base(moduleData)
+    internal CreateObjectDie(GameObject gameObject, GameContext context, CreateObjectDieModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -54,6 +54,6 @@ public sealed class CreateObjectDieModuleData : DieModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new CreateObjectDie(this);
+        return new CreateObjectDie(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/CrushDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CrushDie.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class CrushDie : DieModule
 {
-    public CrushDie(CrushDieModuleData moduleData) : base(moduleData)
+    public CrushDie(GameObject gameObject, GameContext context, CrushDieModuleData moduleData) : base(gameObject, context, moduleData)
     {
     }
 
@@ -45,7 +45,7 @@ public sealed class CrushDieModuleData : DieModuleData
 
     internal override CrushDie CreateModule(GameObject gameObject, GameContext context)
     {
-        return new CrushDie(this);
+        return new CrushDie(gameObject, context, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Die/DamDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DamDie.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 public sealed class DamDie : DieModule
 {
     // TODO
-    public DamDie(DamDieModuleData moduleData) : base(moduleData)
+    public DamDie(GameObject gameObject, GameContext context, DamDieModuleData moduleData) : base(gameObject, context, moduleData)
     {
     }
 
@@ -29,4 +29,9 @@ public sealed class DamDieModuleData : DieModuleData
 
     private static new readonly IniParseTable<DamDieModuleData> FieldParseTable = DieModuleData.FieldParseTable
         .Concat(new IniParseTable<DamDieModuleData>());
+
+    internal override DamDie CreateModule(GameObject gameObject, GameContext context)
+    {
+        return new DamDie(gameObject, context, this);
+    }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/DestroyDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DestroyDie.cs
@@ -4,17 +4,14 @@ namespace OpenSage.Logic.Object;
 
 public sealed class DestroyDie : DieModule
 {
-    private readonly GameObject _gameObject;
-
-    internal DestroyDie(GameObject gameObject, DestroyDieModuleData moduleData)
-        : base(moduleData)
+    internal DestroyDie(GameObject gameObject, GameContext context, DestroyDieModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
-        _gameObject = gameObject;
     }
 
     private protected override void Die(BehaviorUpdateContext context, DeathType deathType)
     {
-        context.GameContext.GameLogic.DestroyObject(_gameObject);
+        context.GameContext.GameLogic.DestroyObject(GameObject);
     }
 
     internal override void Load(StatePersister reader)
@@ -36,6 +33,6 @@ public sealed class DestroyDieModuleData : DieModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new DestroyDie(gameObject, this);
+        return new DestroyDie(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/DieModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DieModule.cs
@@ -9,7 +9,7 @@ public abstract class DieModule : BehaviorModule
 {
     private readonly DieModuleData _moduleData;
 
-    protected DieModule(DieModuleData moduleData)
+    protected DieModule(GameObject gameObject, GameContext context, DieModuleData moduleData) : base(gameObject, context)
     {
         _moduleData = moduleData;
     }

--- a/src/OpenSage.Game/Logic/Object/Die/EjectPilotDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/EjectPilotDie.cs
@@ -6,21 +6,17 @@ namespace OpenSage.Logic.Object;
 
 public sealed class EjectPilotDie : DieModule
 {
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
     private readonly EjectPilotDieModuleData _moduleData;
 
     internal EjectPilotDie(GameObject gameObject, GameContext context, EjectPilotDieModuleData moduleData)
-        : base(moduleData)
+        : base(gameObject, context, moduleData)
     {
-        _gameObject = gameObject;
-        _context = context;
         _moduleData = moduleData;
     }
 
     private protected override void Die(BehaviorUpdateContext context, DeathType deathType)
     {
-        var veterancy = (VeterancyLevel)_gameObject.Rank;
+        var veterancy = (VeterancyLevel)GameObject.Rank;
 
         if (!_moduleData.VeterancyLevels.Get(veterancy))
         {
@@ -29,10 +25,10 @@ public sealed class EjectPilotDie : DieModule
 
         var isOnGround = true; // todo: determine if unit is airborne
         var creationList = isOnGround ? _moduleData.GroundCreationList : _moduleData.AirCreationList;
-        foreach (var gameObject in _context.ObjectCreationLists.Create(creationList.Value, context))
+        foreach (var gameObject in Context.ObjectCreationLists.Create(creationList.Value, context))
         {
-            gameObject.Rank = _gameObject.Rank;
-            _context.AudioSystem.PlayAudioEvent(gameObject, _gameObject.Definition.UnitSpecificSounds.VoiceEject?.Value);
+            gameObject.Rank = GameObject.Rank;
+            Context.AudioSystem.PlayAudioEvent(gameObject, GameObject.Definition.UnitSpecificSounds.VoiceEject?.Value);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Die/FXListDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/FXListDie.cs
@@ -8,8 +8,8 @@ public sealed class FXListDie : DieModule
 {
     private readonly FXListDieModuleData _moduleData;
 
-    internal FXListDie(FXListDieModuleData moduleData)
-        : base(moduleData)
+    internal FXListDie(GameObject gameObject, GameContext context, FXListDieModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -60,6 +60,6 @@ public sealed class FXListDieModuleData : DieModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new FXListDie(this);
+        return new FXListDie(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/KeepObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/KeepObjectDie.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 public sealed class KeepObjectDie : DieModule
 {
-    public KeepObjectDie(KeepObjectDieModuleData moduleData)
-        : base(moduleData)
+    public KeepObjectDie(GameObject gameObject, GameContext context, KeepObjectDieModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
     }
 
@@ -38,6 +38,6 @@ public sealed class KeepObjectDieModuleData : DieModuleData
 
     internal override KeepObjectDie CreateModule(GameObject gameObject, GameContext context)
     {
-        return new KeepObjectDie(this);
+        return new KeepObjectDie(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/RebuildHoleExposeDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/RebuildHoleExposeDie.cs
@@ -6,26 +6,22 @@ namespace OpenSage.Logic.Object;
 
 public sealed class RebuildHoleExposeDie : DieModule
 {
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
     private readonly RebuildHoleExposeDieModuleData _moduleData;
 
     internal RebuildHoleExposeDie(GameObject gameObject, GameContext context, RebuildHoleExposeDieModuleData moduleData)
-        : base(moduleData)
+        : base(gameObject, context, moduleData)
     {
-        _gameObject = gameObject;
-        _context = context;
         _moduleData = moduleData;
     }
 
     private protected override void Die(BehaviorUpdateContext context, DeathType deathType)
     {
-        var hole = _context.GameLogic.CreateObject(_moduleData.HoleDefinition.Value, _gameObject.Owner);
-        hole.SetTransformMatrix(_gameObject.TransformMatrix);
+        var hole = Context.GameLogic.CreateObject(_moduleData.HoleDefinition.Value, GameObject.Owner);
+        hole.SetTransformMatrix(GameObject.TransformMatrix);
         var holeHealth = (Fix64)_moduleData.HoleMaxHealth;
         hole.MaxHealth = holeHealth;
         hole.Health = holeHealth;
-        hole.FindBehavior<RebuildHoleUpdate>().SetOriginalStructure(_gameObject);
+        hole.FindBehavior<RebuildHoleUpdate>().SetOriginalStructure(GameObject);
 
         base.Die(context, deathType);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/UpgradeDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/UpgradeDie.cs
@@ -5,15 +5,11 @@ namespace OpenSage.Logic.Object;
 
 public class UpgradeDieModule : DieModule
 {
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
     private readonly UpgradeDieModuleData _moduleData;
 
     internal UpgradeDieModule(GameObject gameObject, GameContext context, UpgradeDieModuleData moduleData)
-        : base(moduleData)
+        : base(gameObject, context, moduleData)
     {
-        _gameObject = gameObject;
-        _context = context;
         _moduleData = moduleData;
     }
 
@@ -28,7 +24,7 @@ public class UpgradeDieModule : DieModule
 
     private protected override void Die(BehaviorUpdateContext context, DeathType deathType)
     {
-        var parent = _context.GameLogic.GetObjectById(_gameObject.CreatedByObjectID);
+        var parent = Context.GameLogic.GetObjectById(GameObject.CreatedByObjectID);
 
         parent?.RemoveUpgrade(_moduleData.UpgradeToRemove.UpgradeName.Value);
 

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -546,43 +546,43 @@ public sealed class GameObject : Entity, IInspectable, ICollidable, IPersistable
             AddModule(tag, behavior);
         }
 
-        AddBehavior("ModuleTag_SMCHelper", new ObjectSpecialModelConditionHelper());
+        AddBehavior("ModuleTag_SMCHelper", new ObjectSpecialModelConditionHelper(this, gameContext));
 
         if (objectDefinition.KindOf.Get(ObjectKinds.CanBeRepulsed))
         {
-            AddBehavior("ModuleTag_RepulsorHelper", new ObjectRepulsorHelper());
+            AddBehavior("ModuleTag_RepulsorHelper", new ObjectRepulsorHelper(this, gameContext));
         }
 
         // TODO: This shouldn't be added to all objects. I don't know what the rule is.
         if (_gameContext.Game.SageGame >= SageGame.CncGeneralsZeroHour)
         {
-            AddBehavior("ModuleTag_StatusDamageHelper", new StatusDamageHelper());
-            AddBehavior("ModuleTag_SubdualDamageHelper", new SubdualDamageHelper());
+            AddBehavior("ModuleTag_StatusDamageHelper", new StatusDamageHelper(this, gameContext));
+            AddBehavior("ModuleTag_SubdualDamageHelper", new SubdualDamageHelper(this, gameContext));
         }
 
         // TODO: This shouldn't be added to all objects. I don't know what the rule is.
         // Maybe KindOf = CAN_ATTACK ?
-        AddBehavior("ModuleTag_DefectionHelper", new ObjectDefectionHelper());
+        AddBehavior("ModuleTag_DefectionHelper", new ObjectDefectionHelper(this, gameContext));
 
         // TODO: This shouldn't be added to all objects. I don't know what the rule is.
         // Probably only those with weapons.
-        AddBehavior("ModuleTag_WeaponStatusHelper", new ObjectWeaponStatusHelper());
+        AddBehavior("ModuleTag_WeaponStatusHelper", new ObjectWeaponStatusHelper(this, gameContext));
 
         // TODO: This shouldn't be added to all objects. I don't know what the rule is.
         // Probably only those with weapons.
-        AddBehavior("ModuleTag_FiringTrackerHelper", new ObjectFiringTrackerHelper());
+        AddBehavior("ModuleTag_FiringTrackerHelper", new ObjectFiringTrackerHelper(this, gameContext));
 
         // TODO: This shouldn't be added to all objects. I don't know what the rule is.
         if (_gameContext.Game.SageGame is not SageGame.CncGenerals and not SageGame.CncGeneralsZeroHour)
         {
             // this was added in bfme and is not present in generals or zero hour
-            AddBehavior("ModuleTag_ExperienceHelper", new ExperienceUpdate(this));
+            AddBehavior("ModuleTag_ExperienceHelper", new ExperienceUpdate(this, gameContext));
         }
 
         // TODO: This shouldn't be added to all objects. I don't know what the rule is.
         if (_gameContext.Game.SageGame >= SageGame.CncGeneralsZeroHour)
         {
-            AddBehavior("ModuleTag_TempWeaponBonusHelper", new TempWeaponBonusHelper());
+            AddBehavior("ModuleTag_TempWeaponBonusHelper", new TempWeaponBonusHelper(this, gameContext));
         }
 
         foreach (var behaviorDataContainer in objectDefinition.Behaviors.Values)

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectDefectionHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectDefectionHelper.cs
@@ -6,6 +6,10 @@ internal sealed class ObjectDefectionHelper : ObjectHelperModule
     private uint _frameEnd;
     private bool _unknown;
 
+    public ObjectDefectionHelper(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectFiringTrackerHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectFiringTrackerHelper.cs
@@ -7,6 +7,10 @@ internal sealed class ObjectFiringTrackerHelper : UpdateModule
 
     protected override UpdateOrder UpdateOrder => UpdateOrder.Order3;
 
+    public ObjectFiringTrackerHelper(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectHelperModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectHelperModule.cs
@@ -2,6 +2,10 @@
 
 internal abstract class ObjectHelperModule : UpdateModule
 {
+    protected ObjectHelperModule(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectRepulsorHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectRepulsorHelper.cs
@@ -3,6 +3,9 @@
 internal sealed class ObjectRepulsorHelper : ObjectHelperModule
 {
     // TODO
+    public ObjectRepulsorHelper(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
 
     internal override void Load(StatePersister reader)
     {

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectSpecialModelConditionHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectSpecialModelConditionHelper.cs
@@ -8,6 +8,9 @@
 internal sealed class ObjectSpecialModelConditionHelper : ObjectHelperModule
 {
     // TODO
+    public ObjectSpecialModelConditionHelper(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
 
     internal override void Load(StatePersister reader)
     {

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectWeaponStatusHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectWeaponStatusHelper.cs
@@ -5,6 +5,10 @@ internal sealed class ObjectWeaponStatusHelper : ObjectHelperModule
     // TODO
     protected override UpdateOrder UpdateOrder => UpdateOrder.Order3;
 
+    public ObjectWeaponStatusHelper(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Helpers/StatusDamageHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/StatusDamageHelper.cs
@@ -2,6 +2,10 @@
 
 internal sealed class StatusDamageHelper : ObjectHelperModule
 {
+    public StatusDamageHelper(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Helpers/SubdualDamageHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/SubdualDamageHelper.cs
@@ -2,6 +2,10 @@
 
 internal sealed class SubdualDamageHelper : ObjectHelperModule
 {
+    public SubdualDamageHelper(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Helpers/TempWeaponBonusHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/TempWeaponBonusHelper.cs
@@ -4,6 +4,10 @@ internal sealed class TempWeaponBonusHelper : ObjectHelperModule
 {
     private int _unknownInt;
 
+    public TempWeaponBonusHelper(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialPower.cs
@@ -27,18 +27,14 @@ public class SpecialPowerModule : BehaviorModule, IUpgradableScienceModule
     public bool Ready => ReadyProgress() >= 1;
     private bool _ready;
 
-    protected readonly GameObject GameObject;
-    private protected readonly GameContext Context;
     private readonly SpecialPowerModuleData _moduleData;
 
     private bool _unlocked;
 
     public SpecialPowerType SpecialPowerType => _moduleData.SpecialPower.Value.Type;
 
-    internal SpecialPowerModule(GameObject gameObject, GameContext context, SpecialPowerModuleData moduleData)
+    internal SpecialPowerModule(GameObject gameObject, GameContext context, SpecialPowerModuleData moduleData) : base(gameObject, context)
     {
-        GameObject = gameObject;
-        Context = context;
         _moduleData = moduleData;
         _reloadFrames = _moduleData.SpecialPower.Value.ReloadTime;
         _paused = moduleData.StartsPaused;

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -21,8 +21,6 @@ public class AIUpdate : UpdateModule
 
     public Locomotor CurrentLocomotor { get; protected set; }
 
-    protected GameObject GameObject { get; }
-    protected GameContext Context { get; }
     internal virtual AIUpdateModuleData ModuleData { get; }
 
     private readonly TurretAIUpdate _turretAIUpdate;
@@ -92,9 +90,8 @@ public class AIUpdate : UpdateModule
     protected override UpdateOrder UpdateOrder => UpdateOrder.Order0;
 
     internal AIUpdate(GameObject gameObject, GameContext context, AIUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
-        GameObject = gameObject;
-        Context = context;
         ModuleData = moduleData;
 
         TargetPoints = new List<Vector3>();
@@ -108,7 +105,7 @@ public class AIUpdate : UpdateModule
         // and might be overridden in a derived class, causing it to be unintialised despite the assignment above.
         if (moduleData.Turret != null)
         {
-            _turretAIUpdate = moduleData.Turret.CreateTurretAIUpdate(GameObject);
+            _turretAIUpdate = moduleData.Turret.CreateTurretAIUpdate(GameObject, context);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AssistedTargetingUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AssistedTargetingUpdate.cs
@@ -4,6 +4,10 @@ namespace OpenSage.Logic.Object;
 
 public sealed class AssistedTargetingUpdate : UpdateModule
 {
+    public AssistedTargetingUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -34,6 +38,6 @@ public sealed class AssistedTargetingUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new AssistedTargetingUpdate();
+        return new AssistedTargetingUpdate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
@@ -7,8 +7,6 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class AutoDepositUpdate : UpdateModule
 {
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
     private readonly AutoDepositUpdateModuleData _moduleData;
 
     private LogicFrame _nextAwardFrame;
@@ -16,15 +14,14 @@ internal sealed class AutoDepositUpdate : UpdateModule
     private bool _unknownBool2 = true;
 
     internal AutoDepositUpdate(GameObject gameObject, GameContext context, AutoDepositUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
         _moduleData = moduleData;
-        _gameObject = gameObject;
-        _context = context;
     }
 
     internal override void Update(BehaviorUpdateContext context)
     {
-        if (_gameObject.IsBeingConstructed())
+        if (GameObject.IsBeingConstructed())
         {
             return;
         }
@@ -35,9 +32,9 @@ internal sealed class AutoDepositUpdate : UpdateModule
         }
 
         _nextAwardFrame = context.LogicFrame + _moduleData.DepositTiming;
-        var amount = (uint)(_moduleData.DepositAmount * _gameObject.ProductionModifier);
+        var amount = (uint)(_moduleData.DepositAmount * GameObject.ProductionModifier);
 
-        if (_moduleData.UpgradedBoost.HasValue && _gameObject.HasUpgrade(_moduleData.UpgradedBoost.Value.UpgradeType.Value))
+        if (_moduleData.UpgradedBoost.HasValue && GameObject.HasUpgrade(_moduleData.UpgradedBoost.Value.UpgradeType.Value))
         {
             amount += (uint)(amount * (_moduleData.UpgradedBoost.Value.Boost / 100f));
         }
@@ -45,10 +42,10 @@ internal sealed class AutoDepositUpdate : UpdateModule
         GenerateAutoDepositCashEvent((int)amount);
         if (_moduleData.ActualMoney)
         {
-            _gameObject.Owner.BankAccount.Deposit(amount);
+            GameObject.Owner.BankAccount.Deposit(amount);
             if (!_moduleData.GiveNoXP)
             {
-                _gameObject.GainExperience((int)amount);
+                GameObject.GainExperience((int)amount);
             }
         }
     }
@@ -63,14 +60,14 @@ internal sealed class AutoDepositUpdate : UpdateModule
             // It doesn't appear capture bonus and actual money ever intersect, but just in case...
             if (_moduleData.ActualMoney)
             {
-                _gameObject.Owner.BankAccount.Deposit((uint)_moduleData.InitialCaptureBonus);
+                GameObject.Owner.BankAccount.Deposit((uint)_moduleData.InitialCaptureBonus);
             }
         }
     }
 
     private void GenerateAutoDepositCashEvent(int amount)
     {
-        _gameObject.ActiveCashEvent = new CashEvent(amount, _gameObject.Owner.Color, new Vector3(0, 0, 10));
+        GameObject.ActiveCashEvent = new CashEvent(amount, GameObject.Owner.Color, new Vector3(0, 0, 10));
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Update/AutoFindHealingUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoFindHealingUpdate.cs
@@ -6,7 +6,8 @@ public sealed class AutoFindHealingUpdate : UpdateModule
 {
     private readonly AutoFindHealingUpdateModuleData _moduleData;
 
-    public AutoFindHealingUpdate(AutoFindHealingUpdateModuleData moduleData)
+    public AutoFindHealingUpdate(GameObject gameObject, GameContext context, AutoFindHealingUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
         _moduleData = moduleData;
     }
@@ -61,6 +62,6 @@ public sealed class AutoFindHealingUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new AutoFindHealingUpdate(this);
+        return new AutoFindHealingUpdate(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/BannerCarrierUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BannerCarrierUpdate.cs
@@ -6,12 +6,11 @@ namespace OpenSage.Logic.Object;
 [AddedIn(SageGame.Bfme)]
 public class BannerCarrierUpdate : UpdateModule
 {
-    private GameObject _gameObject;
     private BannerCarrierUpdateModuleData _moduleData;
 
-    public BannerCarrierUpdate(GameObject gameObject, BannerCarrierUpdateModuleData moduleData)
+    public BannerCarrierUpdate(GameObject gameObject, GameContext context, BannerCarrierUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
-        _gameObject = gameObject;
         _moduleData = moduleData;
     }
 
@@ -61,7 +60,7 @@ public sealed class BannerCarrierUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new BannerCarrierUpdate(gameObject, this);
+        return new BannerCarrierUpdate(gameObject, context, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/BaseRegenerateUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BaseRegenerateUpdate.cs
@@ -4,15 +4,10 @@ namespace OpenSage.Logic.Object;
 
 public sealed class BaseRegenerateUpdate : UpdateModule, IDamageModule
 {
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
-
     protected override LogicFrameSpan FramesBetweenUpdates => LogicFrameSpan.OneSecond;
 
-    internal BaseRegenerateUpdate(GameObject gameObject, GameContext context)
+    internal BaseRegenerateUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
     {
-        _gameObject = gameObject;
-        _context = context;
         SetNextUpdateFrame(new LogicFrame(uint.MaxValue));
     }
 
@@ -21,15 +16,15 @@ public sealed class BaseRegenerateUpdate : UpdateModule, IDamageModule
     /// </summary>
     public void OnDamage(in DamageData damageData)
     {
-        var currentFrame = _context.GameLogic.CurrentFrame;
-        SetNextUpdateFrame(currentFrame + _context.AssetLoadContext.AssetStore.GameData.Current.BaseRegenDelay);
+        var currentFrame = Context.GameLogic.CurrentFrame;
+        SetNextUpdateFrame(currentFrame + Context.AssetLoadContext.AssetStore.GameData.Current.BaseRegenDelay);
     }
 
     private protected override void RunUpdate(BehaviorUpdateContext context)
     {
-        _gameObject.HealDirectly(_context.AssetLoadContext.AssetStore.GameData.Current.BaseRegenHealthPercentPerSecond);
+        GameObject.HealDirectly(Context.AssetLoadContext.AssetStore.GameData.Current.BaseRegenHealthPercentPerSecond);
 
-        if (_gameObject.IsFullHealth)
+        if (GameObject.IsFullHealth)
         {
             SetNextUpdateFrame(new LogicFrame(uint.MaxValue));
         }

--- a/src/OpenSage.Game/Logic/Object/Update/BoneFXUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BoneFXUpdate.cs
@@ -9,6 +9,10 @@ public sealed class BoneFXUpdate : UpdateModule
     private readonly List<uint> _particleSystemIds = new();
     private readonly int[] _unknownInts = new int[96];
 
+    public BoneFXUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -96,7 +100,7 @@ public sealed class BoneFXUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new BoneFXUpdate();
+        return new BoneFXUpdate(gameObject, context);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/CleanupHazardUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/CleanupHazardUpdate.cs
@@ -4,6 +4,10 @@ namespace OpenSage.Logic.Object;
 
 public sealed class CleanupHazardUpdate : UpdateModule
 {
+    public CleanupHazardUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -36,6 +40,6 @@ public sealed class CleanupHazardUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new CleanupHazardUpdate();
+        return new CleanupHazardUpdate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/CommandButtonHuntUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/CommandButtonHuntUpdate.cs
@@ -6,6 +6,10 @@ public sealed class CommandButtonHuntUpdate : UpdateModule
 {
     private string _commandButtonName;
 
+    public CommandButtonHuntUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -29,6 +33,6 @@ public sealed class CommandButtonHuntUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new CommandButtonHuntUpdate();
+        return new CommandButtonHuntUpdate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
@@ -6,14 +6,13 @@ namespace OpenSage.Logic.Object;
 
 internal class DeletionUpdate : UpdateModule
 {
-    private readonly GameObject _gameObject;
     private readonly DeletionUpdateModuleData _moduleData;
 
     private LogicFrame _frameToDelete;
 
     public DeletionUpdate(GameObject gameObject, GameContext context, DeletionUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
-        _gameObject = gameObject;
         _moduleData = moduleData;
 
         _frameToDelete = context.GameLogic.CurrentFrame + context.GetRandomLogicFrameSpan(_moduleData.MinLifetime, _moduleData.MaxLifetime);
@@ -24,7 +23,7 @@ internal class DeletionUpdate : UpdateModule
     {
         if (context.LogicFrame >= _frameToDelete)
         {
-            context.GameContext.GameLogic.DestroyObject(_gameObject);
+            context.GameContext.GameLogic.DestroyObject(GameObject);
         }
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/DockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DockUpdate.cs
@@ -7,7 +7,6 @@ namespace OpenSage.Logic.Object;
 
 public abstract class DockUpdate : UpdateModule
 {
-    private GameObject _gameObject;
     private DockUpdateModuleData _moduleData;
 
     private Queue<SupplyAIUpdate> _unitsApproaching;
@@ -24,9 +23,9 @@ public abstract class DockUpdate : UpdateModule
     private uint _unknownObjectId;
     private ushort _unknownInt1;
 
-    internal DockUpdate(GameObject gameObject, DockUpdateModuleData moduleData)
+    protected DockUpdate(GameObject gameObject, GameContext context, DockUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
-        _gameObject = gameObject;
         _moduleData = moduleData;
         _unitsApproaching = new Queue<SupplyAIUpdate>();
         _usesWaitingBones = _moduleData.NumberApproachPositions != -1;
@@ -35,19 +34,19 @@ public abstract class DockUpdate : UpdateModule
     private Vector3 GetActionBone()
     {
         // TODO: might also be DOCKSTART or DOCKEND
-        var (actionModelInstance, actionBone) = _gameObject.Drawable.FindBone($"DOCKACTION");
+        var (actionModelInstance, actionBone) = GameObject.Drawable.FindBone($"DOCKACTION");
 
         if (actionModelInstance != null && actionBone != null)
         {
             return actionModelInstance.AbsoluteBoneTransforms[actionBone.Index].Translation;
         }
-        return _gameObject.Translation;
+        return GameObject.Translation;
     }
 
     private Vector3 GetDockWaitingBone(int id)
     {
         var identifier = id.ToString("D2");
-        var (modelInstance, bone) = _gameObject.Drawable.FindBone($"DOCKWAITING{identifier}");
+        var (modelInstance, bone) = GameObject.Drawable.FindBone($"DOCKWAITING{identifier}");
         return modelInstance.AbsoluteBoneTransforms[bone.Index].Translation;
     }
 
@@ -59,7 +58,7 @@ public abstract class DockUpdate : UpdateModule
 
         if (!_usesWaitingBones)
         {
-            return _gameObject.Translation;
+            return GameObject.Translation;
         }
 
         if (_unitsApproaching.Count == 1)
@@ -93,9 +92,9 @@ public abstract class DockUpdate : UpdateModule
 
     internal override void Update(BehaviorUpdateContext context)
     {
-        if (_gameObject.ModelConditionFlags.Get(ModelConditionFlag.DockingActive))
+        if (GameObject.ModelConditionFlags.Get(ModelConditionFlag.DockingActive))
         {
-            _gameObject.ModelConditionFlags.Set(ModelConditionFlag.DockingActive, false);
+            GameObject.ModelConditionFlags.Set(ModelConditionFlag.DockingActive, false);
         }
 
         if (_unitsApproaching.Count > 0)
@@ -108,7 +107,7 @@ public abstract class DockUpdate : UpdateModule
                     aiUpdate.SupplyGatherState = SupplyAIUpdate.SupplyGatherStates.StartDumpingSupplies;
                     break;
                 case SupplyAIUpdate.SupplyGatherStates.FinishedDumpingSupplies:
-                    _gameObject.ModelConditionFlags.Set(ModelConditionFlag.DockingActive, true);
+                    GameObject.ModelConditionFlags.Set(ModelConditionFlag.DockingActive, true);
                     aiUpdate.SupplyGatherState = SupplyAIUpdate.SupplyGatherStates.SearchingForSupplySource;
                     _unitsApproaching.Dequeue();
                     MoveObjectsForward();

--- a/src/OpenSage.Game/Logic/Object/Update/DynamicShroudClearingRangeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DynamicShroudClearingRangeUpdate.cs
@@ -15,6 +15,10 @@ public sealed class DynamicShroudClearingRangeUpdate : UpdateModule
     private float _unknown9;
     private float _unknownFloat;
 
+    public DynamicShroudClearingRangeUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -77,6 +81,6 @@ public sealed class DynamicShroudClearingRangeUpdateModuleData : UpdateModuleDat
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new DynamicShroudClearingRangeUpdate();
+        return new DynamicShroudClearingRangeUpdate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using OpenSage.FX;
 
@@ -8,8 +7,6 @@ namespace OpenSage.Logic.Object;
 [AddedIn(SageGame.Bfme)]
 public class ExperienceUpdate : UpdateModule
 {
-    private GameObject _gameObject;
-
     private List<ExperienceLevel> _experienceLevels;
     private bool _initial;
     private ExperienceLevel _currentLevel;
@@ -18,34 +15,33 @@ public class ExperienceUpdate : UpdateModule
 
     public bool ObjectGainsExperience { get; private set; }
 
-    internal ExperienceUpdate(GameObject gameObject)
+    internal ExperienceUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
     {
-        _gameObject = gameObject;
         _initial = true;
     }
 
     private void Initialize(BehaviorUpdateContext context)
     {
         // not sure why the required experience for rank 1 is 1 instead of 0
-        if (_gameObject.ExperienceValue == 0)
+        if (GameObject.ExperienceValue == 0)
         {
-            _gameObject.ExperienceValue = 1;
+            GameObject.ExperienceValue = 1;
         }
 
         _experienceLevels = FindRelevantExperienceLevels(context);
         if (_experienceLevels != null && _experienceLevels.Count > 0)
         {
             _nextLevel = _experienceLevels.First();
-            _gameObject.ExperienceRequiredForNextLevel = _nextLevel.RequiredExperience;
+            GameObject.ExperienceRequiredForNextLevel = _nextLevel.RequiredExperience;
             ObjectGainsExperience = true;
 
-            while (_gameObject.Rank >= _nextLevel.Rank)
+            while (GameObject.Rank >= _nextLevel.Rank)
             {
                 levelUp();
             }
         }
 
-        _bannerCarrierUpdate = _gameObject.FindBehavior<BannerCarrierUpdate>();
+        _bannerCarrierUpdate = GameObject.FindBehavior<BannerCarrierUpdate>();
         _initial = false;
     }
 
@@ -57,7 +53,7 @@ public class ExperienceUpdate : UpdateModule
         }
 
         if (_experienceLevels == null || _experienceLevels.Count == 0
-            || _gameObject.ExperienceValue < _nextLevel.RequiredExperience)
+            || GameObject.ExperienceValue < _nextLevel.RequiredExperience)
         {
             return;
         }
@@ -70,8 +66,8 @@ public class ExperienceUpdate : UpdateModule
                 context.GameContext));
         }
 
-        _gameObject.ExperienceValue -= _nextLevel.RequiredExperience;
-        _gameObject.Rank = _nextLevel.Rank; _gameObject.Rank = _nextLevel.Rank;
+        GameObject.ExperienceValue -= _nextLevel.RequiredExperience;
+        GameObject.Rank = _nextLevel.Rank; GameObject.Rank = _nextLevel.Rank;
 
         levelUp();
     }
@@ -88,7 +84,7 @@ public class ExperienceUpdate : UpdateModule
 
         if (_nextLevel.SelectionDecal != null)
         {
-            _gameObject.SelectionDecal = _nextLevel.SelectionDecal;
+            GameObject.SelectionDecal = _nextLevel.SelectionDecal;
         }
 
         // TODO:
@@ -100,11 +96,11 @@ public class ExperienceUpdate : UpdateModule
         {
             _currentLevel = _nextLevel;
             _nextLevel = _experienceLevels.First();
-            _gameObject.ExperienceRequiredForNextLevel = _nextLevel.RequiredExperience;
+            GameObject.ExperienceRequiredForNextLevel = _nextLevel.RequiredExperience;
         }
         else
         {
-            _gameObject.ExperienceRequiredForNextLevel = int.MaxValue;
+            GameObject.ExperienceRequiredForNextLevel = int.MaxValue;
         }
     }
 
@@ -119,7 +115,7 @@ public class ExperienceUpdate : UpdateModule
         {
             foreach (var upgrade in _currentLevel.Upgrades)
             {
-                upgrade.Value.RemoveUpgrade(_gameObject);
+                upgrade.Value.RemoveUpgrade(GameObject);
             }
         }
 
@@ -127,7 +123,7 @@ public class ExperienceUpdate : UpdateModule
         {
             foreach (var modifierList in _currentLevel.AttributeModifiers)
             {
-                _gameObject.RemoveAttributeModifier(modifierList.Value.Name);
+                GameObject.RemoveAttributeModifier(modifierList.Value.Name);
             }
         }
     }
@@ -138,7 +134,7 @@ public class ExperienceUpdate : UpdateModule
         {
             foreach (var upgrade in _nextLevel.Upgrades)
             {
-                upgrade.Value.GrantUpgrade(_gameObject);
+                upgrade.Value.GrantUpgrade(GameObject);
             }
         }
 
@@ -147,7 +143,7 @@ public class ExperienceUpdate : UpdateModule
             foreach (var modifierList in _nextLevel.AttributeModifiers)
             {
                 var attributeModifier = new AttributeModifier(modifierList.Value);
-                _gameObject.AddAttributeModifier(modifierList.Value.Name, attributeModifier);
+                GameObject.AddAttributeModifier(modifierList.Value.Name, attributeModifier);
             }
         }
     }
@@ -155,7 +151,7 @@ public class ExperienceUpdate : UpdateModule
     private List<ExperienceLevel> FindRelevantExperienceLevels(BehaviorUpdateContext context)
     {
         var experienceLevels = context.GameContext.AssetLoadContext.AssetStore.ExperienceLevels;
-        var levels = experienceLevels.Where(x => x.TargetNames != null && x.TargetNames.Contains(_gameObject.Definition.Name)).ToList();
+        var levels = experienceLevels.Where(x => x.TargetNames != null && x.TargetNames.Contains(GameObject.Definition.Name)).ToList();
         levels.Sort((x, y) => x.Rank.CompareTo(y.Rank));
         return levels.Count > 0 ? levels : null;
     }

--- a/src/OpenSage.Game/Logic/Object/Update/FireSpreadUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FireSpreadUpdate.cs
@@ -7,6 +7,9 @@ namespace OpenSage.Logic.Object;
 public sealed class FireSpreadUpdate : UpdateModule
 {
     // TODO
+    public FireSpreadUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
 
     internal override void Load(StatePersister reader)
     {
@@ -37,6 +40,6 @@ public sealed class FireSpreadUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new FireSpreadUpdate();
+        return new FireSpreadUpdate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/FireWeaponUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FireWeaponUpdate.cs
@@ -22,6 +22,10 @@ public sealed class FireWeaponUpdate : UpdateModule
     private uint _unknownUInt4;
     private uint _unknownUInt5;
 
+    public FireWeaponUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         var version = reader.PersistVersion(2);
@@ -109,7 +113,7 @@ public sealed class FireWeaponUpdateModuleData : UpdateModuleData
 
     internal override FireWeaponUpdate CreateModule(GameObject gameObject, GameContext context)
     {
-        return new FireWeaponUpdate();
+        return new FireWeaponUpdate(gameObject, context);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/FlammableUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FlammableUpdate.cs
@@ -12,7 +12,8 @@ public sealed class FlammableUpdate : UpdateModule
     private float _remainingDamageBeforeCatchingFire;
     private uint _startedTakingFlameDamageFrame;
 
-    internal FlammableUpdate(FlammableUpdateModuleData moduleData)
+    internal FlammableUpdate(GameObject gameObject, GameContext context, FlammableUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
         _moduleData = moduleData;
         _remainingDamageBeforeCatchingFire = moduleData.FlameDamageLimit;
@@ -145,6 +146,6 @@ public sealed class FlammableUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new FlammableUpdate(this);
+        return new FlammableUpdate(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/HijackerUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/HijackerUpdate.cs
@@ -4,6 +4,10 @@ namespace OpenSage.Logic.Object;
 
 public sealed class HijackerUpdate : UpdateModule
 {
+    public HijackerUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -29,6 +33,6 @@ public sealed class HijackerUpdateModuleData : UpdateModuleData
 
     internal override HijackerUpdate CreateModule(GameObject gameObject, GameContext context)
     {
-        return new HijackerUpdate();
+        return new HijackerUpdate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
@@ -4,8 +4,6 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class LifetimeUpdate : UpdateModule
 {
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
     private readonly LifetimeUpdateModuleData _moduleData;
 
     private LogicFrame _frameToDie;
@@ -18,9 +16,8 @@ internal sealed class LifetimeUpdate : UpdateModule
     }
 
     public LifetimeUpdate(GameObject gameObject, GameContext context, LifetimeUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
-        _gameObject = gameObject;
-        _context = context;
         _moduleData = moduleData;
 
         var lifetimeFrames = context.Random.Next(
@@ -34,7 +31,7 @@ internal sealed class LifetimeUpdate : UpdateModule
     {
         if (context.LogicFrame >= _frameToDie)
         {
-            _gameObject.Die(_moduleData.DeathType);
+            GameObject.Die(_moduleData.DeathType);
             _frameToDie = LogicFrame.MaxValue;
         }
     }

--- a/src/OpenSage.Game/Logic/Object/Update/OCLUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/OCLUpdate.cs
@@ -7,6 +7,10 @@ public sealed class OCLUpdate : UpdateModule
 {
     private bool _unknownBool;
 
+    public OCLUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -54,7 +58,7 @@ public sealed class OCLUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new OCLUpdate();
+        return new OCLUpdate(gameObject, context);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/ParticleUplinkCannonUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ParticleUplinkCannonUpdate.cs
@@ -50,14 +50,11 @@ public sealed class ParticleUplinkCannonUpdate : UpdateModule
     private LogicFrame _mostRecentClickFrame; // the frame of the most recent click
     private LogicFrame _secondMostRecentClickFrame; // the frame of the second-most recent click (most recent click moves here with each click)
 
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
     private readonly ParticleUplinkCannonUpdateModuleData _moduleData;
 
     internal ParticleUplinkCannonUpdate(GameObject gameObject, GameContext context, ParticleUplinkCannonUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
-        _gameObject = gameObject;
-        _context = context;
         _moduleData = moduleData;
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/PowerPlantUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/PowerPlantUpdate.cs
@@ -6,8 +6,6 @@ namespace OpenSage.Logic.Object;
 
 public sealed class PowerPlantUpdate : UpdateModule
 {
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
     private readonly PowerPlantUpdateModuleData _moduleData;
 
     private bool _rodsExtended;
@@ -15,9 +13,8 @@ public sealed class PowerPlantUpdate : UpdateModule
     private LogicFrame _rodsExtendedEndFrame;
 
     internal PowerPlantUpdate(GameObject gameObject, GameContext context, PowerPlantUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
-        _gameObject = gameObject;
-        _context = context;
         _moduleData = moduleData;
     }
 
@@ -25,17 +22,17 @@ public sealed class PowerPlantUpdate : UpdateModule
     {
         _rodsExtended = true;
 
-        _gameObject.Drawable.ModelConditionFlags.Set(ModelConditionFlag.PowerPlantUpgrading, true);
+        GameObject.Drawable.ModelConditionFlags.Set(ModelConditionFlag.PowerPlantUpgrading, true);
 
-        _rodsExtendedEndFrame = _context.GameLogic.CurrentFrame + _moduleData.RodsExtendTime;
+        _rodsExtendedEndFrame = Context.GameLogic.CurrentFrame + _moduleData.RodsExtendTime;
     }
 
     // China powerplant overcharge needs to be able to turn off
     internal void RetractRods()
     {
         _rodsExtended = false;
-        _gameObject.Drawable.ModelConditionFlags.Set(ModelConditionFlag.PowerPlantUpgrading, false);
-        _gameObject.Drawable.ModelConditionFlags.Set(ModelConditionFlag.PowerPlantUpgraded, false);
+        GameObject.Drawable.ModelConditionFlags.Set(ModelConditionFlag.PowerPlantUpgrading, false);
+        GameObject.Drawable.ModelConditionFlags.Set(ModelConditionFlag.PowerPlantUpgraded, false);
 
         _rodsExtendedEndFrame = LogicFrame.MaxValue;
     }
@@ -46,8 +43,8 @@ public sealed class PowerPlantUpdate : UpdateModule
 
         if (_rodsExtended && _rodsExtendedEndFrame < context.LogicFrame)
         {
-            _gameObject.Drawable.ModelConditionFlags.Set(ModelConditionFlag.PowerPlantUpgrading, false);
-            _gameObject.Drawable.ModelConditionFlags.Set(ModelConditionFlag.PowerPlantUpgraded, true);
+            GameObject.Drawable.ModelConditionFlags.Set(ModelConditionFlag.PowerPlantUpgrading, false);
+            GameObject.Drawable.ModelConditionFlags.Set(ModelConditionFlag.PowerPlantUpgraded, true);
             _rodsExtendedEndFrame = LogicFrame.MaxValue;
         }
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/DefaultProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/DefaultProductionExitUpdate.cs
@@ -9,7 +9,8 @@ public sealed class DefaultProductionExitUpdate : UpdateModule, IHasRallyPoint, 
 
     private readonly DefaultProductionExitUpdateModuleData _moduleData;
 
-    internal DefaultProductionExitUpdate(DefaultProductionExitUpdateModuleData moduleData)
+    internal DefaultProductionExitUpdate(GameObject gameObject, GameContext context, DefaultProductionExitUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
         _moduleData = moduleData;
     }
@@ -53,6 +54,6 @@ public sealed class DefaultProductionExitUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new DefaultProductionExitUpdate(this);
+        return new DefaultProductionExitUpdate(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/QueueProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/QueueProductionExitUpdate.cs
@@ -12,7 +12,8 @@ public sealed class QueueProductionExitUpdate : UpdateModule, IHasRallyPoint, IP
     private LogicFrameSpan _framesUntilNextSpawn;
     private readonly QueueProductionExitUpdateModuleData _moduleData;
 
-    internal QueueProductionExitUpdate(QueueProductionExitUpdateModuleData moduleData)
+    internal QueueProductionExitUpdate(GameObject gameObject, GameContext context, QueueProductionExitUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
         _moduleData = moduleData;
         _framesUntilNextSpawn = moduleData.ExitDelay;
@@ -102,6 +103,6 @@ public sealed class QueueProductionExitUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new QueueProductionExitUpdate(this);
+        return new QueueProductionExitUpdate(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SpawnPointProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SpawnPointProductionExitUpdate.cs
@@ -7,13 +7,12 @@ namespace OpenSage.Logic.Object;
 
 public sealed class SpawnPointProductionExitUpdate : UpdateModule, IProductionExit
 {
-    private readonly GameObject _gameObject;
     private readonly SpawnPointProductionExitUpdateModuleData _moduleData;
     private int _nextIndex;
 
-    internal SpawnPointProductionExitUpdate(GameObject gameObject, SpawnPointProductionExitUpdateModuleData moduleData)
+    internal SpawnPointProductionExitUpdate(GameObject gameObject, GameContext context, SpawnPointProductionExitUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
-        _gameObject = gameObject;
         _moduleData = moduleData;
 
         _nextIndex = 1;
@@ -40,7 +39,7 @@ public sealed class SpawnPointProductionExitUpdate : UpdateModule, IProductionEx
     }
 
     private (ModelInstance, ModelBone) FindBone(int index)
-        => _gameObject.Drawable.FindBone(_moduleData.SpawnPointBoneName + index.ToString("D2"));
+        => GameObject.Drawable.FindBone(_moduleData.SpawnPointBoneName + index.ToString("D2"));
 
     Vector3? IProductionExit.GetNaturalRallyPoint() => null;
 }
@@ -58,6 +57,6 @@ public sealed class SpawnPointProductionExitUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new SpawnPointProductionExitUpdate(gameObject, this);
+        return new SpawnPointProductionExitUpdate(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SupplyCenterProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SupplyCenterProductionExitUpdate.cs
@@ -9,7 +9,8 @@ public sealed class SupplyCenterProductionExitUpdate : UpdateModule, IHasRallyPo
 
     private readonly SupplyCenterProductionExitUpdateModuleData _moduleData;
 
-    internal SupplyCenterProductionExitUpdate(SupplyCenterProductionExitUpdateModuleData moduleData)
+    internal SupplyCenterProductionExitUpdate(GameObject gameObject, GameContext context, SupplyCenterProductionExitUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
         _moduleData = moduleData;
     }
@@ -56,6 +57,6 @@ public sealed class SupplyCenterProductionExitUpdateModuleData : UpdateModuleDat
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new SupplyCenterProductionExitUpdate(this);
+        return new SupplyCenterProductionExitUpdate(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/ProjectileStreamUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProjectileStreamUpdate.cs
@@ -9,6 +9,10 @@ public sealed class ProjectileStreamUpdate : UpdateModule
     private uint _unknownInt2;
     private uint _unknownObjectId;
 
+    public ProjectileStreamUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -41,6 +45,6 @@ public sealed class ProjectileStreamUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new ProjectileStreamUpdate();
+        return new ProjectileStreamUpdate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/RadarUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RadarUpdate.cs
@@ -8,6 +8,10 @@ public sealed class RadarUpdate : UpdateModule
     private bool _isRadarExtending;
     private bool _isRadarExtended;
 
+    public RadarUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -35,6 +39,6 @@ public sealed class RadarUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new RadarUpdate();
+        return new RadarUpdate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/RepairDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RepairDockUpdate.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 public sealed class RepairDockUpdate : DockUpdate
 {
-    internal RepairDockUpdate(GameObject gameObject, RepairDockUpdateModuleData moduleData)
-        : base(gameObject, moduleData)
+    internal RepairDockUpdate(GameObject gameObject, GameContext context, RepairDockUpdateModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
 
     }
@@ -23,7 +23,7 @@ public sealed class RepairDockUpdate : DockUpdate
 }
 
 /// <summary>
-/// Hardcoded to require DockWaitingN, DockEndN, DockActionN and DockStartN bones, where N 
+/// Hardcoded to require DockWaitingN, DockEndN, DockActionN and DockStartN bones, where N
 /// should correspond to <see cref="NumberApproachPositions"/>.
 /// </summary>
 public sealed class RepairDockUpdateModuleData : DockUpdateModuleData
@@ -40,6 +40,6 @@ public sealed class RepairDockUpdateModuleData : DockUpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new RepairDockUpdate(gameObject, this);
+        return new RepairDockUpdate(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/SpecialAbilityUpdate/SpecialAbilityUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SpecialAbilityUpdate/SpecialAbilityUpdate.cs
@@ -13,6 +13,10 @@ public class SpecialAbilityUpdate : UpdateModule
     private bool _unknownBool3;
     private float _unknownFloat;
 
+    public SpecialAbilityUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -212,6 +216,6 @@ public class SpecialAbilityUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new SpecialAbilityUpdate();
+        return new SpecialAbilityUpdate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/SpectreGunshipDeploymentUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SpectreGunshipDeploymentUpdate.cs
@@ -5,6 +5,10 @@ namespace OpenSage.Logic.Object;
 [AddedIn(SageGame.CncGeneralsZeroHour)]
 public sealed class SpectreGunshipDeploymentUpdate : UpdateModule
 {
+    public SpectreGunshipDeploymentUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -39,6 +43,6 @@ public sealed class SpectreGunshipDeploymentUpdateModuleData : BehaviorModuleDat
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new SpectreGunshipDeploymentUpdate();
+        return new SpectreGunshipDeploymentUpdate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/StealthDetectorUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StealthDetectorUpdate.cs
@@ -12,7 +12,8 @@ public sealed class StealthDetectorUpdate : UpdateModule
 
     protected override LogicFrameSpan FramesBetweenUpdates => _moduleData.DetectionRate;
 
-    public StealthDetectorUpdate(StealthDetectorUpdateModuleData moduleData)
+    public StealthDetectorUpdate(GameObject gameObject, GameContext context, StealthDetectorUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
         _moduleData = moduleData;
         Active = !_moduleData.InitiallyDisabled;
@@ -97,6 +98,6 @@ public sealed class StealthDetectorUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new StealthDetectorUpdate(this);
+        return new StealthDetectorUpdate(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/StealthUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StealthUpdate.cs
@@ -10,6 +10,10 @@ public sealed class StealthUpdate : UpdateModule
     private float _unknownFloat1;
     private float _unknownFloat2;
 
+    public StealthUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         var version = reader.PersistVersion(2);
@@ -48,8 +52,8 @@ public sealed class StealthUpdate : UpdateModule
 }
 
 /// <summary>
-/// Allows the use of the <see cref="ObjectDefinition.SoundStealthOn"/> and 
-/// <see cref="ObjectDefinition.SoundStealthOff"/> parameters on the object and is hardcoded to 
+/// Allows the use of the <see cref="ObjectDefinition.SoundStealthOn"/> and
+/// <see cref="ObjectDefinition.SoundStealthOff"/> parameters on the object and is hardcoded to
 /// display MESSAGE:StealthNeutralized when the object has been discovered.
 /// </summary>
 public sealed class StealthUpdateModuleData : BehaviorModuleData
@@ -178,6 +182,6 @@ public sealed class StealthUpdateModuleData : BehaviorModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new StealthUpdate();
+        return new StealthUpdate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/StickyBombUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StickyBombUpdate.cs
@@ -8,6 +8,10 @@ public sealed class StickyBombUpdate : UpdateModule
     private uint _unknown2;
     private uint _unknown3;
 
+    public StickyBombUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -45,6 +49,6 @@ public sealed class StickyBombUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new StickyBombUpdate();
+        return new StickyBombUpdate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/StructureCollapseUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StructureCollapseUpdate.cs
@@ -6,12 +6,11 @@ namespace OpenSage.Logic.Object;
 public class StructureCollapseUpdate : UpdateModule
 {
     private readonly StructureCollapseUpdateModuleData _moduleData;
-    private readonly GameObject _gameObject;
 
-    public StructureCollapseUpdate(GameObject gameObject, StructureCollapseUpdateModuleData moduleData)
+    public StructureCollapseUpdate(GameObject gameObject, GameContext context, StructureCollapseUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
         _moduleData = moduleData;
-        _gameObject = gameObject;
     }
 
     internal override void Update(BehaviorUpdateContext context)
@@ -67,7 +66,7 @@ public sealed class StructureCollapseUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new StructureCollapseUpdate(gameObject, this);
+        return new StructureCollapseUpdate(gameObject, context, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/StructureToppleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StructureToppleUpdate.cs
@@ -7,6 +7,10 @@ public sealed class StructureToppleUpdate : UpdateModule
 {
     private float _unknownFloat;
 
+    public StructureToppleUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -75,7 +79,7 @@ public sealed class StructureToppleUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new StructureToppleUpdate();
+        return new StructureToppleUpdate(gameObject, context);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/SupplyCenterDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SupplyCenterDockUpdate.cs
@@ -6,12 +6,11 @@ namespace OpenSage.Logic.Object;
 
 public class SupplyCenterDockUpdate : DockUpdate
 {
-    private GameObject _gameObject;
     private SupplyCenterDockUpdateModuleData _moduleData;
 
-    internal SupplyCenterDockUpdate(GameObject gameObject, SupplyCenterDockUpdateModuleData moduleData) : base(gameObject, moduleData)
+    internal SupplyCenterDockUpdate(GameObject gameObject, GameContext context, SupplyCenterDockUpdateModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
-        _gameObject = gameObject;
         _moduleData = moduleData;
     }
 
@@ -23,14 +22,14 @@ public class SupplyCenterDockUpdate : DockUpdate
         if (_moduleData.BonusScience != null)
         {
             var bonusUpgradeDefinition = assetStore.Upgrades.GetByName(_moduleData.BonusScience);
-            if (_gameObject.HasUpgrade(bonusUpgradeDefinition))
+            if (GameObject.HasUpgrade(bonusUpgradeDefinition))
             {
                 amountPerBox *= _moduleData.BonusScienceMultiplier;
             }
         }
 
-        var amount = (int)(numBoxes * amountPerBox * _gameObject.ProductionModifier);
-        _gameObject.Owner.BankAccount.Deposit((uint)amount);
+        var amount = (int)(numBoxes * amountPerBox * GameObject.ProductionModifier);
+        GameObject.Owner.BankAccount.Deposit((uint)amount);
         numBoxes = 0;
 
         return amount;
@@ -78,6 +77,6 @@ public sealed class SupplyCenterDockUpdateModuleData : DockUpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new SupplyCenterDockUpdate(gameObject, this);
+        return new SupplyCenterDockUpdate(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/SupplyWarehouseDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SupplyWarehouseDockUpdate.cs
@@ -4,13 +4,12 @@ namespace OpenSage.Logic.Object;
 
 public class SupplyWarehouseDockUpdate : DockUpdate
 {
-    private GameObject _gameObject;
     private SupplyWarehouseDockUpdateModuleData _moduleData;
     private int _currentBoxes;
 
-    internal SupplyWarehouseDockUpdate(GameObject gameObject, SupplyWarehouseDockUpdateModuleData moduleData) : base(gameObject, moduleData)
+    internal SupplyWarehouseDockUpdate(GameObject gameObject, GameContext context, SupplyWarehouseDockUpdateModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
-        _gameObject = gameObject;
         _moduleData = moduleData;
         _currentBoxes = _moduleData.StartingBoxes;
     }
@@ -24,7 +23,7 @@ public class SupplyWarehouseDockUpdate : DockUpdate
             _currentBoxes--;
 
             var boxPercentage = (float)_currentBoxes / _moduleData.StartingBoxes;
-            _gameObject.Drawable.SetSupplyBoxesRemaining(boxPercentage);
+            GameObject.Drawable.SetSupplyBoxesRemaining(boxPercentage);
 
             return true;
         }
@@ -37,7 +36,7 @@ public class SupplyWarehouseDockUpdate : DockUpdate
 
         if (_currentBoxes <= 0 && _moduleData.DeleteWhenEmpty)
         {
-            _gameObject.Die(DeathType.Normal);
+            GameObject.Die(DeathType.Normal);
         }
     }
 
@@ -76,6 +75,6 @@ public sealed class SupplyWarehouseDockUpdateModuleData : DockUpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new SupplyWarehouseDockUpdate(gameObject, this);
+        return new SupplyWarehouseDockUpdate(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/ToppleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ToppleUpdate.cs
@@ -8,8 +8,6 @@ namespace OpenSage.Logic.Object;
 
 public sealed class ToppleUpdate : UpdateModule, ICollideModule
 {
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
     private readonly ToppleUpdateModuleData _moduleData;
 
     private ToppleState _toppleState;
@@ -21,9 +19,8 @@ public sealed class ToppleUpdate : UpdateModule, ICollideModule
     private uint _stumpId;
 
     internal ToppleUpdate(GameObject gameObject, GameContext context, ToppleUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
-        _gameObject = gameObject;
-        _context = context;
         _moduleData = moduleData;
 
         _toppleState = ToppleState.NotToppled;
@@ -38,7 +35,7 @@ public sealed class ToppleUpdate : UpdateModule, ICollideModule
                     // TODO: InitialAccelPercent
                     var deltaAngle = 0.01f;
                     _toppleAngle += deltaAngle;
-                    _gameObject.SetRotation(_gameObject.Rotation * Quaternion.CreateFromYawPitchRoll(deltaAngle, 0, 0));
+                    GameObject.SetRotation(GameObject.Rotation * Quaternion.CreateFromYawPitchRoll(deltaAngle, 0, 0));
                     if (_toppleAngle > MathUtility.PiOver2)
                     {
                         _toppleAngle = MathUtility.PiOver2;
@@ -70,7 +67,7 @@ public sealed class ToppleUpdate : UpdateModule, ICollideModule
         }
 
         // Only things with a CrusherLevel greater than our CrushableLevel, can topple us.
-        if (other.Definition.CrusherLevel <= _gameObject.Definition.CrushableLevel)
+        if (other.Definition.CrusherLevel <= GameObject.Definition.CrushableLevel)
         {
             return;
         }
@@ -84,9 +81,9 @@ public sealed class ToppleUpdate : UpdateModule, ICollideModule
     {
         _moduleData.ToppleFX?.Value.Execute(
             new FXListExecutionContext(
-                _gameObject.Rotation,
-                _gameObject.Translation,
-                _context));
+                GameObject.Rotation,
+                GameObject.Translation,
+                Context));
 
         CreateStump();
 
@@ -99,7 +96,7 @@ public sealed class ToppleUpdate : UpdateModule, ICollideModule
         _toppleState = ToppleState.Toppling;
 
         // TODO: Is this the right time to do this?
-        _gameObject.ModelConditionFlags.Set(ModelConditionFlag.Toppled, true);
+        GameObject.ModelConditionFlags.Set(ModelConditionFlag.Toppled, true);
     }
 
     private void CreateStump()
@@ -109,14 +106,14 @@ public sealed class ToppleUpdate : UpdateModule, ICollideModule
             return;
         }
 
-        var stump = _context.GameLogic.CreateObject(_moduleData.StumpName.Value, null);
-        stump.UpdateTransform(_gameObject.Translation, _gameObject.Rotation);
+        var stump = Context.GameLogic.CreateObject(_moduleData.StumpName.Value, null);
+        stump.UpdateTransform(GameObject.Translation, GameObject.Rotation);
         _stumpId = stump.ID;
     }
 
     private void KillObject()
     {
-        _gameObject.Kill(DeathType.Toppled);
+        GameObject.Kill(DeathType.Toppled);
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
@@ -12,12 +12,6 @@ public abstract class UpdateModule : BehaviorModule, IUpdateModule
 
     protected virtual UpdateOrder UpdateOrder => UpdateOrder.Order2;
 
-    // TODO: Remove this once all subclasses use the other constructor.
-    protected UpdateModule()
-    {
-        _nextUpdateFrame.UpdateOrder = UpdateOrder;
-    }
-
     protected UpdateModule(GameObject gameObject, GameContext context)
         : base(gameObject, context)
     {

--- a/src/OpenSage.Game/Logic/Object/Update/WaveGuideUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/WaveGuideUpdate.cs
@@ -5,6 +5,9 @@ namespace OpenSage.Logic.Object;
 public sealed class WaveGuideUpdate : UpdateModule
 {
     // TODO
+    public WaveGuideUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    {
+    }
 
     internal override void Load(StatePersister reader)
     {
@@ -17,8 +20,8 @@ public sealed class WaveGuideUpdate : UpdateModule
 }
 
 /// <summary>
-/// Hardcoded to use the following particle system definitions: WaveSpray03, WaveSpray02, 
-/// WaveSpray01, WaveSplashRight01, WaveSplashLeft01, WaveHit01, WaveSplash01 and also uses the 
+/// Hardcoded to use the following particle system definitions: WaveSpray03, WaveSpray02,
+/// WaveSpray01, WaveSplashRight01, WaveSplashLeft01, WaveHit01, WaveSplash01 and also uses the
 /// WaterWaveBridge object definition as a template when it collides with a bridge.
 /// Requires a WAVEGUIDE KindOf.
 /// </summary>
@@ -63,6 +66,6 @@ public sealed class WaveGuideUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new WaveGuideUpdate();
+        return new WaveGuideUpdate(gameObject, context);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/WeaponSetUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/WeaponSetUpdate.cs
@@ -6,12 +6,11 @@ namespace OpenSage.Logic.Object;
 
 public sealed class WeaponSetUpdate : UpdateModule
 {
-    private readonly GameObject _gameObject;
     private readonly WeaponSetUpdateModuleData _moduleData;
 
-    internal WeaponSetUpdate(GameObject gameObject, WeaponSetUpdateModuleData moduleData)
+    internal WeaponSetUpdate(GameObject gameObject, GameContext context, WeaponSetUpdateModuleData moduleData)
+        : base(gameObject, context)
     {
-        _gameObject = gameObject;
         _moduleData = moduleData;
     }
 
@@ -29,7 +28,7 @@ public sealed class WeaponSetUpdateModuleData : UpdateModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new WeaponSetUpdate(gameObject, this);
+        return new WeaponSetUpdate(gameObject, context, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ArmorUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ArmorUpgrade.cs
@@ -7,8 +7,8 @@ internal sealed class ArmorUpgrade : UpgradeModule
 {
     private readonly ArmorUpgradeModuleData _moduleData;
 
-    internal ArmorUpgrade(GameObject gameObject, ArmorUpgradeModuleData moduleData)
-        : base(gameObject, moduleData)
+    internal ArmorUpgrade(GameObject gameObject, GameContext context, ArmorUpgradeModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -57,6 +57,6 @@ public sealed class ArmorUpgradeModuleData : UpgradeModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new ArmorUpgrade(gameObject, this);
+        return new ArmorUpgrade(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/CommandSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/CommandSetUpgrade.cs
@@ -8,15 +8,15 @@ internal class CommandSetUpgrade : UpgradeModule
 {
     private readonly CommandSetUpgradeModuleData _moduleData;
 
-    public CommandSetUpgrade(GameObject gameObject, CommandSetUpgradeModuleData moduleData)
-        : base(gameObject, moduleData)
+    public CommandSetUpgrade(GameObject gameObject, GameContext context, CommandSetUpgradeModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
     }
 
     protected override void OnUpgrade()
     {
-        _gameObject.Definition.CommandSet = _moduleData.CommandSet;
+        GameObject.Definition.CommandSet = _moduleData.CommandSet;
     }
 
     internal override void Load(StatePersister reader)
@@ -59,6 +59,6 @@ public sealed class CommandSetUpgradeModuleData : UpgradeModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new CommandSetUpgrade(gameObject, this);
+        return new CommandSetUpgrade(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ExperienceScalarUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ExperienceScalarUpgrade.cs
@@ -6,15 +6,15 @@ internal sealed class ExperienceScalarUpgrade : UpgradeModule
 {
     private readonly ExperienceScalarUpgradeModuleData _moduleData;
 
-    internal ExperienceScalarUpgrade(GameObject gameObject, ExperienceScalarUpgradeModuleData moduleData)
-        : base(gameObject, moduleData)
+    internal ExperienceScalarUpgrade(GameObject gameObject, GameContext context, ExperienceScalarUpgradeModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
     }
 
     protected override void OnUpgrade()
     {
-        _gameObject.VeterancyHelper.ExperienceScalar += _moduleData.AddXPScalar;
+        GameObject.VeterancyHelper.ExperienceScalar += _moduleData.AddXPScalar;
     }
 
     internal override void Load(StatePersister reader)
@@ -41,6 +41,6 @@ public sealed class ExperienceScalarUpgradeModuleData : UpgradeModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new ExperienceScalarUpgrade(gameObject, this);
+        return new ExperienceScalarUpgrade(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/GeometryUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/GeometryUpgrade.cs
@@ -8,8 +8,8 @@ internal class GeometryUpgrade : UpgradeModule
 {
     private readonly GeometryUpgradeModuleData _moduleData;
 
-    internal GeometryUpgrade(GameObject gameObject, GeometryUpgradeModuleData moduleData)
-        : base(gameObject, moduleData)
+    internal GeometryUpgrade(GameObject gameObject, GameContext context, GeometryUpgradeModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -20,7 +20,7 @@ internal class GeometryUpgrade : UpgradeModule
         {
             foreach (var showGeometry in _moduleData.ShowGeometry)
             {
-                _gameObject.ShowCollider(showGeometry);
+                GameObject.ShowCollider(showGeometry);
             }
         }
 
@@ -28,7 +28,7 @@ internal class GeometryUpgrade : UpgradeModule
         {
             foreach (var hideGeometry in _moduleData.HideGeometry)
             {
-                _gameObject.HideCollider(hideGeometry);
+                GameObject.HideCollider(hideGeometry);
             }
         }
 
@@ -59,6 +59,6 @@ public sealed class GeometryUpgradeModuleData : UpgradeModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new GeometryUpgrade(gameObject, this);
+        return new GeometryUpgrade(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/GrantScienceUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/GrantScienceUpgrade.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class GrantScienceUpgrade : UpgradeModule
 {
-    public GrantScienceUpgrade(GameObject gameObject, UpgradeModuleData moduleData)
-        : base(gameObject, moduleData)
+    public GrantScienceUpgrade(GameObject gameObject, GameContext context, UpgradeModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
     }
 
@@ -33,6 +33,6 @@ public sealed class GrantScienceUpgradeModuleData : UpgradeModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new GrantScienceUpgrade(gameObject, this);
+        return new GrantScienceUpgrade(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/LocomotorSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/LocomotorSetUpgrade.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class LocomotorSetUpgrade : UpgradeModule
 {
-    public LocomotorSetUpgrade(GameObject gameObject, LocomotorSetUpgradeModuleData moduleData)
-        : base(gameObject, moduleData)
+    public LocomotorSetUpgrade(GameObject gameObject, GameContext context, LocomotorSetUpgradeModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
     }
 
@@ -20,7 +20,7 @@ internal sealed class LocomotorSetUpgrade : UpgradeModule
 }
 
 /// <summary>
-/// Triggers use of SET_NORMAL_UPGRADED locomotor on this object and allows the use of 
+/// Triggers use of SET_NORMAL_UPGRADED locomotor on this object and allows the use of
 /// VoiceMoveUpgrade within the UnitSpecificSounds section of the object.
 /// </summary>
 public sealed class LocomotorSetUpgradeModuleData : UpgradeModuleData
@@ -32,6 +32,6 @@ public sealed class LocomotorSetUpgradeModuleData : UpgradeModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new LocomotorSetUpgrade(gameObject, this);
+        return new LocomotorSetUpgrade(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/MaxHealthUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/MaxHealthUpgrade.cs
@@ -7,8 +7,8 @@ internal sealed class MaxHealthUpgrade : UpgradeModule
 {
     private readonly MaxHealthUpgradeModuleData _moduleData;
 
-    internal MaxHealthUpgrade(GameObject gameObject, MaxHealthUpgradeModuleData moduleData)
-        : base(gameObject, moduleData)
+    internal MaxHealthUpgrade(GameObject gameObject, GameContext context, MaxHealthUpgradeModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -18,17 +18,17 @@ internal sealed class MaxHealthUpgrade : UpgradeModule
         switch (_moduleData.ChangeType)
         {
             case MaxHealthChangeType.PreserveRatio:
-                _gameObject.Health += _gameObject.HealthPercentage * (Fix64)_moduleData.AddMaxHealth;
+                GameObject.Health += GameObject.HealthPercentage * (Fix64)_moduleData.AddMaxHealth;
                 break;
             case MaxHealthChangeType.AddCurrentHealthToo:
-                _gameObject.Health += (Fix64)_moduleData.AddMaxHealth;
+                GameObject.Health += (Fix64)_moduleData.AddMaxHealth;
                 break;
             case MaxHealthChangeType.SameCurrentHealth:
                 // Don't add any new health
                 break;
         }
 
-        _gameObject.MaxHealth += (Fix64)_moduleData.AddMaxHealth;
+        GameObject.MaxHealth += (Fix64)_moduleData.AddMaxHealth;
     }
 
     internal override void Load(StatePersister reader)
@@ -57,7 +57,7 @@ public sealed class MaxHealthUpgradeModuleData : UpgradeModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new MaxHealthUpgrade(gameObject, this);
+        return new MaxHealthUpgrade(gameObject, context, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
@@ -6,20 +6,18 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class ObjectCreationUpgrade : UpgradeModule
 {
-    private readonly GameContext _context;
     private readonly ObjectCreationUpgradeModuleData _moduleData;
 
     internal ObjectCreationUpgrade(GameObject gameObject, GameContext context, ObjectCreationUpgradeModuleData moduleData)
-        : base(gameObject, moduleData)
+        : base(gameObject, context, moduleData)
     {
-        _context = context;
         _moduleData = moduleData;
     }
 
     protected override void OnUpgrade()
     {
         // TODO: Get rid of this context thing.
-        var context = new BehaviorUpdateContext(_context, _gameObject);
+        var context = new BehaviorUpdateContext(Context, GameObject);
 
         foreach (var item in _moduleData.UpgradeObject.Value.Nuggets)
         {
@@ -27,9 +25,9 @@ internal sealed class ObjectCreationUpgrade : UpgradeModule
 
             foreach (var createdObject in createdObjects)
             {
-                createdObject.CreatedByObjectID = _gameObject.ID;
+                createdObject.CreatedByObjectID = GameObject.ID;
                 var slavedUpdateBehaviour = createdObject.FindBehavior<SlavedUpdateModule>();
-                slavedUpdateBehaviour?.SetMaster(_gameObject);
+                slavedUpdateBehaviour?.SetMaster(GameObject);
             }
         }
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/PowerPlantUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/PowerPlantUpgrade.cs
@@ -4,16 +4,16 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class PowerPlantUpgrade : UpgradeModule
 {
-    internal PowerPlantUpgrade(GameObject gameObject, PowerPlantUpgradeModuleData moduleData)
-        : base(gameObject, moduleData)
+    internal PowerPlantUpgrade(GameObject gameObject, GameContext context, PowerPlantUpgradeModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
     }
 
     protected override void OnUpgrade()
     {
-        _gameObject.EnergyProduction += _gameObject.Definition.EnergyBonus;
+        GameObject.EnergyProduction += GameObject.Definition.EnergyBonus;
 
-        foreach (var powerPlantUpdate in _gameObject.FindBehaviors<PowerPlantUpdate>())
+        foreach (var powerPlantUpdate in GameObject.FindBehaviors<PowerPlantUpdate>())
         {
             powerPlantUpdate.ExtendRods();
         }
@@ -30,7 +30,7 @@ internal sealed class PowerPlantUpgrade : UpgradeModule
 }
 
 /// <summary>
-/// Triggers use of the <see cref="ObjectDefinition.EnergyBonus"/> setting on this object to 
+/// Triggers use of the <see cref="ObjectDefinition.EnergyBonus"/> setting on this object to
 /// provide extra power to the faction.
 /// </summary>
 public sealed class PowerPlantUpgradeModuleData : UpgradeModuleData
@@ -42,6 +42,6 @@ public sealed class PowerPlantUpgradeModuleData : UpgradeModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new PowerPlantUpgrade(gameObject, this);
+        return new PowerPlantUpgrade(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/RadarUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/RadarUpgrade.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class RadarUpgrade : UpgradeModule
 {
-    internal RadarUpgrade(GameObject gameObject, RadarUpgradeModuleData moduleData)
-        : base(gameObject, moduleData)
+    internal RadarUpgrade(GameObject gameObject, GameContext context, RadarUpgradeModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
     }
 
@@ -20,7 +20,7 @@ internal sealed class RadarUpgrade : UpgradeModule
 }
 
 /// <summary>
-/// Triggers use of <see cref="RadarUpdateModuleData"/> module on this object if present and enables the 
+/// Triggers use of <see cref="RadarUpdateModuleData"/> module on this object if present and enables the
 /// Radar in the command bar.
 /// </summary>
 public sealed class RadarUpgradeModuleData : UpgradeModuleData
@@ -37,6 +37,6 @@ public sealed class RadarUpgradeModuleData : UpgradeModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new RadarUpgrade(gameObject, this);
+        return new RadarUpgrade(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/StealthUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/StealthUpgrade.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class StealthUpgrade : UpgradeModule
 {
-    public StealthUpgrade(GameObject gameObject, StealthUpgradeModuleData moduleData)
-        : base(gameObject, moduleData)
+    public StealthUpgrade(GameObject gameObject, GameContext context, StealthUpgradeModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
     }
 
@@ -20,8 +20,8 @@ internal sealed class StealthUpgrade : UpgradeModule
 }
 
 /// <summary>
-/// Eenables use of <see cref="StealthUpdateModuleData"/> module on this object. Requires 
-/// <see cref="StealthUpdateModuleData.InnateStealth"/> = No defined in the <see cref="StealthUpdateModuleData"/> 
+/// Eenables use of <see cref="StealthUpdateModuleData"/> module on this object. Requires
+/// <see cref="StealthUpdateModuleData.InnateStealth"/> = No defined in the <see cref="StealthUpdateModuleData"/>
 /// module.
 /// </summary>
 public sealed class StealthUpgradeModuleData : UpgradeModuleData
@@ -33,6 +33,6 @@ public sealed class StealthUpgradeModuleData : UpgradeModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new StealthUpgrade(gameObject, this);
+        return new StealthUpgrade(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/SubObjectsUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/SubObjectsUpgrade.cs
@@ -10,7 +10,8 @@ internal class SubObjectsUpgrade : UpgradeModule
 {
     private readonly SubObjectsUpgradeModuleData _moduleData;
 
-    internal SubObjectsUpgrade(GameObject gameObject, SubObjectsUpgradeModuleData moduleData) : base(gameObject, moduleData)
+    internal SubObjectsUpgrade(GameObject gameObject, GameContext context, SubObjectsUpgradeModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -21,7 +22,7 @@ internal class SubObjectsUpgrade : UpgradeModule
         {
             foreach (var subObject in _moduleData.ShowSubObjects)
             {
-                _gameObject.Drawable.ShowSubObject(subObject);
+                GameObject.Drawable.ShowSubObject(subObject);
             }
         }
 
@@ -29,7 +30,7 @@ internal class SubObjectsUpgrade : UpgradeModule
         {
             foreach (var subObject in _moduleData.HideSubObjects)
             {
-                _gameObject.Drawable.HideSubObject(subObject);
+                GameObject.Drawable.HideSubObject(subObject);
             }
         }
     }
@@ -84,6 +85,6 @@ public sealed class SubObjectsUpgradeModuleData : UpgradeModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new SubObjectsUpgrade(gameObject, this);
+        return new SubObjectsUpgrade(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/UnpauseSpecialPowerUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/UnpauseSpecialPowerUpgrade.cs
@@ -7,8 +7,8 @@ internal sealed class UnpauseSpecialPowerUpgrade : UpgradeModule
 {
     private readonly UnpauseSpecialPowerUpgradeModuleData _moduleData;
 
-    internal UnpauseSpecialPowerUpgrade(GameObject gameObject, UnpauseSpecialPowerUpgradeModuleData moduleData)
-        : base(gameObject, moduleData)
+    internal UnpauseSpecialPowerUpgrade(GameObject gameObject, GameContext context, UnpauseSpecialPowerUpgradeModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -16,7 +16,7 @@ internal sealed class UnpauseSpecialPowerUpgrade : UpgradeModule
     protected override void OnUpgrade()
     {
         var powerToUnpause = _moduleData.SpecialPowerTemplate.Value;
-        foreach (var specialPowerModule in _gameObject.FindBehaviors<SpecialPowerModule>())
+        foreach (var specialPowerModule in GameObject.FindBehaviors<SpecialPowerModule>())
         {
             if (specialPowerModule.Matches(powerToUnpause))
             {
@@ -53,6 +53,6 @@ public sealed class UnpauseSpecialPowerUpgradeModuleData : UpgradeModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new UnpauseSpecialPowerUpgrade(gameObject, this);
+        return new UnpauseSpecialPowerUpgrade(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
@@ -7,18 +7,13 @@ namespace OpenSage.Logic.Object;
 
 public abstract class UpgradeModule : BehaviorModule, IUpgradeableModule
 {
-    // TODO: Make this private.
-    protected readonly GameObject _gameObject;
     private readonly UpgradeModuleData _moduleData;
     private UpgradeLogic _upgradeLogic;
 
-    protected GameObject GameObject => _gameObject;
-
     internal bool Triggered => _upgradeLogic.Triggered;
 
-    internal UpgradeModule(GameObject gameObject, UpgradeModuleData moduleData)
+    internal UpgradeModule(GameObject gameObject, GameContext context, UpgradeModuleData moduleData) : base(gameObject, context)
     {
-        _gameObject = gameObject;
         _moduleData = moduleData;
         _upgradeLogic = new UpgradeLogic(moduleData.UpgradeData, OnUpgrade);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/WeaponBonusUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/WeaponBonusUpgrade.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class WeaponBonusUpgrade : UpgradeModule
 {
-    internal WeaponBonusUpgrade(GameObject gameObject, WeaponBonusUpgradeModuleData moduleData)
-        : base(gameObject, moduleData)
+    internal WeaponBonusUpgrade(GameObject gameObject, GameContext context, WeaponBonusUpgradeModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
     }
 
@@ -31,6 +31,6 @@ public sealed class WeaponBonusUpgradeModuleData : UpgradeModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new WeaponBonusUpgrade(gameObject, this);
+        return new WeaponBonusUpgrade(gameObject, context, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/WeaponSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/WeaponSetUpgrade.cs
@@ -6,14 +6,15 @@ internal sealed class WeaponSetUpgrade : UpgradeModule
 {
     private readonly WeaponSetUpgradeModuleData _moduleData;
 
-    internal WeaponSetUpgrade(GameObject gameObject, WeaponSetUpgradeModuleData moduleData) : base(gameObject, moduleData)
+    internal WeaponSetUpgrade(GameObject gameObject, GameContext context, WeaponSetUpgradeModuleData moduleData)
+        : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
     }
 
     protected override void OnUpgrade()
     {
-        _gameObject.SetWeaponSetCondition(WeaponSetConditions.PlayerUpgrade, true);
+        GameObject.SetWeaponSetCondition(WeaponSetConditions.PlayerUpgrade, true);
     }
 
     internal override void Load(StatePersister reader)
@@ -45,6 +46,6 @@ public sealed class WeaponSetUpgradeModuleData : UpgradeModuleData
 
     internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
     {
-        return new WeaponSetUpgrade(gameObject, this);
+        return new WeaponSetUpgrade(gameObject, context, this);
     }
 }


### PR DESCRIPTION
Removes the empty constructors in `BehaviorModule`, `ObjectModule`, and `UpdateModule`, and updates all subclasses to use the constructors taking a `GameObject` and `GameContext`.