### PR TITLE
Split formatting check into separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,6 @@ jobs:
       with:
         dotnet-version: '8.x'
 
-    - name: Check formatting
-      run: dotnet format src --verify-no-changes --verbosity diagnostic
-
     - name: Test
       run: dotnet test src --configuration Release --filter Category!=Interactive --collect:"XPlat Code Coverage"
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,23 @@
+name: Format
+
+on:
+  push:
+  pull_request:
+  merge_group:
+
+jobs:
+  format:
+    name: Validate
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.x'
+
+    - name: Check formatting
+      run: dotnet format src --verify-no-changes --verbosity diagnostic


### PR DESCRIPTION
This will allow us to have the formatting checks display separately from the build, so the builds can still run independently of any formatting issues.