### PR TITLE
Rename `GameContext` to `GameEngine`

### DIFF
--- a/src/OpenSage.Game.Tests/Logic/AnimationTests.cs
+++ b/src/OpenSage.Game.Tests/Logic/AnimationTests.cs
@@ -113,7 +113,7 @@ public class AnimationTests
     public void TestPlayToEnd(int delay)
     {
         var lastDisplayedFrame = delay * Images.Count; // if I have 4 images, with a delay of 5 frames between images, I'll be done on frame 1 + 5 + 5 + 5 + 5 = 21
-        var msDelay = (1000 / Game.LogicFramesPerSecond) * delay;
+        var msDelay = (1000 / GameEngine.LogicFramesPerSecond) * delay;
         var template = new AnimationTemplate { AnimationMode = AnimationMode.Once, Images = Images, Name = "DefaultHeal", AnimationDelay = (int)msDelay };
         var animation = new Animation(template);
 

--- a/src/OpenSage.Game.Tests/Logic/Object/BehaviorModuleTest.cs
+++ b/src/OpenSage.Game.Tests/Logic/Object/BehaviorModuleTest.cs
@@ -6,5 +6,5 @@ public abstract class BehaviorModuleTest<TModule, TData> : ModuleTest where TMod
 {
     protected override byte[] ModuleData() => [V1, V1, .. base.ModuleData()];
 
-    protected TModule SampleModule(IGame game = null, TData moduleData = null, GameObject gameObject = null) => (TModule)(moduleData ?? new TData()).CreateModule(gameObject, game?.Context);
+    protected TModule SampleModule(IGame game = null, TData moduleData = null, GameObject gameObject = null) => (TModule)(moduleData ?? new TData()).CreateModule(gameObject, game?.GameEngine);
 }

--- a/src/OpenSage.Game.Tests/Logic/Object/Behaviors/FireWeaponWhenDamagedBehaviorTests.cs
+++ b/src/OpenSage.Game.Tests/Logic/Object/Behaviors/FireWeaponWhenDamagedBehaviorTests.cs
@@ -85,7 +85,7 @@ public class FireWeaponWhenDamagedBehaviorTests : UpdateModuleTest<FireWeaponWhe
     private FireWeaponWhenDamagedBehavior CreateTestModule()
     {
         var objectDefinition = new ObjectDefinition();
-        var gameObject = new GameObject(objectDefinition, ZeroHour.Context, null);
+        var gameObject = new GameObject(objectDefinition, ZeroHour.GameEngine, null);
 
         return SampleModule(null, CreateTestModuleData(), gameObject);
     }

--- a/src/OpenSage.Game.Tests/Logic/Object/Behaviors/PhysicsBehaviorTests.cs
+++ b/src/OpenSage.Game.Tests/Logic/Object/Behaviors/PhysicsBehaviorTests.cs
@@ -168,7 +168,7 @@ public class PhysicsBehaviorTests : UpdateModuleTest<PhysicsBehavior, PhysicsBeh
         // TODO: Simplify test setup.
 
         var objectDefinition = new ObjectDefinition();
-        gameObject = new GameObject(objectDefinition, ZeroHour.Context, null);
+        gameObject = new GameObject(objectDefinition, ZeroHour.GameEngine, null);
 
         return SampleModule(ZeroHour, moduleData, gameObject: gameObject);
     }

--- a/src/OpenSage.Game.Tests/Logic/Object/GameObjectTests.cs
+++ b/src/OpenSage.Game.Tests/Logic/Object/GameObjectTests.cs
@@ -14,7 +14,7 @@ public class GameObjectTests : MockedGameTest
         ZeroHour.AssetStore.GameData.Current.Gravity = -0.07f;
 
         var objectDefinition = new ObjectDefinition();
-        var gameObject = new GameObject(objectDefinition, ZeroHour.Context, null);
+        var gameObject = new GameObject(objectDefinition, ZeroHour.GameEngine, null);
 
         gameObject.SetTranslation(new Vector3(0, 0, height));
 

--- a/src/OpenSage.Game.Tests/Logic/Object/Update/JetAIUpdateTests.cs
+++ b/src/OpenSage.Game.Tests/Logic/Object/Update/JetAIUpdateTests.cs
@@ -10,9 +10,9 @@ public class JetAIUpdateTests : MockedGameTest
     public void CanInstantiate()
     {
         var objectDefinition = new ObjectDefinition();
-        var gameObject = new GameObject(objectDefinition, Generals.Context, Generals.PlayerManager.GetPlayerByIndex(0));
+        var gameObject = new GameObject(objectDefinition, Generals.GameEngine, Generals.PlayerManager.GetPlayerByIndex(0));
         var moduleData = new JetAIUpdateModuleData();
-        var update = new JetAIUpdate(gameObject, Generals.Context, moduleData);
+        var update = new JetAIUpdate(gameObject, Generals.GameEngine, moduleData);
         Assert.NotNull(update);
     }
 }

--- a/src/OpenSage.Game.Tests/MockedGameTest.cs
+++ b/src/OpenSage.Game.Tests/MockedGameTest.cs
@@ -45,13 +45,13 @@ public abstract class MockedGameTest : IDisposable
         public bool InGame { get; }
         public AudioSystem Audio { get; }
         public SelectionSystem Selection { get; }
-        public GameContext Context { get; }
+        public GameEngine GameEngine { get; }
 
         public TestGame(SageGame game)
         {
             SageGame = game;
             AssetStore = new AssetStore(game, null, null, null, null, null, null, OnDemandAssetLoadStrategy.None);
-            Context = new GameContext(AssetStore.LoadContext, null, null, null, null, null, null, null, Scene3D, this);
+            GameEngine = new GameEngine(AssetStore.LoadContext, null, null, null, null, null, null, null, Scene3D, this);
 
             AssetStore.PushScope();
 

--- a/src/OpenSage.Game.Tests/RadarTests.cs
+++ b/src/OpenSage.Game.Tests/RadarTests.cs
@@ -227,7 +227,7 @@ public class RadarTests : StatePersisterTest
         {
             RadarPriority = RadarPriority.NotOnRadar,
         };
-        var gameObject = new GameObject(objectDefinition, Generals.Context, null);
+        var gameObject = new GameObject(objectDefinition, Generals.GameEngine, null);
         radar.AddGameObject(gameObject);
 
         Assert.False(radar.VisibleItems.TryGetValue(0, out _));
@@ -242,7 +242,7 @@ public class RadarTests : StatePersisterTest
         {
             RadarPriority = RadarPriority.Unit,
         };
-        var gameObject = new GameObject(objectDefinition, Generals.Context, null);
+        var gameObject = new GameObject(objectDefinition, Generals.GameEngine, null);
         radar.AddGameObject(gameObject);
 
         Assert.True(radar.VisibleItems.TryGetValue(0, out var radarItem));
@@ -258,7 +258,7 @@ public class RadarTests : StatePersisterTest
         {
             RadarPriority = RadarPriority.Unit,
         };
-        var gameObject = new GameObject(objectDefinition, Generals.Context, null);
+        var gameObject = new GameObject(objectDefinition, Generals.GameEngine, null);
 
         radar.AddGameObject(gameObject);
 

--- a/src/OpenSage.Game/Client/GameClient.cs
+++ b/src/OpenSage.Game/Client/GameClient.cs
@@ -23,7 +23,7 @@ internal sealed class GameClient : DisposableBase, IPersistableObject
 
     public Drawable CreateDrawable(ObjectDefinition objectDefinition, GameObject gameObject)
     {
-        var drawable = AddDisposable(new Drawable(objectDefinition, _game.Scene3D.GameContext, gameObject));
+        var drawable = AddDisposable(new Drawable(objectDefinition, _game.Scene3D.GameEngine, gameObject));
 
         drawable.ID = NextDrawableId++;
 

--- a/src/OpenSage.Game/Data/Ini/IniParser.cs
+++ b/src/OpenSage.Game/Data/Ini/IniParser.cs
@@ -457,19 +457,19 @@ internal sealed partial class IniParser
     public TimeSpan ParseTimeMilliseconds() => TimeSpan.FromMilliseconds(ParseFloat());
     public TimeSpan ParseTimeSeconds() => TimeSpan.FromSeconds(ParseInteger());
 
-    public LogicFrameSpan ParseTimeMillisecondsToLogicFrames() => new LogicFrameSpan((uint)MathF.Ceiling(ParseFloat() / Game.LogicUpdateInterval));
+    public LogicFrameSpan ParseTimeMillisecondsToLogicFrames() => new LogicFrameSpan((uint)MathF.Ceiling(ParseFloat() / GameEngine.LogicUpdateInterval));
 
-    public float ParseTimeMillisecondsToLogicFramesFloat() => ParseFloat() / Game.LogicUpdateInterval;
+    public float ParseTimeMillisecondsToLogicFramesFloat() => ParseFloat() / GameEngine.LogicUpdateInterval;
 
-    public LogicFrameSpan ParseTimeSecondsToLogicFrames() => new LogicFrameSpan((uint)MathF.Ceiling(ParseFloat() * Game.LogicFramesPerSecond));
+    public LogicFrameSpan ParseTimeSecondsToLogicFrames() => new LogicFrameSpan((uint)MathF.Ceiling(ParseFloat() * GameEngine.LogicFramesPerSecond));
 
-    public LogicFrameSpan ScanTimeMillisecondsToLogicFrames(in IniToken token) => new LogicFrameSpan((uint)MathF.Ceiling(ScanFloat(token) / Game.LogicUpdateInterval));
+    public LogicFrameSpan ScanTimeMillisecondsToLogicFrames(in IniToken token) => new LogicFrameSpan((uint)MathF.Ceiling(ScanFloat(token) / GameEngine.LogicUpdateInterval));
 
-    public float ParseAngularVelocityToLogicFrames() => ParseFloat() * MathUtility.DegreesToRadiansRatio / Game.LogicFramesPerSecond;
+    public float ParseAngularVelocityToLogicFrames() => ParseFloat() * MathUtility.DegreesToRadiansRatio / GameEngine.LogicFramesPerSecond;
 
-    public float ParseVelocityToLogicFrames() => ParseFloat() / Game.LogicFramesPerSecond;
+    public float ParseVelocityToLogicFrames() => ParseFloat() / GameEngine.LogicFramesPerSecond;
 
-    public float ParseAccelerationToLogicFrames() => ParseFloat() / (Game.LogicFramesPerSecond * Game.LogicFramesPerSecond);
+    public float ParseAccelerationToLogicFrames() => ParseFloat() / (GameEngine.LogicFramesPerSecond * GameEngine.LogicFramesPerSecond);
 
     public float ParseAngle() => ParseFloat() * MathUtility.DegreesToRadiansRatio;
 

--- a/src/OpenSage.Game/Diagnostics/AssetViews/FXListView.cs
+++ b/src/OpenSage.Game/Diagnostics/AssetViews/FXListView.cs
@@ -17,7 +17,7 @@ internal sealed class FXListView : AssetView
             new FXListExecutionContext(
                 Quaternion.Identity,
                 Vector3.Zero,
-                _renderedView.Scene.GameContext));
+                _renderedView.Scene.GameEngine));
     }
 
     public override void Draw()

--- a/src/OpenSage.Game/FX/FXList.cs
+++ b/src/OpenSage.Game/FX/FXList.cs
@@ -66,6 +66,6 @@ public sealed class FXList : BaseAsset
             new FXListExecutionContext(
                 context.GameObject.Rotation,
                 context.GameObject.Translation,
-                context.GameContext));
+                context.GameEngine));
     }
 }

--- a/src/OpenSage.Game/FX/FXListExecutionContext.cs
+++ b/src/OpenSage.Game/FX/FXListExecutionContext.cs
@@ -6,15 +6,15 @@ internal sealed class FXListExecutionContext
 {
     public readonly Quaternion Rotation;
     public readonly Vector3 Position;
-    public readonly GameContext GameContext;
+    public readonly GameEngine GameEngine;
 
     public FXListExecutionContext(
         in Quaternion rotation,
         in Vector3 position,
-        GameContext gameContext)
+        GameEngine gameEngine)
     {
         Rotation = rotation;
         Position = position;
-        GameContext = gameContext;
+        GameEngine = gameEngine;
     }
 }

--- a/src/OpenSage.Game/FX/FXNuggets/ParticleSystemFXNugget.cs
+++ b/src/OpenSage.Game/FX/FXNuggets/ParticleSystemFXNugget.cs
@@ -86,12 +86,12 @@ public sealed class ParticleSystemFXNugget : FXNugget
 
         if (CreateAtGroundHeight)
         {
-            position.Z = context.GameContext.Terrain.HeightMap.GetHeight(position.X, position.Y);
+            position.Z = context.GameEngine.Terrain.HeightMap.GetHeight(position.X, position.Y);
         }
 
         worldMatrix.Translation = position + Offset;
 
-        context.GameContext.ParticleSystems.Create(
+        context.GameEngine.ParticleSystems.Create(
             Template.Value,
             worldMatrix);
     }

--- a/src/OpenSage.Game/FX/FXNuggets/SoundFXNugget.cs
+++ b/src/OpenSage.Game/FX/FXNuggets/SoundFXNugget.cs
@@ -17,6 +17,6 @@ public sealed class SoundFXNugget : FXNugget
 
     internal override void Execute(FXListExecutionContext context)
     {
-        context.GameContext.AudioSystem.PlayAudioEvent(Value?.Value);
+        context.GameEngine.AudioSystem.PlayAudioEvent(Value?.Value);
     }
 }

--- a/src/OpenSage.Game/FX/FXNuggets/ViewShakeFXNugget.cs
+++ b/src/OpenSage.Game/FX/FXNuggets/ViewShakeFXNugget.cs
@@ -16,7 +16,7 @@ public sealed class ViewShakeFXNugget : FXNugget
 
     internal override void Execute(FXListExecutionContext context)
     {
-        var gameData = context.GameContext.AssetLoadContext.AssetStore.GameData.Current;
+        var gameData = context.GameEngine.AssetLoadContext.AssetStore.GameData.Current;
 
         var intensity = Math.Min(GetShakeIntensity(gameData), gameData.MaxShakeIntensity);
 

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -39,22 +39,6 @@ namespace OpenSage;
 
 public sealed class Game : DisposableBase, IGame
 {
-    static Game()
-    {
-        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-    }
-
-    // TODO: These should be configurable at runtime with GameSpeed.
-
-    public const float LogicFramesPerSecond = LogicFramesPerSecondN;
-    public const int LogicFramesPerSecondN = 30;
-    public const float SecondsPerLogicFrame = 1.0f / LogicFramesPerSecond;
-
-    // TODO: Revert this change. We haven't yet implemented interpolation between logic ticks,
-    // so as a temporary workaround, we simply tick the logic at 30fps.
-    //internal const double LogicUpdateInterval = 1000.0 / 5.0;
-    internal const float LogicUpdateInterval = 1000.0f / LogicFramesPerSecond;
-
     private readonly double _scriptingUpdateInterval;
 
     private readonly FileSystem _fileSystem;
@@ -815,7 +799,7 @@ public sealed class Game : DisposableBase, IGame
             LogicTick();
             CumulativeLogicUpdateError += (totalGameTime - _nextLogicUpdate);
             // Logic updates happen at 5Hz.
-            _nextLogicUpdate += TimeSpan.FromMilliseconds(LogicUpdateInterval);
+            _nextLogicUpdate += TimeSpan.FromMilliseconds(GameEngine.LogicUpdateInterval);
 
             if (_isStepping)
             {
@@ -854,7 +838,7 @@ public sealed class Game : DisposableBase, IGame
 
         // How close are we to the next logic frame?
         var tickT = (float)(1.0 - TimeSpanUtility.Max(_nextLogicUpdate - MapTime.TotalTime, TimeSpan.Zero)
-                                 .TotalMilliseconds / LogicUpdateInterval);
+                                 .TotalMilliseconds / GameEngine.LogicUpdateInterval);
 
         // We pass RenderTime to Scene2D so that the UI remains responsive even when the game is paused.
         Scene2D.LocalLogicTick(RenderTime, Scene3D?.LocalPlayer);
@@ -880,7 +864,7 @@ public sealed class Game : DisposableBase, IGame
         PartitionCellManager.Update();
     }
 
-    internal TimeInterval GetTimeInterval() => new TimeInterval(MapTime.TotalTime, TimeSpan.FromMilliseconds(LogicUpdateInterval));
+    internal TimeInterval GetTimeInterval() => new TimeInterval(MapTime.TotalTime, TimeSpan.FromMilliseconds(GameEngine.LogicUpdateInterval));
 
     public void ToggleLogicRunning()
     {

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -401,7 +401,7 @@ public sealed class Game : DisposableBase, IGame
 
     public PartitionCellManager PartitionCellManager { get; }
 
-    public GameContext Context => Scene3D.GameContext;
+    public GameEngine GameEngine => Scene3D.GameEngine;
 
     public Game(GameInstallation installation)
         : this(installation, null, new Configuration(), null)

--- a/src/OpenSage.Game/GameEngine.cs
+++ b/src/OpenSage.Game/GameEngine.cs
@@ -11,7 +11,7 @@ using OpenSage.Logic.Object;
 
 namespace OpenSage;
 
-public sealed class GameContext
+public sealed class GameEngine
 {
     internal readonly AssetLoadContext AssetLoadContext;
     public readonly AudioSystem AudioSystem;
@@ -43,10 +43,10 @@ public sealed class GameContext
 
     public readonly IQuadtree<GameObject> Quadtree;
 
-    // TODO: This is temporary until Scene3D and GameContext are merged.
+    // TODO: This is temporary until Scene3D and GameEngine are merged.
     public readonly Scene3D Scene3D;
 
-    internal GameContext(
+    internal GameEngine(
         AssetLoadContext assetLoadContext,
         AudioSystem audioSystem,
         ParticleSystemManager particleSystems,

--- a/src/OpenSage.Game/GameEngine.cs
+++ b/src/OpenSage.Game/GameEngine.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using OpenSage.Audio;
 using OpenSage.Client;
 using OpenSage.Content;
@@ -13,6 +14,22 @@ namespace OpenSage;
 
 public sealed class GameEngine
 {
+    static GameEngine()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
+
+    // TODO: These should be configurable at runtime with GameSpeed.
+
+    public const float LogicFramesPerSecond = LogicFramesPerSecondN;
+    public const int LogicFramesPerSecondN = 30;
+    public const float SecondsPerLogicFrame = 1.0f / LogicFramesPerSecond;
+
+    // TODO: Revert this change. We haven't yet implemented interpolation between logic ticks,
+    // so as a temporary workaround, we simply tick the logic at 30fps.
+    //internal const double LogicUpdateInterval = 1000.0 / 5.0;
+    internal const float LogicUpdateInterval = 1000.0f / LogicFramesPerSecond;
+
     internal readonly AssetLoadContext AssetLoadContext;
     public readonly AudioSystem AudioSystem;
     internal readonly ParticleSystemManager ParticleSystems;

--- a/src/OpenSage.Game/IGame.cs
+++ b/src/OpenSage.Game/IGame.cs
@@ -33,7 +33,7 @@ public interface IGame
     AudioSystem Audio { get; }
     public SelectionSystem Selection { get; }
     bool InGame { get; }
-    GameContext Context { get; }
+    GameEngine GameEngine { get; }
 
     void StartCampaign(string campaignName, string missionName);
     void StartSkirmishOrMultiPlayerGame(string mapFileName, IConnection connection, PlayerSetting[] playerSettings, int seed, bool isMultiPlayer);

--- a/src/OpenSage.Game/Logic/AI/AIStates/HackInternetAIUpdate/HackInternetState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/HackInternetAIUpdate/HackInternetState.cs
@@ -35,7 +35,7 @@ internal sealed class HackInternetState : State
         {
             SetFramesUntilNextHack(GameObject);
 
-            Context.AudioSystem.PlayAudioEvent(GameObject, GameObject.Definition.UnitSpecificSounds.UnitCashPing?.Value);
+            GameEngine.AudioSystem.PlayAudioEvent(GameObject, GameObject.Definition.UnitSpecificSounds.UnitCashPing?.Value);
 
             var amount = GetCashGrant(GameObject);
 

--- a/src/OpenSage.Game/Logic/AI/AIStates/HackInternetAIUpdate/StartHackingInternetState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/HackInternetAIUpdate/StartHackingInternetState.cs
@@ -23,9 +23,9 @@ internal sealed class StartHackingInternetState : State
         GameObject.ModelConditionFlags.Set(ModelConditionFlag.FiringA, false);
         GameObject.ModelConditionFlags.Set(ModelConditionFlag.Packing, false);
 
-        Context.AudioSystem.PlayAudioEvent(GameObject, GameObject.Definition.UnitSpecificSounds.UnitUnpack?.Value);
+        GameEngine.AudioSystem.PlayAudioEvent(GameObject, GameObject.Definition.UnitSpecificSounds.UnitUnpack?.Value);
 
-        var frames = _stateMachine.GetVariableFrames(_stateMachine.AIUpdate.ModuleData.UnpackTime, Context);
+        var frames = _stateMachine.GetVariableFrames(_stateMachine.AIUpdate.ModuleData.UnpackTime, GameEngine);
 
         GameObject.Drawable.SetAnimationDuration(frames);
 

--- a/src/OpenSage.Game/Logic/AI/AIStates/HackInternetAIUpdate/StopHackingInternetState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/HackInternetAIUpdate/StopHackingInternetState.cs
@@ -23,9 +23,9 @@ internal sealed class StopHackingInternetState : State
         GameObject.ModelConditionFlags.Set(ModelConditionFlag.FiringA, false);
         GameObject.ModelConditionFlags.Set(ModelConditionFlag.Packing, true);
 
-        Context.AudioSystem.PlayAudioEvent(GameObject, GameObject.Definition.UnitSpecificSounds.UnitPack?.Value);
+        GameEngine.AudioSystem.PlayAudioEvent(GameObject, GameObject.Definition.UnitSpecificSounds.UnitPack?.Value);
 
-        var frames = _stateMachine.GetVariableFrames(_stateMachine.AIUpdate.ModuleData.PackTime, Context);
+        var frames = _stateMachine.GetVariableFrames(_stateMachine.AIUpdate.ModuleData.PackTime, GameEngine);
 
         GameObject.Drawable.SetAnimationDuration(frames);
 

--- a/src/OpenSage.Game/Logic/AI/AIUpdateStateMachine.cs
+++ b/src/OpenSage.Game/Logic/AI/AIUpdateStateMachine.cs
@@ -14,7 +14,7 @@ internal class AIUpdateStateMachine : StateMachineBase
     private State _overrideState;
     private LogicFrame _overrideStateUntilFrame;
 
-    public AIUpdateStateMachine(GameObject gameObject, GameContext context, AIUpdate aiUpdate) : base(gameObject, context, aiUpdate)
+    public AIUpdateStateMachine(GameObject gameObject, GameEngine gameEngine, AIUpdate aiUpdate) : base(gameObject, gameEngine, aiUpdate)
     {
         AddState(IdleState.StateId, new IdleState(this));
         AddState(1, new MoveTowardsState(this));
@@ -54,7 +54,7 @@ internal class AIUpdateStateMachine : StateMachineBase
         {
             var overrideStateResult = _overrideState.Update();
 
-            var currentFrame = Context.GameLogic.CurrentFrame;
+            var currentFrame = GameEngine.GameLogic.CurrentFrame;
 
             var shouldContinueOverrideState = overrideStateResult.Type switch
             {

--- a/src/OpenSage.Game/Logic/AI/State.cs
+++ b/src/OpenSage.Game/Logic/AI/State.cs
@@ -9,7 +9,7 @@ internal abstract class State : IPersistableObject
     public uint Id { get; internal set; }
 
     private protected GameObject GameObject => _stateMachine.GameObject;
-    private protected GameContext Context => _stateMachine.Context;
+    private protected GameEngine GameEngine => _stateMachine.GameEngine;
 
     private readonly StateMachineBase _stateMachine;
 

--- a/src/OpenSage.Game/Logic/AI/StateMachineBase.cs
+++ b/src/OpenSage.Game/Logic/AI/StateMachineBase.cs
@@ -10,7 +10,7 @@ namespace OpenSage.Logic.AI;
 internal abstract class StateMachineBase : IPersistableObject
 {
     public GameObject GameObject { get; }
-    public GameContext Context { get; }
+    public GameEngine GameEngine { get; }
     public virtual AIUpdate AIUpdate { get; }
 
     private readonly Dictionary<uint, State> _states;
@@ -26,15 +26,15 @@ internal abstract class StateMachineBase : IPersistableObject
     private bool _unknownBool1;
     private bool _unknownBool2;
 
-    protected StateMachineBase(GameObject gameObject, GameContext context, AIUpdate aiUpdate)
+    protected StateMachineBase(GameObject gameObject, GameEngine gameEngine, AIUpdate aiUpdate)
     {
         GameObject = gameObject;
-        Context = context;
+        GameEngine = gameEngine;
         AIUpdate = aiUpdate;
         _states = new Dictionary<uint, State>();
     }
 
-    protected StateMachineBase(StateMachineBase parent) : this(parent.GameObject, parent.Context, parent.AIUpdate)
+    protected StateMachineBase(StateMachineBase parent) : this(parent.GameObject, parent.GameEngine, parent.AIUpdate)
     {
     }
 

--- a/src/OpenSage.Game/Logic/AI/SupplyAIUpdateStateMachine.cs
+++ b/src/OpenSage.Game/Logic/AI/SupplyAIUpdateStateMachine.cs
@@ -9,7 +9,7 @@ internal sealed class SupplyAIUpdateStateMachine : StateMachineBase
 {
     public override SupplyAIUpdate AIUpdate { get; }
 
-    public SupplyAIUpdateStateMachine(GameObject gameObject, GameContext context, SupplyAIUpdate aiUpdate) : base(gameObject, context, aiUpdate)
+    public SupplyAIUpdateStateMachine(GameObject gameObject, GameEngine gameEngine, SupplyAIUpdate aiUpdate) : base(gameObject, gameEngine, aiUpdate)
     {
         AIUpdate = aiUpdate;
 

--- a/src/OpenSage.Game/Logic/GameLogic.cs
+++ b/src/OpenSage.Game/Logic/GameLogic.cs
@@ -66,7 +66,7 @@ internal sealed class GameLogic : DisposableBase, IGameObjectCollection, IPersis
             return null;
         }
 
-        var gameObject = AddDisposable(new GameObject(objectDefinition, _game.Context, player));
+        var gameObject = AddDisposable(new GameObject(objectDefinition, _game.GameEngine, player));
 
         gameObject.ID = NextObjectId++;
 

--- a/src/OpenSage.Game/Logic/ModifierList.cs
+++ b/src/OpenSage.Game/Logic/ModifierList.cs
@@ -30,7 +30,7 @@ public class AttributeModifier
         _delayedUpgrades = new List<(UpgradeTemplate, TimeSpan)>();
     }
 
-    public void Apply(GameObject gameObject, GameContext context, in TimeInterval time)
+    public void Apply(GameObject gameObject, GameEngine gameEngine, in TimeInterval time)
     {
         if (_selfExpiring)
         {
@@ -68,9 +68,9 @@ public class AttributeModifier
             }
         }
 
-        TriggerFX(_modifierList.FX, gameObject, context);
-        TriggerFX(_modifierList.FX2, gameObject, context);
-        TriggerFX(_modifierList.FX3, gameObject, context);
+        TriggerFX(_modifierList.FX, gameObject, gameEngine);
+        TriggerFX(_modifierList.FX2, gameObject, gameEngine);
+        TriggerFX(_modifierList.FX3, gameObject, gameEngine);
 
         Applied = true;
     }
@@ -98,7 +98,7 @@ public class AttributeModifier
         }
     }
 
-    public void Remove(GameObject gameObject, GameContext context)
+    public void Remove(GameObject gameObject, GameEngine gameEngine)
     {
         foreach (var modifier in _modifierList.Modifiers)
         {
@@ -122,17 +122,17 @@ public class AttributeModifier
             }
         }
 
-        TriggerFX(_modifierList.EndFX, gameObject, context);
-        TriggerFX(_modifierList.EndFX2, gameObject, context);
-        TriggerFX(_modifierList.EndFX3, gameObject, context);
+        TriggerFX(_modifierList.EndFX, gameObject, gameEngine);
+        TriggerFX(_modifierList.EndFX2, gameObject, gameEngine);
+        TriggerFX(_modifierList.EndFX3, gameObject, gameEngine);
     }
 
-    private void TriggerFX(LazyAssetReference<FXList> fx, GameObject gameObject, GameContext context)
+    private void TriggerFX(LazyAssetReference<FXList> fx, GameObject gameObject, GameEngine gameEngine)
     {
         fx?.Value?.Execute(new FXListExecutionContext(
                 gameObject.Rotation,
                 gameObject.Translation,
-                context));
+                gameEngine));
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Animation.cs
+++ b/src/OpenSage.Game/Logic/Object/Animation.cs
@@ -23,7 +23,7 @@ public sealed class Animation : IPersistableObject
     public Animation(AnimationTemplate template)
     {
         Template = template;
-        _animationDelayFrames = (uint)Math.Round(template.AnimationDelay * (Game.LogicFramesPerSecond / 1000));
+        _animationDelayFrames = (uint)Math.Round(template.AnimationDelay * (GameEngine.LogicFramesPerSecond / 1000));
         _lastImageIndex = (ushort)(template.Images.Count - 1);
         AnimationType = AnimationNameToType(template.Name);
         if (template.AnimationMode is AnimationMode.LoopBackwards or AnimationMode.OnceBackwards)

--- a/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
+++ b/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
@@ -9,12 +9,12 @@ public abstract class ObjectModule : ModuleBase
 {
     protected GameObject GameObject { get; }
 
-    protected GameContext Context { get; }
+    protected GameEngine GameEngine { get; }
 
-    protected ObjectModule(GameObject gameObject, GameContext context)
+    protected ObjectModule(GameObject gameObject, GameEngine gameEngine)
     {
         GameObject = gameObject;
-        Context = context;
+        GameEngine = gameEngine;
     }
 
     internal override void Load(StatePersister reader)
@@ -29,8 +29,8 @@ public abstract class ObjectModule : ModuleBase
 
 public abstract class BehaviorModule : ObjectModule
 {
-    protected BehaviorModule(GameObject gameObject, GameContext context)
-        : base(gameObject, context)
+    protected BehaviorModule(GameObject gameObject, GameEngine gameEngine)
+        : base(gameObject, gameEngine)
     {
     }
 
@@ -55,16 +55,16 @@ public interface IDestroyModule
 
 internal sealed class BehaviorUpdateContext
 {
-    public readonly GameContext GameContext;
+    public readonly GameEngine GameEngine;
     public readonly GameObject GameObject;
 
-    public LogicFrame LogicFrame => GameContext.GameLogic.CurrentFrame;
+    public LogicFrame LogicFrame => GameEngine.GameLogic.CurrentFrame;
 
     public BehaviorUpdateContext(
-        GameContext gameContext,
+        GameEngine gameEngine,
         GameObject gameObject)
     {
-        GameContext = gameContext;
+        GameEngine = gameEngine;
         GameObject = gameObject;
     }
 }
@@ -614,5 +614,5 @@ public abstract class BehaviorModuleData : ModuleData
         { "WeaponSetUpgrade", WeaponSetUpgradeModuleData.Parse },
     };
 
-    internal virtual BehaviorModule CreateModule(GameObject gameObject, GameContext context) => null; // TODO: Make this abstract.
+    internal virtual BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine) => null; // TODO: Make this abstract.
 }

--- a/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
+++ b/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
@@ -142,7 +142,7 @@ public readonly struct LogicFrameSpan
 {
     public static readonly LogicFrameSpan Zero = new LogicFrameSpan(0);
 
-    public static readonly LogicFrameSpan OneSecond = new LogicFrameSpan((uint)Game.LogicFramesPerSecond);
+    public static readonly LogicFrameSpan OneSecond = new LogicFrameSpan((uint)GameEngine.LogicFramesPerSecond);
 
     internal readonly uint Value;
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/AutoHealBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/AutoHealBehavior.cs
@@ -17,8 +17,8 @@ public sealed class AutoHealBehavior : UpdateModule, IUpgradeableModule, IDamage
     /// </summary>
     private LogicFrame _endOfStartHealingDelay;
 
-    public AutoHealBehavior(GameObject gameObject, GameContext context, AutoHealBehaviorModuleData moduleData)
-        : base(gameObject, context)
+    public AutoHealBehavior(GameObject gameObject, GameEngine gameEngine, AutoHealBehaviorModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
         SetNextUpdateFrame(new LogicFrame(uint.MaxValue));
@@ -32,7 +32,7 @@ public sealed class AutoHealBehavior : UpdateModule, IUpgradeableModule, IDamage
     private void OnUpgrade()
     {
         // todo: if unit is max health and this is a self-heal behavior, even if upgrade was triggered, nextupdateframe is still maxvalue
-        SetNextUpdateFrame(Context.GameLogic.CurrentFrame);
+        SetNextUpdateFrame(GameEngine.GameLogic.CurrentFrame);
     }
 
     /// <summary>
@@ -44,7 +44,7 @@ public sealed class AutoHealBehavior : UpdateModule, IUpgradeableModule, IDamage
         // make sure the upgrade is triggered before resetting any frames
         if (_moduleData.StartHealingDelay != LogicFrameSpan.Zero && _upgradeLogic.Triggered)
         {
-            var currentFrame = Context.GameLogic.CurrentFrame;
+            var currentFrame = GameEngine.GameLogic.CurrentFrame;
             _endOfStartHealingDelay = currentFrame + _moduleData.StartHealingDelay;
             SetNextUpdateFrame(_endOfStartHealingDelay);
         }
@@ -62,7 +62,7 @@ public sealed class AutoHealBehavior : UpdateModule, IUpgradeableModule, IDamage
             if (_moduleData.AffectsWholePlayer)
             {
                 // USA hospital has this behavior
-                foreach (var candidate in Context.GameLogic.Objects)
+                foreach (var candidate in GameEngine.GameLogic.Objects)
                 {
                     if (ObjectIsOwnedBySamePlayer(candidate) && CanHealUnit(candidate))
                     {
@@ -80,7 +80,7 @@ public sealed class AutoHealBehavior : UpdateModule, IUpgradeableModule, IDamage
             return;
         }
 
-        foreach (var candidate in Context.Quadtree.FindNearby(GameObject, GameObject.Transform, _moduleData.Radius))
+        foreach (var candidate in GameEngine.Quadtree.FindNearby(GameObject, GameObject.Transform, _moduleData.Radius))
         {
             if (_moduleData.SkipSelfForHealing && candidate == GameObject) continue;
             if (!CanHealUnit(candidate)) continue;
@@ -254,8 +254,8 @@ public sealed class AutoHealBehaviorModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2Rotwk)]
     public bool HealOnlyIfNotUnderAttack { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new AutoHealBehavior(gameObject, context, this);
+        return new AutoHealBehavior(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BezierProjectileBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BezierProjectileBehavior.cs
@@ -19,8 +19,8 @@ public class BezierProjectileBehavior : UpdateModule
 
     internal FXList DetonationFX { get; set; }
 
-    internal BezierProjectileBehavior(GameObject gameObject, GameContext context, BezierProjectileBehaviorData moduleData)
-        : base(gameObject, context)
+    internal BezierProjectileBehavior(GameObject gameObject, GameEngine gameEngine, BezierProjectileBehaviorData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -63,7 +63,7 @@ public class BezierProjectileBehavior : UpdateModule
     {
         var translation = context.GameObject.Translation;
 
-        var terrainHeight = context.GameContext.Terrain.HeightMap.GetHeight(
+        var terrainHeight = context.GameEngine.Terrain.HeightMap.GetHeight(
             translation.X,
             translation.Y);
 
@@ -88,7 +88,7 @@ public class BezierProjectileBehavior : UpdateModule
             groundHitFX?.Execute(new FXListExecutionContext(
                 context.GameObject.Rotation,
                 context.GameObject.Translation,
-                context.GameContext));
+                context.GameEngine));
         }
 
         if (detonateCallsKill)
@@ -208,8 +208,8 @@ public class BezierProjectileBehaviorData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool PreLandingEmotionAffectsAllies { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new BezierProjectileBehavior(gameObject, context, this);
+        return new BezierProjectileBehavior(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BezierProjectileBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BezierProjectileBehavior.cs
@@ -36,7 +36,7 @@ public class BezierProjectileBehavior : UpdateModule
         var direction = Vector3.TransformNormal(Vector3.UnitX, context.GameObject.TransformMatrix);
         var velocity = direction * context.GameObject.Speed;
 
-        GameObject.SetTranslation(GameObject.Translation + velocity * ((float)Game.LogicUpdateInterval / 1000.0f));
+        GameObject.SetTranslation(GameObject.Translation + velocity * ((float)GameEngine.LogicUpdateInterval / 1000.0f));
 
         CheckForHit(
             context,

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BridgeBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BridgeBehavior.cs
@@ -7,7 +7,7 @@ public sealed class BridgeBehavior : UpdateModule
 {
     private readonly uint[] _towerIds = new uint[4];
 
-    public BridgeBehavior(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public BridgeBehavior(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -53,9 +53,9 @@ public sealed class BridgeBehaviorModuleData : BehaviorModuleData
     public List<BridgeDieObjectCreationList> BridgeDieOCLs { get; } = new List<BridgeDieObjectCreationList>();
     public List<BridgeDieFX> BridgeDieFXs { get; } = new List<BridgeDieFX>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new BridgeBehavior(gameObject, context);
+        return new BridgeBehavior(gameObject, gameEngine);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BridgeTowerBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BridgeTowerBehavior.cs
@@ -7,7 +7,7 @@ public sealed class BridgeTowerBehavior : BehaviorModule
     private int _unknown1;
     private int _unknown2;
 
-    public BridgeTowerBehavior(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public BridgeTowerBehavior(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -33,8 +33,8 @@ public sealed class BridgeTowerBehaviorModuleData : BehaviorModuleData
 
     private static readonly IniParseTable<BridgeTowerBehaviorModuleData> FieldParseTable = new IniParseTable<BridgeTowerBehaviorModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new BridgeTowerBehavior(gameObject, context);
+        return new BridgeTowerBehavior(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BuildingBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BuildingBehavior.cs
@@ -12,8 +12,8 @@ public class BuildingBehavior : UpdateModule
     private bool _fire;
     private bool _isGlowing;
 
-    internal BuildingBehavior(GameObject gameObject, GameContext context, BuildingBehaviorModuleData moduleData)
-        : base(gameObject, context)
+    internal BuildingBehavior(GameObject gameObject, GameEngine gameEngine, BuildingBehaviorModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
 
@@ -109,8 +109,8 @@ public sealed class BuildingBehaviorModuleData : BehaviorModuleData
     public string GlowWindowName { get; private set; }
     public List<string> FireNames { get; private set; } = new List<string>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new BuildingBehavior(gameObject, context, this);
+        return new BuildingBehavior(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
@@ -23,7 +23,7 @@ internal sealed class CastleBehavior : FoundationAIUpdate
     {
         IsUnpacked = false;
         _moduleData = moduleData;
-        _updateInterval = new LogicFrameSpan((uint)MathF.Ceiling(Game.LogicFramesPerSecond / 2)); // 0.5s
+        _updateInterval = new LogicFrameSpan((uint)MathF.Ceiling(GameEngine.LogicFramesPerSecond / 2)); // 0.5s
         _nativePlayer = gameObject.Owner;
     }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
@@ -11,24 +11,20 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class CastleBehavior : FoundationAIUpdate
 {
-    private GameObject _gameObject;
     private CastleBehaviorModuleData _moduleData;
-    private GameContext _context;
     private LogicFrame _waitUntil;
     private LogicFrameSpan _updateInterval;
     private Player _nativePlayer;
 
     public bool IsUnpacked { get; set; }
 
-    internal CastleBehavior(GameObject gameObject, GameContext context, CastleBehaviorModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal CastleBehavior(GameObject gameObject, GameEngine gameEngine, CastleBehaviorModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         IsUnpacked = false;
         _moduleData = moduleData;
-        _gameObject = gameObject;
-        _context = context;
         _updateInterval = new LogicFrameSpan((uint)MathF.Ceiling(Game.LogicFramesPerSecond / 2)); // 0.5s
-        _nativePlayer = _gameObject.Owner;
+        _nativePlayer = gameObject.Owner;
     }
 
     public float GetUnpackCost(Player player)
@@ -44,8 +40,8 @@ internal sealed class CastleBehavior : FoundationAIUpdate
             return;
         }
 
-        _gameObject.Hidden = true;
-        _gameObject.IsSelectable = false;
+        GameObject.Hidden = true;
+        GameObject.IsSelectable = false;
 
         var castleEntry = FindCastle(player.Template.Side);
 
@@ -53,7 +49,7 @@ internal sealed class CastleBehavior : FoundationAIUpdate
         {
             var basePath = $"bases\\{castleEntry.Camp}\\{castleEntry.Camp}.bse";
 
-            var entry = _context.AssetLoadContext.FileSystem.GetFile(basePath);
+            var entry = GameEngine.AssetLoadContext.FileSystem.GetFile(basePath);
             var mapFile = MapFile.FromFileSystemEntry(entry);
             var mapObjects = mapFile.ObjectsList.Objects.ToList();
 
@@ -61,14 +57,14 @@ internal sealed class CastleBehavior : FoundationAIUpdate
             {
                 var mapObject = mapObjects.Find(x => x.TypeName == castleTemplate.TemplateName);
 
-                var viewAngle = MathUtility.ToRadians(_gameObject.Definition.PlacementViewAngle);
+                var viewAngle = MathUtility.ToRadians(GameObject.Definition.PlacementViewAngle);
 
                 var offset = Vector4.Transform(new Vector4(castleTemplate.Offset.X, castleTemplate.Offset.Y, 0.0f, 1.0f), Quaternion.CreateFromAxisAngle(Vector3.UnitZ, viewAngle)).ToVector3();
 
                 var angle = viewAngle + castleTemplate.Angle;
-                mapObject.Position = new Vector3(_gameObject.Translation.X, _gameObject.Translation.Y, 0.0f) + offset;
+                mapObject.Position = new Vector3(GameObject.Translation.X, GameObject.Translation.Y, 0.0f) + offset;
 
-                var baseObject = GameObject.FromMapObject(mapObject, _context, false, angle);
+                var baseObject = GameObject.FromMapObject(mapObject, GameEngine, false, angle);
 
                 if (!instant)
                 {
@@ -91,40 +87,40 @@ internal sealed class CastleBehavior : FoundationAIUpdate
         if (IsUnpacked)
         {
             // not sure if this is correct, or does any object with BASE_FOUNDATION or BASE_SITE automatically get a FoundationAIUpdate?
-            FoundationAIUpdate.CheckForStructure(context, _gameObject, ref _waitUntil, _updateInterval);
+            FoundationAIUpdate.CheckForStructure(context, GameObject, ref _waitUntil, _updateInterval);
             return;
         }
 
         // TODO: Figure out the other unpack conditions
         if (_moduleData.InstantUnpack)
         {
-            Unpack(_gameObject.Owner, instant: true);
+            Unpack(GameObject.Owner, instant: true);
         }
 
-        var nearbyUnits = context.GameContext.Game.PartitionCellManager.QueryObjects(
-            _gameObject,
-            _gameObject.Translation,
+        var nearbyUnits = context.GameEngine.Game.PartitionCellManager.QueryObjects(
+            GameObject,
+            GameObject.Translation,
             _moduleData.ScanDistance,
             new PartitionQueries.TrueQuery());
 
         if (!nearbyUnits.Any())
         {
-            _gameObject.Owner = _nativePlayer;
+            GameObject.Owner = _nativePlayer;
             return;
         }
 
         // TODO: check if all nearby units are from the same owner
         foreach (var unit in nearbyUnits)
         {
-            if (unit == _gameObject)
+            if (unit == GameObject)
             {
                 continue;
             }
 
-            var distance = (unit.Translation - _gameObject.Translation).Length();
+            var distance = (unit.Translation - GameObject.Translation).Length();
             if (distance < _moduleData.ScanDistance)
             {
-                _gameObject.Owner = unit.Owner;
+                GameObject.Owner = unit.Owner;
                 return;
             }
         }
@@ -215,9 +211,9 @@ public class CastleBehaviorModuleData : FoundationAIUpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool Summoned { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new CastleBehavior(gameObject, context, this);
+        return new CastleBehavior(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDamagedBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDamagedBehavior.cs
@@ -25,8 +25,8 @@ public sealed class FireWeaponWhenDamagedBehavior : UpdateModule, IUpgradeableMo
 
     internal UpgradeLogic UpgradeLogic { get; }
 
-    public FireWeaponWhenDamagedBehavior(GameObject gameObject, GameContext context, FireWeaponWhenDamagedBehaviorModuleData moduleData)
-        : base(gameObject, context)
+    public FireWeaponWhenDamagedBehavior(GameObject gameObject, GameEngine gameEngine, FireWeaponWhenDamagedBehaviorModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
 
@@ -56,7 +56,7 @@ public sealed class FireWeaponWhenDamagedBehavior : UpdateModule, IUpgradeableMo
             GameObject,
             weaponTemplate,
             WeaponSlot.Primary,
-            Context);
+            GameEngine);
     }
 
     public bool CanUpgrade(UpgradeSet existingUpgrades) => UpgradeLogic.CanUpgrade(existingUpgrades);
@@ -177,8 +177,8 @@ public sealed class FireWeaponWhenDamagedBehaviorModuleData : UpgradeModuleData
     /// </summary>
     public float DamageAmount { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new FireWeaponWhenDamagedBehavior(gameObject, context, this);
+        return new FireWeaponWhenDamagedBehavior(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDeadBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDeadBehavior.cs
@@ -13,8 +13,8 @@ public sealed class FireWeaponWhenDeadBehavior : BehaviorModule, IUpgradeableMod
 
     internal UpgradeLogic UpgradeLogic { get; }
 
-    internal FireWeaponWhenDeadBehavior(GameObject gameObject, GameContext context, FireWeaponWhenDeadBehaviorModuleData moduleData)
-        : base(gameObject, context)
+    internal FireWeaponWhenDeadBehavior(GameObject gameObject, GameEngine gameEngine, FireWeaponWhenDeadBehaviorModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
         UpgradeLogic = new UpgradeLogic(moduleData.UpgradeData, OnUpgrade);
@@ -48,7 +48,7 @@ public sealed class FireWeaponWhenDeadBehavior : BehaviorModule, IUpgradeableMod
                 GameObject,
                 deathWeaponTemplate,
                 WeaponSlot.Primary,
-                Context);
+                GameEngine);
 
             deathWeapon.SetTarget(new WeaponTarget(GameObject.Translation));
             deathWeapon.Fire();
@@ -90,8 +90,8 @@ public sealed class FireWeaponWhenDeadBehaviorModuleData : UpgradeModuleData
     [AddedIn(SageGame.Bfme)]
     public Vector3 WeaponOffset { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new FireWeaponWhenDeadBehavior(gameObject, context, this);
+        return new FireWeaponWhenDeadBehavior(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/GateOpenAndCloseBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/GateOpenAndCloseBehavior.cs
@@ -26,8 +26,8 @@ public class GateOpenAndCloseBehavior : UpdateModule
     private AudioSource _openingSoundLoop;
     private AudioSource _closingSoundLoop;
 
-    internal GateOpenAndCloseBehavior(GameObject gameObject, GameContext context, GateOpenAndCloseBehaviorModuleData moduleData)
-        : base(gameObject, context)
+    internal GateOpenAndCloseBehavior(GameObject gameObject, GameEngine gameEngine, GateOpenAndCloseBehaviorModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
 
@@ -55,7 +55,7 @@ public class GateOpenAndCloseBehavior : UpdateModule
 
     internal override void Update(BehaviorUpdateContext context)
     {
-        var audioSystem = context.GameContext.AudioSystem;
+        var audioSystem = context.GameEngine.AudioSystem;
 
         switch (_state)
         {
@@ -183,8 +183,8 @@ public sealed class GateOpenAndCloseBehaviorModuleData : BehaviorModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool RepelCollidingUnits { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new GateOpenAndCloseBehavior(gameObject, context, this);
+        return new GateOpenAndCloseBehavior(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/HelicopterSlowDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/HelicopterSlowDeathBehavior.cs
@@ -5,8 +5,8 @@ namespace OpenSage.Logic.Object;
 
 public sealed class HelicopterSlowDeathBehavior : SlowDeathBehavior
 {
-    internal HelicopterSlowDeathBehavior(GameObject gameObject, GameContext context, HelicopterSlowDeathBehaviorModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal HelicopterSlowDeathBehavior(GameObject gameObject, GameEngine gameEngine, HelicopterSlowDeathBehaviorModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -89,8 +89,8 @@ public sealed class HelicopterSlowDeathBehaviorModuleData : SlowDeathBehaviorMod
     public int DelayFromGroundToFinalDeath { get; private set; }
     public string FinalRubbleObject { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new HelicopterSlowDeathBehavior(gameObject, context, this);
+        return new HelicopterSlowDeathBehavior(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/InstantDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/InstantDeathBehavior.cs
@@ -9,22 +9,22 @@ public sealed class InstantDeathBehavior : DieModule
 {
     private readonly InstantDeathBehaviorModuleData _moduleData;
 
-    internal InstantDeathBehavior(GameObject gameObject, GameContext context, InstantDeathBehaviorModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal InstantDeathBehavior(GameObject gameObject, GameEngine gameEngine, InstantDeathBehaviorModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
 
     private protected override void Die(BehaviorUpdateContext context, DeathType deathType)
     {
-        Context.GameLogic.DestroyObject(GameObject);
+        GameEngine.GameLogic.DestroyObject(GameObject);
 
         Matrix4x4.Decompose(context.GameObject.TransformMatrix, out _, out var rotation, out var translation);
 
         _moduleData.FX?.Value?.Execute(new FXListExecutionContext(
             rotation,
             translation,
-            context.GameContext));
+            context.GameEngine));
     }
 
     internal override void Load(StatePersister reader)
@@ -51,8 +51,8 @@ public sealed class InstantDeathBehaviorModuleData : DieModuleData
     public LazyAssetReference<FXList> FX { get; private set; }
     public string OCL { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new InstantDeathBehavior(gameObject, context, this);
+        return new InstantDeathBehavior(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/MinefieldBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/MinefieldBehavior.cs
@@ -8,7 +8,7 @@ public sealed class MinefieldBehavior : UpdateModule
     private uint _numVirtualMachines;
     private uint _unknownFrame;
 
-    public MinefieldBehavior(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public MinefieldBehavior(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -72,9 +72,9 @@ public sealed class MinefieldBehaviorModuleData : BehaviorModuleData
     public bool StopsRegenAfterCreatorDies { get; private set; }
     public Percentage DegenPercentPerSecondAfterCreatorDies { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new MinefieldBehavior(gameObject, context);
+        return new MinefieldBehavior(gameObject, gameEngine);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
@@ -11,8 +11,8 @@ public sealed class OverchargeBehavior : UpdateModule
     private bool _enabled;
     public bool Enabled => _enabled;
 
-    public OverchargeBehavior(GameObject gameObject, GameContext context, OverchargeBehaviorModuleData moduleData)
-        : base(gameObject, context)
+    public OverchargeBehavior(GameObject gameObject, GameEngine gameEngine, OverchargeBehaviorModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -28,7 +28,7 @@ public sealed class OverchargeBehavior : UpdateModule
         }
 
         // todo: this is fine for now, but generals seems to have some way of making sure it doesn't immediately sap health on subsequent toggles
-        SetNextUpdateFrame(Context.GameLogic.CurrentFrame);
+        SetNextUpdateFrame(GameEngine.GameLogic.CurrentFrame);
     }
 
     public void Deactivate()
@@ -99,8 +99,8 @@ public sealed class OverchargeBehaviorModuleData : UpdateModuleData
     /// </summary>
     public Percentage NotAllowedWhenHealthBelowPercent { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new OverchargeBehavior(gameObject, context, this);
+        return new OverchargeBehavior(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
@@ -53,7 +53,7 @@ public sealed class OverchargeBehavior : UpdateModule
         }
 
         GameObject.DoDamage(DamageType.Penalty, _moduleData.HealthPercentToDrainPerSecond, DeathType.Normal, GameObject);
-        SetNextUpdateFrame(new LogicFrame((uint)Game.LogicFramesPerSecond));
+        SetNextUpdateFrame(new LogicFrame((uint)GameEngine.LogicFramesPerSecond));
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Behaviors/ParkingPlaceBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/ParkingPlaceBehavior.cs
@@ -28,8 +28,8 @@ public sealed class ParkingPlaceBehaviour : UpdateModule, IHasRallyPoint, IProdu
     private const int HealsPerSecond = 5; // not sure if this is configured anywhere
     private static readonly LogicFrameSpan HealUpdateRate = new((uint)(Game.LogicFramesPerSecond / HealsPerSecond));
 
-    internal ParkingPlaceBehaviour(GameObject gameObject, GameContext context, ParkingPlaceBehaviorModuleData moduleData)
-        : base(gameObject, context)
+    internal ParkingPlaceBehaviour(GameObject gameObject, GameEngine gameEngine, ParkingPlaceBehaviorModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
 
@@ -89,7 +89,7 @@ public sealed class ParkingPlaceBehaviour : UpdateModule, IHasRallyPoint, IProdu
                 _nextHealFrame += HealUpdateRate;
                 foreach (var objectToHeal in _healingData)
                 {
-                    var gameObject = Context.GameLogic.GetObjectById(objectToHeal.ObjectId);
+                    var gameObject = GameEngine.GameLogic.GetObjectById(objectToHeal.ObjectId);
                     gameObject?.Heal(_healAmountPerHealTick, GameObject);
                 }
             }
@@ -714,8 +714,8 @@ public sealed class ParkingPlaceBehaviorModuleData : UpdateModuleData
     public int ApproachHeight { get; private set; }
     public bool ParkInHangars { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new ParkingPlaceBehaviour(gameObject, context, this);
+        return new ParkingPlaceBehaviour(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/ParkingPlaceBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/ParkingPlaceBehavior.cs
@@ -26,7 +26,7 @@ public sealed class ParkingPlaceBehaviour : UpdateModule, IHasRallyPoint, IProdu
     private LogicFrame _nextHealFrame = NoHealingFrame;
     private readonly Fix64 _healAmountPerHealTick;
     private const int HealsPerSecond = 5; // not sure if this is configured anywhere
-    private static readonly LogicFrameSpan HealUpdateRate = new((uint)(Game.LogicFramesPerSecond / HealsPerSecond));
+    private static readonly LogicFrameSpan HealUpdateRate = new((uint)(GameEngine.LogicFramesPerSecond / HealsPerSecond));
 
     internal ParkingPlaceBehaviour(GameObject gameObject, GameEngine gameEngine, ParkingPlaceBehaviorModuleData moduleData)
         : base(gameObject, gameEngine)

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PassiveAreaEffectBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PassiveAreaEffectBehavior.cs
@@ -12,8 +12,8 @@ public class PassiveAreaEffectBehavior : UpdateModule
     private readonly PassiveAreaEffectBehaviorModuleData _moduleData;
     private LogicFrame _nextPing;
 
-    public PassiveAreaEffectBehavior(GameObject gameObject, GameContext context, PassiveAreaEffectBehaviorModuleData moduleData)
-        : base(gameObject, context)
+    public PassiveAreaEffectBehavior(GameObject gameObject, GameEngine gameEngine, PassiveAreaEffectBehaviorModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -26,7 +26,7 @@ public class PassiveAreaEffectBehavior : UpdateModule
         }
         _nextPing = context.LogicFrame + _moduleData.PingDelay;
 
-        var nearbyObjects = context.GameContext.Game.PartitionCellManager.QueryObjects(
+        var nearbyObjects = context.GameEngine.Game.PartitionCellManager.QueryObjects(
             GameObject,
             GameObject.Translation,
             _moduleData.EffectRadius,
@@ -80,8 +80,8 @@ public sealed class PassiveAreaEffectBehaviorModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public BitArray<ModifierCategory> AntiCategories { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new PassiveAreaEffectBehavior(gameObject, context, this);
+        return new PassiveAreaEffectBehavior(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
@@ -20,7 +20,7 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
 
     private const float InvalidVelocityMagnitude = -1.0f;
 
-    private const int MotiveFrames = (int)Game.LogicFramesPerSecond / 3;
+    private const int MotiveFrames = (int)GameEngine.LogicFramesPerSecond / 3;
 
     private readonly PhysicsBehaviorModuleData _moduleData;
 
@@ -1659,7 +1659,7 @@ public class PhysicsBehaviorModuleData : UpdateModuleData
     private static float ParseFrictionPerSec(IniParser parser)
     {
         var frictionPerSecond = parser.ParseFloat();
-        var frictionPerFrame = frictionPerSecond * Game.SecondsPerLogicFrame;
+        var frictionPerFrame = frictionPerSecond * GameEngine.SecondsPerLogicFrame;
         return frictionPerFrame;
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
@@ -22,8 +22,6 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
 
     private const int MotiveFrames = (int)Game.LogicFramesPerSecond / 3;
 
-    private readonly GameObject _gameObject;
-    private readonly GameContext _context;
     private readonly PhysicsBehaviorModuleData _moduleData;
 
     private readonly float _gravity;
@@ -59,7 +57,7 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
 
     public float CenterOfMassOffset => _moduleData.CenterOfMassOffset;
 
-    public bool IsMotive => _motiveForceExpires > _context.GameLogic.CurrentFrame;
+    public bool IsMotive => _motiveForceExpires > GameEngine.GameLogic.CurrentFrame;
 
     public bool IsStunned => GetFlag(PhysicsFlagType.IsStunned);
 
@@ -69,9 +67,9 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
         {
             var result = _mass;
 
-            if (_gameObject.Contain != null)
+            if (GameObject.Contain != null)
             {
-                result += _gameObject.Contain.GetContainedItemsMass();
+                result += GameObject.Contain.GetContainedItemsMass();
             }
 
             return result;
@@ -157,11 +155,9 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
         set => SetFlag(PhysicsFlagType.ApplyFriction2DWhenAirborne, value);
     }
 
-    internal PhysicsBehavior(GameObject gameObject, GameContext context, PhysicsBehaviorModuleData moduleData)
-        : base(gameObject, context)
+    internal PhysicsBehavior(GameObject gameObject, GameEngine gameEngine, PhysicsBehaviorModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
-        _gameObject = gameObject;
-        _context = context;
         _moduleData = moduleData;
 
         Mass = moduleData.Mass;
@@ -171,7 +167,7 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
 
         SetWakeFrame(UpdateSleepTime.None);
 
-        _gravity = context.AssetStore.GameData.Current.Gravity * moduleData.GravityMult;
+        _gravity = gameEngine.AssetStore.GameData.Current.Gravity * moduleData.GravityMult;
 
         _aerodynamicFriction = Math.Clamp(moduleData.AerodynamicFriction, MinAeroFriction, MaxFriction);
         _forwardFriction = Math.Clamp(moduleData.ForwardFriction, MinNonAeroFriction, MaxFriction);
@@ -181,7 +177,7 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
 
     protected internal override void OnObjectCreated()
     {
-        _projectileUpdate = _gameObject.FindBehavior<IProjectileUpdate>();
+        _projectileUpdate = GameObject.FindBehavior<IProjectileUpdate>();
     }
 
     public void SetAllowBouncing(bool allow) => SetFlag(PhysicsFlagType.AllowBounce, allow);
@@ -225,9 +221,9 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
     /// </summary>
     public override UpdateSleepTime Update()
     {
-        var obj = _gameObject;
+        var obj = GameObject;
         var d = _moduleData;
-        var airborneAtStart = _gameObject.IsAboveTerrain;
+        var airborneAtStart = GameObject.IsAboveTerrain;
         var activeVelocityZ = 0.0f;
         var bounceForce = Vector3.Zero;
         var gotBounceForce = false;
@@ -242,12 +238,12 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
             SetFlag(PhysicsFlagType.WasAirborneLastFrame, airborneAtStart);
         }
 
-        var prevPos = _gameObject.Translation;
+        var prevPos = GameObject.Translation;
         _previousAcceleration = _acceleration;
 
-        if (!_gameObject.IsDisabledByType(DisabledType.Held))
+        if (!GameObject.IsDisabledByType(DisabledType.Held))
         {
-            var mtx = _gameObject.TransformMatrix;
+            var mtx = GameObject.TransformMatrix;
 
             ApplyGravitationalForces();
             ApplyFrictionalForces();
@@ -275,10 +271,10 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
             var oldPosZ = mtx.Translation.Z;
 
             // Integrate velocity into position.
-            if (_gameObject.TestStatus(ObjectStatus.IsBraking))
+            if (GameObject.TestStatus(ObjectStatus.IsBraking))
             {
                 // Don't update position if the locomotor is braking.
-                if (!_gameObject.IsKindOf(ObjectKinds.Projectile))
+                if (!GameObject.IsKindOf(ObjectKinds.Projectile))
                 {
                     // Things other than projectiles don't cheat in z.
                     var translation = mtx.Translation;
@@ -294,7 +290,7 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
             if (Vector3Utility.IsNaN(mtx.Translation))
             {
                 Debug.Fail("Object position is NaN");
-                _context.GameLogic.DestroyObject(obj);
+                GameEngine.GameLogic.DestroyObject(obj);
             }
 
             // Check when to clear the stunned status.
@@ -363,7 +359,7 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
             }
 
             // Do not allow object to pass through the ground.
-            var groundZ = _context.Game.TerrainLogic.GetLayerHeight(
+            var groundZ = GameEngine.Game.TerrainLogic.GetLayerHeight(
                 mtx.GetXTranslation(),
                 mtx.GetYTranslation(),
                 obj.Layer);
@@ -420,11 +416,11 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
             if (gotBounceForce)
             {
                 // Right the object after the bounce since the pitch and roll may have been affected.
-                var yawAngle = _gameObject.TransformMatrix.GetZRotation();
+                var yawAngle = GameObject.TransformMatrix.GetZRotation();
                 SetAngles(yawAngle, 0.0f, 0.0f);
 
                 // Set the translation of the after bounce matrix to the one calculated above.
-                var afterBounceMatrix = _gameObject.TransformMatrix;
+                var afterBounceMatrix = GameObject.TransformMatrix;
                 afterBounceMatrix.Translation = mtx.Translation;
 
                 // Set the result of the after bounce matrix as the object's final matrix.
@@ -550,7 +546,7 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
         var modForce = force;
         if (IsMotive)
         {
-            var dir = _gameObject.UnitDirectionVector2D;
+            var dir = GameObject.UnitDirectionVector2D;
             // Only accept the lateral acceleration.
             var lateralDot = (force.X * -dir.Y) + (force.Y * dir.X);
             modForce.X = lateralDot * -dir.Y;
@@ -603,13 +599,13 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
         // Set bounce to true for a while until the unit is complete bouncing.
         SetAllowBouncing(true);
 
-        var randomModifier = _context.Random.NextSingle(-1.0f, 1.0f);
+        var randomModifier = GameEngine.Random.NextSingle(-1.0f, 1.0f);
         _yawRate += _moduleData.ShockMaxYaw * randomModifier;
 
-        randomModifier = _context.Random.NextSingle(-1.0f, 1.0f);
+        randomModifier = GameEngine.Random.NextSingle(-1.0f, 1.0f);
         _pitchRate += _moduleData.ShockMaxPitch * randomModifier;
 
-        randomModifier = _context.Random.NextSingle(-1.0f, 1.0f);
+        randomModifier = GameEngine.Random.NextSingle(-1.0f, 1.0f);
         _rollRate += _moduleData.ShockMaxRoll * randomModifier;
 
         MaybeWakeUp();
@@ -620,7 +616,7 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
         // Make it accept this force unquestioningly.
         _motiveForceExpires = new LogicFrame(0);
         ApplyForce(force);
-        _motiveForceExpires = _context.GameLogic.CurrentFrame + new LogicFrameSpan(MotiveFrames);
+        _motiveForceExpires = GameEngine.GameLogic.CurrentFrame + new LogicFrameSpan(MotiveFrames);
     }
 
     public void ResetDynamicPhysics()
@@ -650,18 +646,18 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
     {
         // Are we a plane that is taxiing on a deck with a height offset?
         // This deckTaxiing thing is new in Zero Hour, but it's backwards-compatible with Generals.
-        var deckTaxiing = _gameObject.TestStatus(ObjectStatus.DeckHeightOffset)
-            && _gameObject.AIUpdate?.CurrentLocomotorSetType == LocomotorSetType.Taxiing;
+        var deckTaxiing = GameObject.TestStatus(ObjectStatus.DeckHeightOffset)
+            && GameObject.AIUpdate?.CurrentLocomotorSetType == LocomotorSetType.Taxiing;
 
         if (GetFlag(PhysicsFlagType.ApplyFriction2DWhenAirborne)
-            || !_gameObject.IsSignificantlyAboveTerrain
+            || !GameObject.IsSignificantlyAboveTerrain
             || deckTaxiing)
         {
             ApplyYawPitchRollDamping(1.0f - PhysicsBehaviorModuleData.DefaultLateralFriction);
 
             if (_velocity.X != 0.0f || _velocity.Y != 0.0f)
             {
-                var dir = _gameObject.UnitDirectionVector2D;
+                var dir = GameObject.UnitDirectionVector2D;
                 var mass = Mass;
 
                 var lateralDot = (_velocity.X * -dir.Y) + (_velocity.Y * dir.X);
@@ -708,7 +704,7 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
             const float maxStiffness = 0.99f;
 
             var stiffness = Math.Clamp(
-                Context.AssetStore.GameData.Current.GroundStiffness,
+                base.GameEngine.AssetStore.GameData.Current.GroundStiffness,
                 minStiffness,
                 maxStiffness);
 
@@ -727,15 +723,15 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
             if (velocityZ < 0.0f)
             {
                 // TODO: Check that "Up" is correct here.
-                var zVec = _gameObject.TransformMatrix.GetZVector();
+                var zVec = GameObject.TransformMatrix.GetZVector();
                 var rollAngle = zVec.Z > 0 ? 0 : MathF.PI;
                 // Don't flip both pitch and roll... we'll "flip" twice.
                 var pitchAngle = 0.0f;
-                var yawAngle = _gameObject.Transform.Yaw;
+                var yawAngle = GameObject.Transform.Yaw;
                 SetAngles(yawAngle, pitchAngle, rollAngle);
             }
 
-            if (_context.Game.SageGame == SageGame.CncGenerals)
+            if (GameEngine.Game.SageGame == SageGame.CncGenerals)
             {
                 return true;
             }
@@ -775,10 +771,10 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
         }
 
         // Grab the object.
-        var obj = _gameObject;
+        var obj = GameObject;
 
         // If a stunned object is upside down when it hits the ground, kill it.
-        if (_gameObject.TransformMatrix.GetZVector().Z < 0.0f)
+        if (GameObject.TransformMatrix.GetZVector().Z < 0.0f)
         {
             obj.Kill();
             return;
@@ -798,10 +794,10 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
             return;
         }
 
-        var pos = _gameObject.Translation;
+        var pos = GameObject.Translation;
 
         // Check for object being stuck on cliffs. If so, kill it.
-        if (_context.Game.TerrainLogic.IsCliffCell(pos.X, pos.Y)
+        if (GameEngine.Game.TerrainLogic.IsCliffCell(pos.X, pos.Y)
             && !ai.HasLocomotorForSurface(Surfaces.Cliff))
         {
             obj.Kill();
@@ -809,7 +805,7 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
         }
 
         // Check for object being stuck on water. If so, kill it.
-        if (_context.Game.TerrainLogic.IsUnderwater(pos.X, pos.Y, out var _)
+        if (GameEngine.Game.TerrainLogic.IsUnderwater(pos.X, pos.Y, out var _)
             && !ai.HasLocomotorForSurface(Surfaces.Water))
         {
             obj.Kill();
@@ -849,14 +845,14 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
 
     public void SetAngles(float yaw, float pitch, float roll)
     {
-        var pos = _gameObject.Translation;
+        var pos = GameObject.Translation;
 
         // TODO(Port): Check if this is correct.
         var transform = Matrix4x4.CreateFromYawPitchRoll(yaw, pitch, roll);
 
         transform.Translation = pos;
 
-        _gameObject.SetTransformMatrix(transform);
+        GameObject.SetTransformMatrix(transform);
     }
 
     private void DoBounceSound(in Vector3 prevPos)
@@ -876,8 +872,8 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
             && _acceleration == Vector3.Zero
             && !GetFlag(PhysicsFlagType.HasPitchRollYaw)
             && !IsMotive
-            && _gameObject.Layer == PathfindLayerType.Ground
-            && !_gameObject.IsAboveTerrain
+            && GameObject.Layer == PathfindLayerType.Ground
+            && !GameObject.IsAboveTerrain
             && _currentOverlap == 0
             && _previousOverlap == 0
             && GetFlag(PhysicsFlagType.UpdateEverRun))
@@ -912,7 +908,7 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
             }
         }
 
-        var obj = _gameObject;
+        var obj = GameObject;
         var objContainedBy = obj.ContainedBy;
 
         // Note that other == null means "collide with ground".
@@ -964,9 +960,9 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
                 // In order to make things easier for the designers, we are going
                 // to transfer the name of the infantry to the vehicle... so the
                 // designer can control the vehicle with their scripts.
-                _context.Game.Scripting.TransferObjectName(obj.Name, other);
+                GameEngine.Game.Scripting.TransferObjectName(obj.Name, other);
 
-                _context.GameLogic.DestroyObject(obj);
+                GameEngine.GameLogic.DestroyObject(obj);
             }
             return;
         }
@@ -1033,7 +1029,7 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
             return false;
         }
 
-        var crusherMe = _gameObject;
+        var crusherMe = GameObject;
         var crusheeOther = other;
 
         // Determine if we can crush the other object.
@@ -1376,7 +1372,7 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
     /// </summary>
     public float GetForwardSpeed2D()
     {
-        var dir = _gameObject.UnitDirectionVector2D;
+        var dir = GameObject.UnitDirectionVector2D;
 
         var vx = _velocity.X * dir.X;
         var vy = _velocity.Y * dir.Y;
@@ -1399,7 +1395,7 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
     /// </summary>
     public float GetForwardSpeed3D()
     {
-        var dir = _gameObject.TransformMatrix.GetXVector();
+        var dir = GameObject.TransformMatrix.GetXVector();
 
         var vx = _velocity.X * dir.X;
         var vy = _velocity.Y * dir.Y;
@@ -1644,9 +1640,9 @@ public class PhysicsBehaviorModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme)]
     public int SecondHeight { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new PhysicsBehavior(gameObject, context, this);
+        return new PhysicsBehavior(gameObject, gameEngine, this);
     }
 
     private static float HeightToSpeed(IniParser parser, float height)

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PoisonedBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PoisonedBehavior.cs
@@ -6,7 +6,7 @@ public sealed class PoisonedBehavior : UpdateModule
 {
     private uint _unknown;
 
-    public PoisonedBehavior(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public PoisonedBehavior(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -44,8 +44,8 @@ public sealed class PoisonedBehaviorModuleData : UpdateModuleData
     /// </summary>
     public int PoisonDuration { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new PoisonedBehavior(gameObject, context);
+        return new PoisonedBehavior(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PropagandaTowerBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PropagandaTowerBehavior.cs
@@ -18,8 +18,8 @@ public sealed class PropagandaTowerBehavior : UpdateModule
 
     private readonly BitArray<ObjectKinds> _allowedKinds = new();
 
-    public PropagandaTowerBehavior(GameObject gameObject, GameContext context, PropagandaTowerBehaviorModuleData moduleData)
-        : base(gameObject, context)
+    public PropagandaTowerBehavior(GameObject gameObject, GameEngine gameEngine, PropagandaTowerBehaviorModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
         _allowedKinds.Set(ObjectKinds.Infantry, true);
@@ -49,7 +49,7 @@ public sealed class PropagandaTowerBehavior : UpdateModule
 
         fx.Value.Execute(context);
 
-        foreach (var candidate in Context.Quadtree.FindNearby(GameObject, GameObject.Transform, _moduleData.Radius))
+        foreach (var candidate in GameEngine.Quadtree.FindNearby(GameObject, GameObject.Transform, _moduleData.Radius))
         {
             if (!_moduleData.AffectsSelf && candidate == GameObject) continue;
             if (!CanHealUnit(candidate)) continue;
@@ -60,7 +60,7 @@ public sealed class PropagandaTowerBehavior : UpdateModule
 
     private GameObject GameObjectForId(uint unitId)
     {
-        return Context.GameLogic.GetObjectById(unitId);
+        return GameEngine.GameLogic.GetObjectById(unitId);
     }
 
     private void HealUnit(GameObject gameObject)
@@ -167,8 +167,8 @@ public sealed class PropagandaTowerBehaviorModuleData : BehaviorModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public bool AffectsSelf { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new PropagandaTowerBehavior(gameObject, context, this);
+        return new PropagandaTowerBehavior(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/RailroadBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/RailroadBehavior.cs
@@ -21,8 +21,8 @@ public sealed class RailroadBehavior : PhysicsBehavior
     private readonly RailroadBehaviorSomething _something1 = new();
     private readonly RailroadBehaviorSomething _something2 = new();
 
-    internal RailroadBehavior(GameObject gameObject, GameContext context, PhysicsBehaviorModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal RailroadBehavior(GameObject gameObject, GameEngine gameEngine, PhysicsBehaviorModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -163,8 +163,8 @@ public sealed class RailroadBehaviorModuleData : PhysicsBehaviorModuleData
 
     public List<string> CarriageTemplateNames { get; } = new List<string>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new RailroadBehavior(gameObject, context, this);
+        return new RailroadBehavior(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
@@ -30,8 +30,8 @@ public class SlowDeathBehavior : UpdateModule
 
     public int ProbabilityModifier => _moduleData.ProbabilityModifier;
 
-    internal SlowDeathBehavior(GameObject gameObject, GameContext context, SlowDeathBehaviorModuleData moduleData)
-        : base(gameObject, context)
+    internal SlowDeathBehavior(GameObject gameObject, GameEngine gameEngine, SlowDeathBehaviorModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -66,7 +66,7 @@ public class SlowDeathBehavior : UpdateModule
 
     private static LogicFrameSpan GetDelayWithVariance(BehaviorUpdateContext context, LogicFrameSpan delay, LogicFrameSpan variance)
     {
-        var randomMultiplier = (context.GameContext.Random.NextDouble() * 2.0) - 1.0;
+        var randomMultiplier = (context.GameEngine.Random.NextDouble() * 2.0) - 1.0;
         return delay + (variance * (float)randomMultiplier);
     }
 
@@ -76,7 +76,7 @@ public class SlowDeathBehavior : UpdateModule
 
         if (_moduleData.OCLs.TryGetValue(phase, out var ocl) && ocl != null)
         {
-            context.GameContext.ObjectCreationLists.Create(ocl.Value, context);
+            context.GameEngine.ObjectCreationLists.Create(ocl.Value, context);
         }
 
         if (_moduleData.FXs.TryGetValue(phase, out var fx) && fx != null)
@@ -85,7 +85,7 @@ public class SlowDeathBehavior : UpdateModule
                 new FXListExecutionContext(
                     context.GameObject.Rotation,
                     context.GameObject.Translation,
-                    context.GameContext));
+                    context.GameEngine));
         }
 
         // TODO: Weapon
@@ -112,7 +112,7 @@ public class SlowDeathBehavior : UpdateModule
         {
             ExecutePhaseActions(context, SlowDeathPhase.Final);
             context.GameObject.ModelConditionFlags.Set(ModelConditionFlag.Dying, false);
-            context.GameContext.GameLogic.DestroyObject(context.GameObject);
+            context.GameEngine.GameLogic.DestroyObject(context.GameObject);
             _isDying = false;
         }
 
@@ -235,9 +235,9 @@ public class SlowDeathBehaviorModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2Rotwk)]
     public bool DoNotRandomizeMidpoint { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SlowDeathBehavior(gameObject, context, this);
+        return new SlowDeathBehavior(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
@@ -27,7 +27,7 @@ internal sealed class SpawnBehavior : BehaviorModule, IUpdateModule
 
     public UpdateOrder UpdatePhase => UpdateOrder.Order2;
 
-    internal SpawnBehavior(GameObject gameObject, GameContext context, SpawnBehaviorModuleData moduleData) : base(gameObject, context)
+    internal SpawnBehavior(GameObject gameObject, GameEngine gameEngine, SpawnBehaviorModuleData moduleData) : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
 
@@ -37,7 +37,7 @@ internal sealed class SpawnBehavior : BehaviorModule, IUpdateModule
 
     private void SpawnUnit()
     {
-        var spawnedObject = Context.GameLogic.CreateObject(_moduleData.SpawnTemplate?.Value, GameObject.Owner);
+        var spawnedObject = GameEngine.GameLogic.CreateObject(_moduleData.SpawnTemplate?.Value, GameObject.Owner);
         _spawnedUnits.Add(spawnedObject);
 
         spawnedObject.CreatedByObjectID = GameObject.ID;
@@ -243,8 +243,8 @@ public sealed class SpawnBehaviorModuleData : UpgradeModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool SpawnInsideBuilding { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SpawnBehavior(gameObject, context, this);
+        return new SpawnBehavior(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/TechBuildingBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/TechBuildingBehavior.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class TechBuildingBehavior : UpdateModule
 {
-    public TechBuildingBehavior(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public TechBuildingBehavior(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -27,8 +27,8 @@ public sealed class TechBuildingBehaviorModuleData : BehaviorModuleData
 
     private static readonly IniParseTable<TechBuildingBehaviorModuleData> FieldParseTable = new IniParseTable<TechBuildingBehaviorModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new TechBuildingBehavior(gameObject, context);
+        return new TechBuildingBehavior(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Body/ActiveBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/ActiveBody.cs
@@ -42,7 +42,7 @@ public class ActiveBody : BodyModule
 
     public DamageData LastDamage => _lastDamage;
 
-    internal ActiveBody(GameObject gameObject, GameContext context, ActiveBodyModuleData moduleData) : base(gameObject, context)
+    internal ActiveBody(GameObject gameObject, GameEngine gameEngine, ActiveBodyModuleData moduleData) : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
 
@@ -98,14 +98,14 @@ public class ActiveBody : BodyModule
 
         SetHealth(newHealth);
 
-        var damager = Context.GameLogic.GetObjectById(damageInfo.Request.DamageDealer);
+        var damager = GameEngine.GameLogic.GetObjectById(damageInfo.Request.DamageDealer);
         damageInfo.Request.AttackerName = damager?.Definition.Name ?? string.Empty;
 
         damageInfo.Result.DamageAfterArmorCalculation = (float)actualDamage;
         damageInfo.Result.ActualDamageApplied = _lastHealthBeforeDamage - _currentHealth;
 
         _lastDamage = damageInfo;
-        _lastDamagedAt = Context.GameLogic.CurrentFrame;
+        _lastDamagedAt = GameEngine.GameLogic.CurrentFrame;
 
         // TODO: DamageFX
         if (_currentDamageFX != null) //e.g. AmericaJetRaptor's ArmorSet has no DamageFX (None)
@@ -118,7 +118,7 @@ public class ActiveBody : BodyModule
                 new FXListExecutionContext(
                     GameObject.Rotation,
                     GameObject.Translation,
-                    Context));
+                    GameEngine));
         }
 
         if (Health <= Fix64.Zero)
@@ -316,9 +316,9 @@ public class ActiveBodyModuleData : BodyModuleData
     [AddedIn(SageGame.Bfme2Rotwk)]
     public string ReallyDamagedAttributeModifier { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new ActiveBody(gameObject, context, this);
+        return new ActiveBody(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Body/BodyModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/BodyModule.cs
@@ -11,7 +11,7 @@ public abstract class BodyModule : BehaviorModule
 {
     private float _armorDamageScalar;
 
-    protected BodyModule(GameObject gameObject, GameContext context) : base(gameObject, context)
+    protected BodyModule(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Body/HighlanderBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/HighlanderBody.cs
@@ -5,8 +5,8 @@ namespace OpenSage.Logic.Object;
 
 public sealed class HighlanderBody : ActiveBody
 {
-    internal HighlanderBody(GameObject gameObject, GameContext context, HighlanderBodyModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal HighlanderBody(GameObject gameObject, GameEngine gameEngine, HighlanderBodyModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -51,8 +51,8 @@ public sealed class HighlanderBodyModuleData : ActiveBodyModuleData
     private static new readonly IniParseTable<HighlanderBodyModuleData> FieldParseTable = ActiveBodyModuleData.FieldParseTable
         .Concat(new IniParseTable<HighlanderBodyModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new HighlanderBody(gameObject, context, this);
+        return new HighlanderBody(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Body/ImmortalBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/ImmortalBody.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 public sealed class ImmortalBody : ActiveBody
 {
-    internal ImmortalBody(GameObject gameObject, GameContext context, ImmortalBodyModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal ImmortalBody(GameObject gameObject, GameEngine gameEngine, ImmortalBodyModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -29,8 +29,8 @@ public sealed class ImmortalBodyModuleData : ActiveBodyModuleData
     private static new readonly IniParseTable<ImmortalBodyModuleData> FieldParseTable = ActiveBodyModuleData.FieldParseTable
         .Concat(new IniParseTable<ImmortalBodyModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new ImmortalBody(gameObject, context, this);
+        return new ImmortalBody(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Body/InactiveBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/InactiveBody.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class InactiveBody : BodyModule
 {
-    internal InactiveBody(GameObject gameObject, GameContext context) : base(gameObject, context)
+    internal InactiveBody(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -43,8 +43,8 @@ public sealed class InactiveBodyModuleData : BodyModuleData
 
     private static readonly IniParseTable<InactiveBodyModuleData> FieldParseTable = new IniParseTable<InactiveBodyModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new InactiveBody(gameObject, context);
+        return new InactiveBody(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Body/StructureBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/StructureBody.cs
@@ -6,8 +6,8 @@ public sealed class StructureBody : ActiveBody
 {
     private uint _unknown;
 
-    internal StructureBody(GameObject gameObject, GameContext context, StructureBodyModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal StructureBody(GameObject gameObject, GameEngine gameEngine, StructureBodyModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -33,8 +33,8 @@ public sealed class StructureBodyModuleData : ActiveBodyModuleData
     private static new readonly IniParseTable<StructureBodyModuleData> FieldParseTable = ActiveBodyModuleData.FieldParseTable
         .Concat(new IniParseTable<StructureBodyModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new StructureBody(gameObject, context, this);
+        return new StructureBody(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/ClientUpdate/AnimatedParticleSysBoneClientUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/ClientUpdate/AnimatedParticleSysBoneClientUpdate.cs
@@ -25,7 +25,7 @@ public sealed class AnimatedParticleSysBoneClientUpdateModuleData : ClientUpdate
 
     internal static readonly IniParseTable<AnimatedParticleSysBoneClientUpdateModuleData> FieldParseTable = new IniParseTable<AnimatedParticleSysBoneClientUpdateModuleData>();
 
-    internal override ClientUpdateModule CreateModule(Drawable drawable, GameContext context)
+    internal override ClientUpdateModule CreateModule(Drawable drawable, GameEngine gameEngine)
     {
         return new AnimatedParticleSysBoneClientUpdate();
     }

--- a/src/OpenSage.Game/Logic/Object/ClientUpdate/BeaconClientUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/ClientUpdate/BeaconClientUpdate.cs
@@ -25,7 +25,7 @@ public sealed class BeaconClientUpdateModuleData : ClientUpdateModuleData
     public int RadarPulseFrequency { get; private set; }
     public int RadarPulseDuration { get; private set; }
 
-    internal override ClientUpdateModule CreateModule(Drawable drawable, GameContext context)
+    internal override ClientUpdateModule CreateModule(Drawable drawable, GameEngine gameEngine)
     {
         return new BeaconClientUpdate();
     }

--- a/src/OpenSage.Game/Logic/Object/ClientUpdate/ClientUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/ClientUpdate/ClientUpdate.cs
@@ -36,5 +36,5 @@ public abstract class ClientUpdateModuleData : ModuleData
         { "SwayClientUpdate", SwayClientUpdateModuleData.Parse },
     };
 
-    internal virtual ClientUpdateModule CreateModule(Drawable drawable, GameContext context) => null; // TODO: Make this abstract.
+    internal virtual ClientUpdateModule CreateModule(Drawable drawable, GameEngine gameEngine) => null; // TODO: Make this abstract.
 }

--- a/src/OpenSage.Game/Logic/Object/ClientUpdate/LaserUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/ClientUpdate/LaserUpdate.cs
@@ -74,7 +74,7 @@ public sealed class LaserUpdateModuleData : ClientUpdateModuleData
     [AddedIn(SageGame.Bfme)]
     public LogicFrameSpan LaserLifetime { get; private set; }
 
-    internal override LaserUpdate CreateModule(Drawable drawable, GameContext context)
+    internal override LaserUpdate CreateModule(Drawable drawable, GameEngine gameEngine)
     {
         return new LaserUpdate();
     }

--- a/src/OpenSage.Game/Logic/Object/ClientUpdate/SwayClientUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/ClientUpdate/SwayClientUpdate.cs
@@ -14,7 +14,7 @@ namespace OpenSage.Logic.Object;
 public sealed class SwayClientUpdate : ClientUpdateModule
 {
     private readonly Drawable _drawable;
-    private readonly GameContext _context;
+    private readonly GameEngine _gameEngine;
 
     private float _currentValue;
     private float _currentAngle;
@@ -24,10 +24,10 @@ public sealed class SwayClientUpdate : ClientUpdateModule
     private short _currentVersion = -1; // So we don't match the first time
     private bool _swaying = true;
 
-    internal SwayClientUpdate(Drawable drawable, GameContext context)
+    internal SwayClientUpdate(Drawable drawable, GameEngine gameEngine)
     {
         _drawable = drawable;
-        _context = context;
+        _gameEngine = gameEngine;
     }
 
     public override void ClientUpdate(in TimeInterval gameTime)
@@ -41,7 +41,7 @@ public sealed class SwayClientUpdate : ClientUpdateModule
 
         // If breeze changes, always process the full update, even if not visible,
         // so that things offscreen won't "pop" when first viewed.
-        ref readonly var breezeInfo = ref _context.Game.Scripting.BreezeInfo;
+        ref readonly var breezeInfo = ref _gameEngine.Game.Scripting.BreezeInfo;
         if (breezeInfo.BreezeVersion != _currentVersion)
         {
             UpdateSway();
@@ -94,7 +94,7 @@ public sealed class SwayClientUpdate : ClientUpdateModule
     /// </summary>
     private void UpdateSway()
     {
-        ref readonly var breezeInfo = ref _context.Game.Scripting.BreezeInfo;
+        ref readonly var breezeInfo = ref _gameEngine.Game.Scripting.BreezeInfo;
 
         if (breezeInfo.Randomness == 0.0f)
         {
@@ -103,9 +103,9 @@ public sealed class SwayClientUpdate : ClientUpdateModule
 
         var delta = breezeInfo.Randomness * 0.5f;
 
-        _currentAngleLimit = breezeInfo.Intensity * _context.Random.NextSingle(1.0f - delta, 1.0f + delta);
-        _currentDelta = 2.0f * MathF.PI / breezeInfo.BreezePeriod * _context.Random.NextSingle(1.0f - delta, 1.0f + delta);
-        _leanAngle = breezeInfo.Lean * _context.Random.NextSingle(1.0f - delta, 1.0f + delta);
+        _currentAngleLimit = breezeInfo.Intensity * _gameEngine.Random.NextSingle(1.0f - delta, 1.0f + delta);
+        _currentDelta = 2.0f * MathF.PI / breezeInfo.BreezePeriod * _gameEngine.Random.NextSingle(1.0f - delta, 1.0f + delta);
+        _leanAngle = breezeInfo.Lean * _gameEngine.Random.NextSingle(1.0f - delta, 1.0f + delta);
         _currentVersion = breezeInfo.BreezeVersion;
     }
 
@@ -149,8 +149,8 @@ public sealed class SwayClientUpdateModuleData : ClientUpdateModuleData
 
     private static readonly IniParseTable<SwayClientUpdateModuleData> FieldParseTable = new IniParseTable<SwayClientUpdateModuleData>();
 
-    internal override ClientUpdateModule CreateModule(Drawable drawable, GameContext context)
+    internal override ClientUpdateModule CreateModule(Drawable drawable, GameEngine gameEngine)
     {
-        return new SwayClientUpdate(drawable, context);
+        return new SwayClientUpdate(drawable, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Collide/CollideModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/CollideModule.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public abstract class CollideModule : BehaviorModule, ICollideModule
 {
-    protected CollideModule(GameObject gameObject, GameContext context) : base(gameObject, context)
+    protected CollideModule(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Collide/ConvertToCarBombCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/ConvertToCarBombCrateCollide.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class ConvertToCarBombCrateCollide : CrateCollide
 {
-    public ConvertToCarBombCrateCollide(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public ConvertToCarBombCrateCollide(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -27,8 +27,8 @@ public sealed class ConvertToCarBombCrateCollideModuleData : CrateCollideModuleD
     private static new readonly IniParseTable<ConvertToCarBombCrateCollideModuleData> FieldParseTable = CrateCollideModuleData.FieldParseTable
         .Concat(new IniParseTable<ConvertToCarBombCrateCollideModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new ConvertToCarBombCrateCollide(gameObject, context);
+        return new ConvertToCarBombCrateCollide(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Collide/ConvertToHijackedVehicleCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/ConvertToHijackedVehicleCrateCollide.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class ConvertToHijackedVehicleCrateCollide : CrateCollide
 {
-    public ConvertToHijackedVehicleCrateCollide(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public ConvertToHijackedVehicleCrateCollide(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -29,8 +29,8 @@ public sealed class ConvertToHijackedVehicleCrateCollideModuleData : CrateCollid
     private static new readonly IniParseTable<ConvertToHijackedVehicleCrateCollideModuleData> FieldParseTable = CrateCollideModuleData.FieldParseTable
         .Concat(new IniParseTable<ConvertToHijackedVehicleCrateCollideModuleData>());
 
-    internal override ConvertToHijackedVehicleCrateCollide CreateModule(GameObject gameObject, GameContext context)
+    internal override ConvertToHijackedVehicleCrateCollide CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new ConvertToHijackedVehicleCrateCollide(gameObject, context);
+        return new ConvertToHijackedVehicleCrateCollide(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Collide/CrateCollideModuleData.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/CrateCollideModuleData.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 
 public abstract class CrateCollide : CollideModule
 {
-    protected CrateCollide(GameObject gameObject, GameContext context) : base(gameObject, context)
+    protected CrateCollide(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Collide/FireWeaponCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/FireWeaponCollide.cs
@@ -11,7 +11,7 @@ public sealed class FireWeaponCollide : CollideModule
     private readonly Weapon _collideWeapon;
     private bool _unknown2;
 
-    internal FireWeaponCollide(GameObject gameObject, GameContext context, FireWeaponCollideModuleData moduleData) : base(gameObject, context)
+    internal FireWeaponCollide(GameObject gameObject, GameEngine gameEngine, FireWeaponCollideModuleData moduleData) : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
 
@@ -19,7 +19,7 @@ public sealed class FireWeaponCollide : CollideModule
             gameObject,
             moduleData.CollideWeapon.Value,
             WeaponSlot.Primary,
-            context);
+            gameEngine);
     }
 
     internal override void Load(StatePersister reader)
@@ -49,8 +49,8 @@ public sealed class FireWeaponCollideModuleData : CollideModuleData
     public LazyAssetReference<WeaponTemplate> CollideWeapon { get; private set; }
     public ModelConditionFlag RequiredStatus { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new FireWeaponCollide(gameObject, context, this);
+        return new FireWeaponCollide(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Collide/MoneyCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/MoneyCrateCollide.cs
@@ -7,7 +7,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class MoneyCrateCollide : CrateCollide
 {
-    public MoneyCrateCollide(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public MoneyCrateCollide(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -35,9 +35,9 @@ public sealed class MoneyCrateCollideModuleData : CrateCollideModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public BoostUpgrade UpgradedBoost { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new MoneyCrateCollide(gameObject, context);
+        return new MoneyCrateCollide(gameObject, gameEngine);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Collide/SalvageCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/SalvageCrateCollide.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class SalvageCrateCollide : CrateCollide
 {
-    public SalvageCrateCollide(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public SalvageCrateCollide(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -76,8 +76,8 @@ public sealed class SalvageCrateCollideModuleData : CrateCollideModuleData
     [AddedIn(SageGame.Bfme)]
     public bool AllowAIPickup { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SalvageCrateCollide(gameObject, context);
+        return new SalvageCrateCollide(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Collide/SquishCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/SquishCollide.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 public sealed class SquishCollide : CollideModule
 {
     // TODO
-    public SquishCollide(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public SquishCollide(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -25,8 +25,8 @@ public sealed class SquishCollideModuleData : CollideModuleData
 
     private static readonly IniParseTable<SquishCollideModuleData> FieldParseTable = new IniParseTable<SquishCollideModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SquishCollide(gameObject, context);
+        return new SquishCollide(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Contain/GarrisonContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/GarrisonContain.cs
@@ -13,7 +13,7 @@ public sealed class GarrisonContain : OpenContainModule
     private readonly Vector3[] _positions = new Vector3[120];
     private bool _originalTeamSet;
 
-    internal GarrisonContain(GameObject gameObject, GameContext gameContext, OpenContainModuleData moduleData) : base(gameObject, gameContext, moduleData)
+    internal GarrisonContain(GameObject gameObject, GameEngine gameEngine, OpenContainModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -46,8 +46,8 @@ public sealed class GarrisonContain : OpenContainModule
             }
             else
             {
-                var owner = Context.Game.TeamFactory.FindTeamById(_originalTeamId)?.Template.Owner;
-                owner ??= Context.Game.PlayerManager.GetCivilianPlayer(); // todo: this behavior can be removed when DefaultTeam is set properly
+                var owner = GameEngine.Game.TeamFactory.FindTeamById(_originalTeamId)?.Template.Owner;
+                owner ??= GameEngine.Game.PlayerManager.GetCivilianPlayer(); // todo: this behavior can be removed when DefaultTeam is set properly
 
                 GameObject.Owner = owner;
             }
@@ -138,9 +138,9 @@ public class GarrisonContainModuleData : OpenContainModuleData
     [AddedIn(SageGame.Bfme)]
     public ObjectFilter PassengerFilter { get; private set; } = new();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new GarrisonContain(gameObject, context, this);
+        return new GarrisonContain(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Contain/HealContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/HealContain.cs
@@ -10,7 +10,7 @@ public sealed class HealContain : OpenContainModule
 {
     private readonly HealContainModuleData _moduleData;
 
-    internal HealContain(GameObject gameObject, GameContext gameContext, HealContainModuleData moduleData) : base(gameObject, gameContext, moduleData)
+    internal HealContain(GameObject gameObject, GameEngine gameEngine, HealContainModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -63,8 +63,8 @@ public sealed class HealContainModuleData : GarrisonContainModuleData
 
     public int TimeForFullHeal { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new HealContain(gameObject, context, this);
+        return new HealContain(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Contain/HordeContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/HordeContain.cs
@@ -17,8 +17,8 @@ public sealed class HordeContainBehavior : UpdateModule
     private ProductionUpdate _productionUpdate;
     private int _pendingRegistrations;
 
-    public HordeContainBehavior(GameObject gameObject, GameContext context, HordeContainModuleData moduleData)
-        : base(gameObject, context)
+    public HordeContainBehavior(GameObject gameObject, GameEngine gameEngine, HordeContainModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
 
@@ -63,7 +63,7 @@ public sealed class HordeContainBehavior : UpdateModule
         {
             foreach (var position in rank)
             {
-                var createdObject = Context.GameLogic.CreateObject(position.Definition, GameObject.Owner);
+                var createdObject = GameEngine.GameLogic.CreateObject(position.Definition, GameObject.Owner);
                 createdObject.ParentHorde = GameObject;
                 position.Object = createdObject;
                 _payload.Add(createdObject);
@@ -295,9 +295,9 @@ public class HordeContainModuleData : BehaviorModuleData
     [AddedIn(SageGame.Bfme2Rotwk)]
     public string LivingWorldOverloadTemplate { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new HordeContainBehavior(gameObject, context, this);
+        return new HordeContainBehavior(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
@@ -184,7 +184,7 @@ public abstract class OpenContainModule : UpdateModule, IHasRallyPoint
 
     protected void HealUnits(int fullHealTimeMs)
     {
-        var percentToHeal = new Percentage(1 / (Game.LogicFramesPerSecond * (fullHealTimeMs / 1000f)));
+        var percentToHeal = new Percentage(1 / (GameEngine.LogicFramesPerSecond * (fullHealTimeMs / 1000f)));
         foreach (var unitId in ContainedObjectIds)
         {
             var unit = GameObjectForId(unitId);

--- a/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
@@ -39,8 +39,8 @@ public abstract class OpenContainModule : UpdateModule, IHasRallyPoint
     protected const string ExitBoneStartName = "ExitStart";
     protected const string ExitBoneEndName = "ExitEnd";
 
-    private protected OpenContainModule(GameObject gameObject, GameContext context, OpenContainModuleData moduleData)
-        : base(gameObject, context)
+    private protected OpenContainModule(GameObject gameObject, GameEngine gameEngine, OpenContainModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -79,7 +79,7 @@ public abstract class OpenContainModule : UpdateModule, IHasRallyPoint
         unit.AddToContainer(GameObject.ID);
         if (!initial)
         {
-            Context.AudioSystem.PlayAudioEvent(unit, GetEnterVoiceLine(unit.Definition.UnitSpecificSounds));
+            GameEngine.AudioSystem.PlayAudioEvent(unit, GetEnterVoiceLine(unit.Definition.UnitSpecificSounds));
         }
     }
 
@@ -104,7 +104,7 @@ public abstract class OpenContainModule : UpdateModule, IHasRallyPoint
 
     public void Evacuate()
     {
-        Context.AudioSystem.PlayAudioEvent(GameObject,
+        GameEngine.AudioSystem.PlayAudioEvent(GameObject,
             GameObject.Definition.UnitSpecificSounds.VoiceUnload?.Value);
         foreach (var id in ContainedObjectIds)
         {
@@ -176,7 +176,7 @@ public abstract class OpenContainModule : UpdateModule, IHasRallyPoint
         }
         else
         {
-            Context.AudioSystem.PlayAudioEvent(GameObject.Definition.SoundExit?.Value);
+            GameEngine.AudioSystem.PlayAudioEvent(GameObject.Definition.SoundExit?.Value);
         }
 
         unit.RemoveFromContainer();
@@ -194,7 +194,7 @@ public abstract class OpenContainModule : UpdateModule, IHasRallyPoint
 
     protected GameObject GameObjectForId(uint unitId)
     {
-        return Context.GameLogic.GetObjectById(unitId);
+        return GameEngine.GameLogic.GetObjectById(unitId);
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Contain/OverlordContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OverlordContain.cs
@@ -6,8 +6,8 @@ public sealed class OverlordContain : TransportContain
 {
     private readonly OverlordContainModuleData _moduleData;
 
-    internal OverlordContain(GameObject gameObject, GameContext gameContext, OverlordContainModuleData moduleData)
-        : base(gameObject, gameContext, moduleData)
+    internal OverlordContain(GameObject gameObject, GameEngine gameEngine, OverlordContainModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -48,8 +48,8 @@ public sealed class OverlordContainModuleData : TransportContainModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public bool ExperienceSinkForRider { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new OverlordContain(gameObject, context, this);
+        return new OverlordContain(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
@@ -104,7 +104,7 @@ public class TransportContain : OpenContainModule
             if (_moduleData.ExitDelay > 0)
             {
                 // todo: humvee had DOOR_1_CLOSING ModelConditionFlag when between exits and DOOR_1_OPENING before first exit
-                var exitDelayFrames = _moduleData.ExitDelay / 1000f * Game.LogicFramesPerSecond;
+                var exitDelayFrames = _moduleData.ExitDelay / 1000f * GameEngine.LogicFramesPerSecond;
                 _nextEvacAllowedAfter = currentFrame + new LogicFrameSpan((uint)exitDelayFrames);
             }
             return true;

--- a/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
@@ -14,7 +14,7 @@ public class TransportContain : OpenContainModule
 
     private LogicFrame _nextEvacAllowedAfter; // unsure if this is correct, but seems plausible from testing?
 
-    internal TransportContain(GameObject gameObject, GameContext gameContext, TransportContainModuleData moduleData) : base(gameObject, gameContext, moduleData)
+    internal TransportContain(GameObject gameObject, GameEngine gameEngine, TransportContainModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
 
@@ -23,7 +23,7 @@ public class TransportContain : OpenContainModule
         {
             for (var i = 0; i < payload.Count; i++)
             {
-                var unit = gameContext.GameLogic.CreateObject(payload.Object.Value, gameObject.Owner);
+                var unit = gameEngine.GameLogic.CreateObject(payload.Object.Value, gameObject.Owner);
                 Add(unit, true);
             }
         }
@@ -59,7 +59,7 @@ public class TransportContain : OpenContainModule
                 // testing with a humvee, evacuating individually, the units never use the same exit path
                 // using the evac command, two pairs of rangers will share an exit path, and the 5th ranger will use a 3rd exit path
                 // todo: this doesn't seem to be strictly random, but it's unclear how this works at the moment
-                var pathToChoose = Context.Random.Next(1, _moduleData.NumberOfExitPaths + 1);
+                var pathToChoose = GameEngine.Random.Next(1, _moduleData.NumberOfExitPaths + 1);
                 startBoneName = $"{startBoneName}{pathToChoose:00}";
                 endBoneName = $"{endBoneName}{pathToChoose:00}";
             }
@@ -310,9 +310,9 @@ public class TransportContainModuleData : OpenContainModuleData
     [AddedIn(SageGame.Bfme2Rotwk)]
     public ModelConditionFlag ConditionForEntry { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new TransportContain(gameObject, context, this);
+        return new TransportContain(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Contain/TunnelContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TunnelContain.cs
@@ -7,14 +7,14 @@ namespace OpenSage.Logic.Object;
 
 public sealed class TunnelContain : OpenContainModule
 {
-    public override int TotalSlots => Context.Game.AssetStore.GameData.Current.MaxTunnelCapacity;
+    public override int TotalSlots => GameEngine.Game.AssetStore.GameData.Current.MaxTunnelCapacity;
     public override IList<uint> ContainedObjectIds => GameObject.Owner.TunnelManager!.ContainedObjectIds;
 
     private readonly TunnelContainModuleData _moduleData;
     private bool _unknown1;
     private bool _unknown2;
 
-    internal TunnelContain(GameObject gameObject, GameContext gameContext, TunnelContainModuleData moduleData) : base(gameObject, gameContext, moduleData)
+    internal TunnelContain(GameObject gameObject, GameEngine gameEngine, TunnelContainModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
         gameObject.Owner.TunnelManager?.TunnelIds.Add(gameObject.ID);
@@ -125,8 +125,8 @@ public sealed class TunnelContainModuleData : GarrisonContainModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool AllowOwnPlayerInsideOverride { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new TunnelContain(gameObject, context, this);
+        return new TunnelContain(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Create/CreateModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/CreateModule.cs
@@ -4,7 +4,7 @@ public abstract class CreateModule : BehaviorModule, ICreateModule
 {
     private bool _shouldCallOnBuildComplete = true;
 
-    protected CreateModule(GameObject gameObject, GameContext context) : base(gameObject, context)
+    protected CreateModule(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Create/ExperienceLevelCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/ExperienceLevelCreate.cs
@@ -7,8 +7,8 @@ internal sealed class ExperienceLevelCreateBehavior : CreateModule
 {
     ExperienceLevelCreateModuleData _moduleData;
 
-    internal ExperienceLevelCreateBehavior(GameObject gameObject, GameContext context, ExperienceLevelCreateModuleData moduleData)
-        : base(gameObject, context)
+    internal ExperienceLevelCreateBehavior(GameObject gameObject, GameEngine gameEngine, ExperienceLevelCreateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -32,8 +32,8 @@ public sealed class ExperienceLevelCreateModuleData : CreateModuleData
     public int LevelToGrant { get; private set; }
     public bool MPOnly { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new ExperienceLevelCreateBehavior(gameObject, context, this);
+        return new ExperienceLevelCreateBehavior(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Create/GrantUpgradeCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/GrantUpgradeCreate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class GrantUpgradeCreate : CreateModule
 {
-    public GrantUpgradeCreate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public GrantUpgradeCreate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -35,8 +35,8 @@ public sealed class GrantUpgradeCreateModuleData : CreateModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool GiveOnBuildComplete { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new GrantUpgradeCreate(gameObject, context);
+        return new GrantUpgradeCreate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Create/LockWeaponCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/LockWeaponCreate.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 [AddedIn(SageGame.CncGeneralsZeroHour)]
 public sealed class LockWeaponCreate : CreateModule
 {
-    public LockWeaponCreate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public LockWeaponCreate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -34,8 +34,8 @@ public sealed class LockWeaponCreateModuleData : CreateModuleData
 
     public WeaponSlot SlotToLock { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new LockWeaponCreate(gameObject, context);
+        return new LockWeaponCreate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Create/PreorderCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/PreorderCreate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class PreorderCreate : CreateModule
 {
-    public PreorderCreate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public PreorderCreate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -29,8 +29,8 @@ public sealed class PreorderCreateModuleData : CreateModuleData
 
     private static readonly IniParseTable<PreorderCreateModuleData> FieldParseTable = new IniParseTable<PreorderCreateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new PreorderCreate(gameObject, context);
+        return new PreorderCreate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Create/SpecialPowerCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/SpecialPowerCreate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public class SpecialPowerCreate : CreateModule
 {
-    public SpecialPowerCreate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public SpecialPowerCreate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -36,8 +36,8 @@ public sealed class SpecialPowerCreateModuleData : CreateModuleData
 
     private static readonly IniParseTable<SpecialPowerCreateModuleData> FieldParseTable = new IniParseTable<SpecialPowerCreateModuleData>();
 
-    internal override SpecialPowerCreate CreateModule(GameObject gameObject, GameContext context)
+    internal override SpecialPowerCreate CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SpecialPowerCreate(gameObject, context);
+        return new SpecialPowerCreate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Create/SupplyCenterCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/SupplyCenterCreate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class SupplyCenterCreate : CreateModule, IDestroyModule
 {
-    public SupplyCenterCreate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public SupplyCenterCreate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -44,8 +44,8 @@ public sealed class SupplyCenterCreateModuleData : CreateModuleData
 
     private static readonly IniParseTable<SupplyCenterCreateModuleData> FieldParseTable = new IniParseTable<SupplyCenterCreateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SupplyCenterCreate(gameObject, context);
+        return new SupplyCenterCreate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Create/SupplyCenterCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/SupplyCenterCreate.cs
@@ -4,13 +4,13 @@ namespace OpenSage.Logic.Object;
 
 public sealed class SupplyCenterCreate : CreateModule, IDestroyModule
 {
-    public SupplyCenterCreate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public SupplyCenterCreate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
     protected override void OnBuildCompleteImpl()
     {
-        foreach (var player in Context.Scene3D.Players)
+        foreach (var player in GameEngine.Scene3D.Players)
         {
             player.SupplyManager.AddSupplyCenter(GameObject);
         }
@@ -18,7 +18,7 @@ public sealed class SupplyCenterCreate : CreateModule, IDestroyModule
 
     public void OnDestroy()
     {
-        foreach (var player in Context.Scene3D.Players)
+        foreach (var player in GameEngine.Scene3D.Players)
         {
             player.SupplyManager.RemoveSupplyCenter(GameObject);
         }
@@ -44,7 +44,7 @@ public sealed class SupplyCenterCreateModuleData : CreateModuleData
 
     private static readonly IniParseTable<SupplyCenterCreateModuleData> FieldParseTable = new IniParseTable<SupplyCenterCreateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new SupplyCenterCreate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Create/SupplyWarehouseCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/SupplyWarehouseCreate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class SupplyWarehouseCreate : CreateModule, IDestroyModule
 {
-    public SupplyWarehouseCreate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public SupplyWarehouseCreate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -43,8 +43,8 @@ public sealed class SupplyWarehouseCreateModuleData : CreateModuleData
 
     private static readonly IniParseTable<SupplyWarehouseCreateModuleData> FieldParseTable = new IniParseTable<SupplyWarehouseCreateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SupplyWarehouseCreate(gameObject, context);
+        return new SupplyWarehouseCreate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Create/SupplyWarehouseCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/SupplyWarehouseCreate.cs
@@ -4,13 +4,13 @@ namespace OpenSage.Logic.Object;
 
 public sealed class SupplyWarehouseCreate : CreateModule, IDestroyModule
 {
-    public SupplyWarehouseCreate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public SupplyWarehouseCreate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
     public override void OnCreate()
     {
-        foreach (var player in Context.Scene3D.Players)
+        foreach (var player in GameEngine.Scene3D.Players)
         {
             player.SupplyManager.AddSupplyWarehouse(GameObject);
         }
@@ -18,7 +18,7 @@ public sealed class SupplyWarehouseCreate : CreateModule, IDestroyModule
 
     public void OnDestroy()
     {
-        foreach (var player in Context.Scene3D.Players)
+        foreach (var player in GameEngine.Scene3D.Players)
         {
             player.SupplyManager.RemoveSupplyWarehouse(GameObject);
         }
@@ -43,7 +43,7 @@ public sealed class SupplyWarehouseCreateModuleData : CreateModuleData
 
     private static readonly IniParseTable<SupplyWarehouseCreateModuleData> FieldParseTable = new IniParseTable<SupplyWarehouseCreateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new SupplyWarehouseCreate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Create/VeterancyGainCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/VeterancyGainCreate.cs
@@ -7,8 +7,8 @@ public sealed class VeterancyGainCreate : CreateModule
 {
     private readonly VeterancyGainCreateModuleData _moduleData;
 
-    public VeterancyGainCreate(GameObject gameObject, GameEngine context, VeterancyGainCreateModuleData moduleData)
-        : base(gameObject, context)
+    public VeterancyGainCreate(GameObject gameObject, GameEngine gameEngine, VeterancyGainCreateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -51,8 +51,8 @@ public sealed class VeterancyGainCreateModuleData : CreateModuleData
     public VeterancyLevel StartingLevel { get; private set; }
     public LazyAssetReference<Science> ScienceRequired { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new VeterancyGainCreate(gameObject, context, this);
+        return new VeterancyGainCreate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Create/VeterancyGainCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/VeterancyGainCreate.cs
@@ -7,7 +7,7 @@ public sealed class VeterancyGainCreate : CreateModule
 {
     private readonly VeterancyGainCreateModuleData _moduleData;
 
-    public VeterancyGainCreate(GameObject gameObject, GameContext context, VeterancyGainCreateModuleData moduleData)
+    public VeterancyGainCreate(GameObject gameObject, GameEngine context, VeterancyGainCreateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -51,7 +51,7 @@ public sealed class VeterancyGainCreateModuleData : CreateModuleData
     public VeterancyLevel StartingLevel { get; private set; }
     public LazyAssetReference<Science> ScienceRequired { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new VeterancyGainCreate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Damage/BoneFXDamage.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/BoneFXDamage.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class BoneFXDamage : DamageModule
 {
-    public BoneFXDamage(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public BoneFXDamage(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -28,8 +28,8 @@ public sealed class BoneFXDamageModuleData : DamageModuleData
 
     private static readonly IniParseTable<BoneFXDamageModuleData> FieldParseTable = new IniParseTable<BoneFXDamageModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new BoneFXDamage(gameObject, context);
+        return new BoneFXDamage(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Damage/BoneFXDamage.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/BoneFXDamage.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class BoneFXDamage : DamageModule
 {
-    public BoneFXDamage(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public BoneFXDamage(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -28,7 +28,7 @@ public sealed class BoneFXDamageModuleData : DamageModuleData
 
     private static readonly IniParseTable<BoneFXDamageModuleData> FieldParseTable = new IniParseTable<BoneFXDamageModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new BoneFXDamage(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Damage/DamageModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/DamageModule.cs
@@ -2,7 +2,7 @@
 
 public abstract class DamageModule : BehaviorModule
 {
-    protected DamageModule(GameObject gameObject, GameContext context) : base(gameObject, context)
+    protected DamageModule(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Damage/TransitionDamageFX.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/TransitionDamageFX.cs
@@ -16,8 +16,8 @@ public sealed class TransitionDamageFX : DamageModule
     private const int NumParticleSystemsPerDamageType = 12;
     private readonly uint[] _particleSystemIds = new uint[EnumUtility.GetEnumCount<BodyDamageType>() * NumParticleSystemsPerDamageType];
 
-    public TransitionDamageFX(GameObject gameObject, GameEngine context, TransitionDamageFXModuleData moduleData)
-        : base(gameObject, context)
+    public TransitionDamageFX(GameObject gameObject, GameEngine gameEngine, TransitionDamageFXModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -158,9 +158,9 @@ public sealed class TransitionDamageFXModuleData : DamageModuleData
     [AddedIn(SageGame.Bfme)]
     public string[] ReallyDamagedHideSubObject { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new TransitionDamageFX(gameObject, context, this);
+        return new TransitionDamageFX(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Damage/TransitionDamageFX.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/TransitionDamageFX.cs
@@ -16,7 +16,7 @@ public sealed class TransitionDamageFX : DamageModule
     private const int NumParticleSystemsPerDamageType = 12;
     private readonly uint[] _particleSystemIds = new uint[EnumUtility.GetEnumCount<BodyDamageType>() * NumParticleSystemsPerDamageType];
 
-    public TransitionDamageFX(GameObject gameObject, GameContext context, TransitionDamageFXModuleData moduleData)
+    public TransitionDamageFX(GameObject gameObject, GameEngine context, TransitionDamageFXModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -47,7 +47,7 @@ public sealed class TransitionDamageFX : DamageModule
 
             foreach (var particleSystemTemplate in particleSystems)
             {
-                context.GameContext.ParticleSystems
+                context.GameEngine.ParticleSystems
                     .Create(particleSystemTemplate.ParticleSystem.Value, worldMatrix);
             }
         }
@@ -158,7 +158,7 @@ public sealed class TransitionDamageFXModuleData : DamageModuleData
     [AddedIn(SageGame.Bfme)]
     public string[] ReallyDamagedHideSubObject { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new TransitionDamageFX(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
@@ -9,8 +9,8 @@ public sealed class CreateCrateDie : DieModule
 {
     private readonly CreateCrateDieModuleData _moduleData;
 
-    internal CreateCrateDie(GameObject gameObject, GameEngine context, CreateCrateDieModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal CreateCrateDie(GameObject gameObject, GameEngine gameEngine, CreateCrateDieModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -95,8 +95,8 @@ public sealed class CreateCrateDieModuleData : DieModuleData
 
     public LazyAssetReference<CrateData> CrateData { get; private set; }
 
-    internal override CreateCrateDie CreateModule(GameObject gameObject, GameEngine context)
+    internal override CreateCrateDie CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new CreateCrateDie(gameObject, context, this);
+        return new CreateCrateDie(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
@@ -9,7 +9,7 @@ public sealed class CreateCrateDie : DieModule
 {
     private readonly CreateCrateDieModuleData _moduleData;
 
-    internal CreateCrateDie(GameObject gameObject, GameContext context, CreateCrateDieModuleData moduleData)
+    internal CreateCrateDie(GameObject gameObject, GameEngine context, CreateCrateDieModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -21,15 +21,15 @@ public sealed class CreateCrateDie : DieModule
 
         if (GameObject.TryGetLastDamage(out var lastDamageData))
         {
-            var killer = Context.GameLogic.GetObjectById(lastDamageData.Request.DamageDealer);
+            var killer = GameEngine.GameLogic.GetObjectById(lastDamageData.Request.DamageDealer);
 
             if (KillerCanSpawnCrate(killer, crateData))
             {
-                if (Context.Random.NextSingle() < crateData.CreationChance)
+                if (GameEngine.Random.NextSingle() < crateData.CreationChance)
                 {
                     // actually create the crate
                     float totalProbability = 0;
-                    var selection = Context.Random.NextSingle();
+                    var selection = GameEngine.Random.NextSingle();
                     foreach (var crate in crateData.CrateObjects)
                     {
                         totalProbability += crate.Probability;
@@ -63,7 +63,7 @@ public sealed class CreateCrateDie : DieModule
     {
         if (crate.Object is not null)
         {
-            var newCrate = Context.GameLogic.CreateObject(crate.Object.Value, GameObject.Owner);
+            var newCrate = GameEngine.GameLogic.CreateObject(crate.Object.Value, GameObject.Owner);
             newCrate.SetTransformMatrix(GameObject.TransformMatrix);
 
             if (crateData.OwnedByMaker)
@@ -95,7 +95,7 @@ public sealed class CreateCrateDieModuleData : DieModuleData
 
     public LazyAssetReference<CrateData> CrateData { get; private set; }
 
-    internal override CreateCrateDie CreateModule(GameObject gameObject, GameContext context)
+    internal override CreateCrateDie CreateModule(GameObject gameObject, GameEngine context)
     {
         return new CreateCrateDie(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
@@ -7,7 +7,7 @@ public sealed class CreateObjectDie : DieModule
 {
     private readonly CreateObjectDieModuleData _moduleData;
 
-    internal CreateObjectDie(GameObject gameObject, GameContext context, CreateObjectDieModuleData moduleData)
+    internal CreateObjectDie(GameObject gameObject, GameEngine context, CreateObjectDieModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -15,7 +15,7 @@ public sealed class CreateObjectDie : DieModule
 
     private protected override void Die(BehaviorUpdateContext context, DeathType deathType)
     {
-        context.GameContext.ObjectCreationLists.Create(_moduleData.CreationList.Value, context);
+        context.GameEngine.ObjectCreationLists.Create(_moduleData.CreationList.Value, context);
     }
 
     internal override void Load(StatePersister reader)
@@ -52,7 +52,7 @@ public sealed class CreateObjectDieModuleData : DieModuleData
     [AddedIn(SageGame.Bfme2)]
     public string[] UpgradeRequired { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new CreateObjectDie(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
@@ -7,8 +7,8 @@ public sealed class CreateObjectDie : DieModule
 {
     private readonly CreateObjectDieModuleData _moduleData;
 
-    internal CreateObjectDie(GameObject gameObject, GameEngine context, CreateObjectDieModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal CreateObjectDie(GameObject gameObject, GameEngine gameEngine, CreateObjectDieModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -52,8 +52,8 @@ public sealed class CreateObjectDieModuleData : DieModuleData
     [AddedIn(SageGame.Bfme2)]
     public string[] UpgradeRequired { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new CreateObjectDie(gameObject, context, this);
+        return new CreateObjectDie(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/CrushDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CrushDie.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class CrushDie : DieModule
 {
-    public CrushDie(GameObject gameObject, GameEngine context, CrushDieModuleData moduleData) : base(gameObject, context, moduleData)
+    public CrushDie(GameObject gameObject, GameEngine gameEngine, CrushDieModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -43,9 +43,9 @@ public sealed class CrushDieModuleData : DieModuleData
     public int BackEndCrushSoundPercent { get; private set; }
     public int FrontEndCrushSoundPercent { get; private set; }
 
-    internal override CrushDie CreateModule(GameObject gameObject, GameEngine context)
+    internal override CrushDie CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new CrushDie(gameObject, context, this);
+        return new CrushDie(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Die/CrushDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CrushDie.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class CrushDie : DieModule
 {
-    public CrushDie(GameObject gameObject, GameContext context, CrushDieModuleData moduleData) : base(gameObject, context, moduleData)
+    public CrushDie(GameObject gameObject, GameEngine context, CrushDieModuleData moduleData) : base(gameObject, context, moduleData)
     {
     }
 
@@ -43,7 +43,7 @@ public sealed class CrushDieModuleData : DieModuleData
     public int BackEndCrushSoundPercent { get; private set; }
     public int FrontEndCrushSoundPercent { get; private set; }
 
-    internal override CrushDie CreateModule(GameObject gameObject, GameContext context)
+    internal override CrushDie CreateModule(GameObject gameObject, GameEngine context)
     {
         return new CrushDie(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/DamDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DamDie.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 public sealed class DamDie : DieModule
 {
     // TODO
-    public DamDie(GameObject gameObject, GameContext context, DamDieModuleData moduleData) : base(gameObject, context, moduleData)
+    public DamDie(GameObject gameObject, GameEngine context, DamDieModuleData moduleData) : base(gameObject, context, moduleData)
     {
     }
 
@@ -30,7 +30,7 @@ public sealed class DamDieModuleData : DieModuleData
     private static new readonly IniParseTable<DamDieModuleData> FieldParseTable = DieModuleData.FieldParseTable
         .Concat(new IniParseTable<DamDieModuleData>());
 
-    internal override DamDie CreateModule(GameObject gameObject, GameContext context)
+    internal override DamDie CreateModule(GameObject gameObject, GameEngine context)
     {
         return new DamDie(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/DamDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DamDie.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 public sealed class DamDie : DieModule
 {
     // TODO
-    public DamDie(GameObject gameObject, GameEngine context, DamDieModuleData moduleData) : base(gameObject, context, moduleData)
+    public DamDie(GameObject gameObject, GameEngine gameEngine, DamDieModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -30,8 +30,8 @@ public sealed class DamDieModuleData : DieModuleData
     private static new readonly IniParseTable<DamDieModuleData> FieldParseTable = DieModuleData.FieldParseTable
         .Concat(new IniParseTable<DamDieModuleData>());
 
-    internal override DamDie CreateModule(GameObject gameObject, GameEngine context)
+    internal override DamDie CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new DamDie(gameObject, context, this);
+        return new DamDie(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/DestroyDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DestroyDie.cs
@@ -4,14 +4,14 @@ namespace OpenSage.Logic.Object;
 
 public sealed class DestroyDie : DieModule
 {
-    internal DestroyDie(GameObject gameObject, GameContext context, DestroyDieModuleData moduleData)
+    internal DestroyDie(GameObject gameObject, GameEngine context, DestroyDieModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
     }
 
     private protected override void Die(BehaviorUpdateContext context, DeathType deathType)
     {
-        context.GameContext.GameLogic.DestroyObject(GameObject);
+        context.GameEngine.GameLogic.DestroyObject(GameObject);
     }
 
     internal override void Load(StatePersister reader)
@@ -31,7 +31,7 @@ public sealed class DestroyDieModuleData : DieModuleData
     private static new readonly IniParseTable<DestroyDieModuleData> FieldParseTable = DieModuleData.FieldParseTable
         .Concat(new IniParseTable<DestroyDieModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new DestroyDie(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/DestroyDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DestroyDie.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 public sealed class DestroyDie : DieModule
 {
-    internal DestroyDie(GameObject gameObject, GameEngine context, DestroyDieModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal DestroyDie(GameObject gameObject, GameEngine gameEngine, DestroyDieModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -31,8 +31,8 @@ public sealed class DestroyDieModuleData : DieModuleData
     private static new readonly IniParseTable<DestroyDieModuleData> FieldParseTable = DieModuleData.FieldParseTable
         .Concat(new IniParseTable<DestroyDieModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new DestroyDie(gameObject, context, this);
+        return new DestroyDie(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/DieModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DieModule.cs
@@ -9,7 +9,7 @@ public abstract class DieModule : BehaviorModule
 {
     private readonly DieModuleData _moduleData;
 
-    protected DieModule(GameObject gameObject, GameContext context, DieModuleData moduleData) : base(gameObject, context)
+    protected DieModule(GameObject gameObject, GameEngine gameEngine, DieModuleData moduleData) : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }

--- a/src/OpenSage.Game/Logic/Object/Die/EjectPilotDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/EjectPilotDie.cs
@@ -8,8 +8,8 @@ public sealed class EjectPilotDie : DieModule
 {
     private readonly EjectPilotDieModuleData _moduleData;
 
-    internal EjectPilotDie(GameObject gameObject, GameEngine context, EjectPilotDieModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal EjectPilotDie(GameObject gameObject, GameEngine gameEngine, EjectPilotDieModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -61,8 +61,8 @@ public sealed class EjectPilotDieModuleData : DieModuleData
     public LazyAssetReference<ObjectCreationList> AirCreationList { get; private set; }
     public BitArray<VeterancyLevel> VeterancyLevels { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new EjectPilotDie(gameObject, context, this);
+        return new EjectPilotDie(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/EjectPilotDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/EjectPilotDie.cs
@@ -8,7 +8,7 @@ public sealed class EjectPilotDie : DieModule
 {
     private readonly EjectPilotDieModuleData _moduleData;
 
-    internal EjectPilotDie(GameObject gameObject, GameContext context, EjectPilotDieModuleData moduleData)
+    internal EjectPilotDie(GameObject gameObject, GameEngine context, EjectPilotDieModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -25,10 +25,10 @@ public sealed class EjectPilotDie : DieModule
 
         var isOnGround = true; // todo: determine if unit is airborne
         var creationList = isOnGround ? _moduleData.GroundCreationList : _moduleData.AirCreationList;
-        foreach (var gameObject in Context.ObjectCreationLists.Create(creationList.Value, context))
+        foreach (var gameObject in GameEngine.ObjectCreationLists.Create(creationList.Value, context))
         {
             gameObject.Rank = GameObject.Rank;
-            Context.AudioSystem.PlayAudioEvent(gameObject, GameObject.Definition.UnitSpecificSounds.VoiceEject?.Value);
+            GameEngine.AudioSystem.PlayAudioEvent(gameObject, GameObject.Definition.UnitSpecificSounds.VoiceEject?.Value);
         }
     }
 
@@ -61,7 +61,7 @@ public sealed class EjectPilotDieModuleData : DieModuleData
     public LazyAssetReference<ObjectCreationList> AirCreationList { get; private set; }
     public BitArray<VeterancyLevel> VeterancyLevels { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new EjectPilotDie(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/FXListDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/FXListDie.cs
@@ -8,7 +8,7 @@ public sealed class FXListDie : DieModule
 {
     private readonly FXListDieModuleData _moduleData;
 
-    internal FXListDie(GameObject gameObject, GameContext context, FXListDieModuleData moduleData)
+    internal FXListDie(GameObject gameObject, GameEngine context, FXListDieModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -19,7 +19,7 @@ public sealed class FXListDie : DieModule
         _moduleData.DeathFX.Value.Execute(new FXListExecutionContext(
             context.GameObject.Rotation,
             context.GameObject.Translation,
-            context.GameContext));
+            context.GameEngine));
     }
 
     internal override void Load(StatePersister reader)
@@ -58,7 +58,7 @@ public sealed class FXListDieModuleData : DieModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public string[] TriggeredBy { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new FXListDie(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/FXListDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/FXListDie.cs
@@ -8,8 +8,8 @@ public sealed class FXListDie : DieModule
 {
     private readonly FXListDieModuleData _moduleData;
 
-    internal FXListDie(GameObject gameObject, GameEngine context, FXListDieModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal FXListDie(GameObject gameObject, GameEngine gameEngine, FXListDieModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -58,8 +58,8 @@ public sealed class FXListDieModuleData : DieModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public string[] TriggeredBy { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new FXListDie(gameObject, context, this);
+        return new FXListDie(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/KeepObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/KeepObjectDie.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class KeepObjectDie : DieModule
 {
-    public KeepObjectDie(GameObject gameObject, GameContext context, KeepObjectDieModuleData moduleData)
+    public KeepObjectDie(GameObject gameObject, GameEngine context, KeepObjectDieModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
     }
@@ -36,7 +36,7 @@ public sealed class KeepObjectDieModuleData : DieModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool StayOnRadar { get; private set; }
 
-    internal override KeepObjectDie CreateModule(GameObject gameObject, GameContext context)
+    internal override KeepObjectDie CreateModule(GameObject gameObject, GameEngine context)
     {
         return new KeepObjectDie(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/KeepObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/KeepObjectDie.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 public sealed class KeepObjectDie : DieModule
 {
-    public KeepObjectDie(GameObject gameObject, GameEngine context, KeepObjectDieModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    public KeepObjectDie(GameObject gameObject, GameEngine gameEngine, KeepObjectDieModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -36,8 +36,8 @@ public sealed class KeepObjectDieModuleData : DieModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool StayOnRadar { get; private set; }
 
-    internal override KeepObjectDie CreateModule(GameObject gameObject, GameEngine context)
+    internal override KeepObjectDie CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new KeepObjectDie(gameObject, context, this);
+        return new KeepObjectDie(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/RebuildHoleExposeDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/RebuildHoleExposeDie.cs
@@ -8,7 +8,7 @@ public sealed class RebuildHoleExposeDie : DieModule
 {
     private readonly RebuildHoleExposeDieModuleData _moduleData;
 
-    internal RebuildHoleExposeDie(GameObject gameObject, GameContext context, RebuildHoleExposeDieModuleData moduleData)
+    internal RebuildHoleExposeDie(GameObject gameObject, GameEngine context, RebuildHoleExposeDieModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -16,7 +16,7 @@ public sealed class RebuildHoleExposeDie : DieModule
 
     private protected override void Die(BehaviorUpdateContext context, DeathType deathType)
     {
-        var hole = Context.GameLogic.CreateObject(_moduleData.HoleDefinition.Value, GameObject.Owner);
+        var hole = GameEngine.GameLogic.CreateObject(_moduleData.HoleDefinition.Value, GameObject.Owner);
         hole.SetTransformMatrix(GameObject.TransformMatrix);
         var holeHealth = (Fix64)_moduleData.HoleMaxHealth;
         hole.MaxHealth = holeHealth;
@@ -67,7 +67,7 @@ public sealed class RebuildHoleExposeDieModuleData : DieModuleData
         DieData.ExemptStatus = ObjectStatus.UnderConstruction;
     }
 
-    internal override RebuildHoleExposeDie CreateModule(GameObject gameObject, GameContext context)
+    internal override RebuildHoleExposeDie CreateModule(GameObject gameObject, GameEngine context)
     {
         return new RebuildHoleExposeDie(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/RebuildHoleExposeDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/RebuildHoleExposeDie.cs
@@ -8,8 +8,8 @@ public sealed class RebuildHoleExposeDie : DieModule
 {
     private readonly RebuildHoleExposeDieModuleData _moduleData;
 
-    internal RebuildHoleExposeDie(GameObject gameObject, GameEngine context, RebuildHoleExposeDieModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal RebuildHoleExposeDie(GameObject gameObject, GameEngine gameEngine, RebuildHoleExposeDieModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -67,8 +67,8 @@ public sealed class RebuildHoleExposeDieModuleData : DieModuleData
         DieData.ExemptStatus = ObjectStatus.UnderConstruction;
     }
 
-    internal override RebuildHoleExposeDie CreateModule(GameObject gameObject, GameEngine context)
+    internal override RebuildHoleExposeDie CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new RebuildHoleExposeDie(gameObject, context, this);
+        return new RebuildHoleExposeDie(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Die/UpgradeDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/UpgradeDie.cs
@@ -7,7 +7,7 @@ public class UpgradeDieModule : DieModule
 {
     private readonly UpgradeDieModuleData _moduleData;
 
-    internal UpgradeDieModule(GameObject gameObject, GameContext context, UpgradeDieModuleData moduleData)
+    internal UpgradeDieModule(GameObject gameObject, GameEngine context, UpgradeDieModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -24,7 +24,7 @@ public class UpgradeDieModule : DieModule
 
     private protected override void Die(BehaviorUpdateContext context, DeathType deathType)
     {
-        var parent = Context.GameLogic.GetObjectById(GameObject.CreatedByObjectID);
+        var parent = GameEngine.GameLogic.GetObjectById(GameObject.CreatedByObjectID);
 
         parent?.RemoveUpgrade(_moduleData.UpgradeToRemove.UpgradeName.Value);
 
@@ -47,7 +47,7 @@ public sealed class UpgradeDieModuleData : DieModuleData
 
     public UpgradeToRemove UpgradeToRemove { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new UpgradeDieModule(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/UpgradeDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/UpgradeDie.cs
@@ -7,8 +7,8 @@ public class UpgradeDieModule : DieModule
 {
     private readonly UpgradeDieModuleData _moduleData;
 
-    internal UpgradeDieModule(GameObject gameObject, GameEngine context, UpgradeDieModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal UpgradeDieModule(GameObject gameObject, GameEngine gameEngine, UpgradeDieModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -47,9 +47,9 @@ public sealed class UpgradeDieModuleData : DieModuleData
 
     public UpgradeToRemove UpgradeToRemove { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new UpgradeDieModule(gameObject, context, this);
+        return new UpgradeDieModule(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
@@ -114,5 +114,5 @@ public abstract class DrawModuleData : ModuleData
         { "W3DTruckDraw", W3dTruckDrawModuleData.Parse },
     };
 
-    internal virtual DrawModule? CreateDrawModule(Drawable drawable, GameContext context) => null; // TODO: Make this abstract.
+    internal virtual DrawModule? CreateDrawModule(Drawable drawable, GameEngine context) => null; // TODO: Make this abstract.
 }

--- a/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
@@ -114,5 +114,5 @@ public abstract class DrawModuleData : ModuleData
         { "W3DTruckDraw", W3dTruckDrawModuleData.Parse },
     };
 
-    internal virtual DrawModule? CreateDrawModule(Drawable drawable, GameEngine context) => null; // TODO: Make this abstract.
+    internal virtual DrawModule? CreateDrawModule(Drawable drawable, GameEngine gameEngine) => null; // TODO: Make this abstract.
 }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dDebrisDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dDebrisDraw.cs
@@ -108,8 +108,8 @@ public sealed class W3dDebrisDrawModuleData : DrawModuleData
 
     internal static readonly IniParseTable<W3dDebrisDrawModuleData> FieldParseTable = new IniParseTable<W3dDebrisDrawModuleData>();
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
     {
-        return new W3dDebrisDraw(this, context);
+        return new W3dDebrisDraw(this, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dDebrisDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dDebrisDraw.cs
@@ -14,7 +14,7 @@ namespace OpenSage.Logic.Object;
 public sealed class W3dDebrisDraw : DrawModule
 {
     private readonly W3dDebrisDrawModuleData _data;
-    private readonly GameContext _gameContext;
+    private readonly GameEngine _gameEngine;
     private ModelInstance _modelInstance;
 
     private string _modelName;
@@ -22,16 +22,16 @@ public sealed class W3dDebrisDraw : DrawModule
     private uint _unknownInt2;
     private bool _unknownBool;
 
-    internal W3dDebrisDraw(W3dDebrisDrawModuleData data, GameContext context)
+    internal W3dDebrisDraw(W3dDebrisDrawModuleData data, GameEngine gameEngine)
     {
         _data = data;
-        _gameContext = context;
+        _gameEngine = gameEngine;
     }
 
     public void SetModelName(string modelName)
     {
-        var model = _gameContext.AssetLoadContext.AssetStore.Models.GetByName(modelName);
-        _modelInstance = AddDisposable(model.CreateInstance(_gameContext.AssetLoadContext));
+        var model = _gameEngine.AssetLoadContext.AssetStore.Models.GetByName(modelName);
+        _modelInstance = AddDisposable(model.CreateInstance(_gameEngine.AssetLoadContext));
         _modelInstance.Update(TimeInterval.Zero);
     }
 
@@ -108,7 +108,7 @@ public sealed class W3dDebrisDrawModuleData : DrawModuleData
 
     internal static readonly IniParseTable<W3dDebrisDrawModuleData> FieldParseTable = new IniParseTable<W3dDebrisDrawModuleData>();
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
     {
         return new W3dDebrisDraw(this, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dDefaultDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dDefaultDraw.cs
@@ -71,7 +71,7 @@ public sealed class W3dDefaultDrawModuleData : DrawModuleData
 
     internal static readonly IniParseTable<W3dDefaultDrawModuleData> DefaultFieldParseTable = new IniParseTable<W3dDefaultDrawModuleData>();
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
     {
         return new W3dDefaultDraw();
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dDefaultDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dDefaultDraw.cs
@@ -71,7 +71,7 @@ public sealed class W3dDefaultDrawModuleData : DrawModuleData
 
     internal static readonly IniParseTable<W3dDefaultDrawModuleData> DefaultFieldParseTable = new IniParseTable<W3dDefaultDrawModuleData>();
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
     {
         return new W3dDefaultDraw();
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dFloorDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dFloorDraw.cs
@@ -110,9 +110,9 @@ public sealed class W3dFloorDrawModuleData : DrawModuleData
     [AddedIn(SageGame.Bfme2)]
     public WeatherTexture WeatherTexture { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
     {
-        return Model.Value == null ? null : (DrawModule)new W3dFloorDraw(this, context, drawable);
+        return Model.Value == null ? null : (DrawModule)new W3dFloorDraw(this, gameEngine, drawable);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dFloorDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dFloorDraw.cs
@@ -17,18 +17,18 @@ namespace OpenSage.Logic.Object;
 public sealed class W3dFloorDraw : DrawModule
 {
     private readonly Drawable _drawable;
-    private readonly GameContext _gameContext;
+    private readonly GameEngine _gameEngine;
     private readonly ModelInstance _modelInstance;
     private readonly W3dFloorDrawModuleData _moduleData;
 
     public override IEnumerable<BitArray<ModelConditionFlag>> ModelConditionStates { get; } = Array.Empty<BitArray<ModelConditionFlag>>();
 
-    internal W3dFloorDraw(W3dFloorDrawModuleData moduleData, GameContext context, Drawable drawable)
+    internal W3dFloorDraw(W3dFloorDrawModuleData moduleData, GameEngine gameEngine, Drawable drawable)
     {
         _drawable = drawable;
-        _gameContext = context;
+        _gameEngine = gameEngine;
         _moduleData = moduleData;
-        _modelInstance = AddDisposable(_moduleData.Model.Value.CreateInstance(_gameContext.AssetLoadContext));
+        _modelInstance = AddDisposable(_moduleData.Model.Value.CreateInstance(_gameEngine.AssetLoadContext));
     }
 
     internal override void BuildRenderList(
@@ -110,7 +110,7 @@ public sealed class W3dFloorDrawModuleData : DrawModuleData
     [AddedIn(SageGame.Bfme2)]
     public WeatherTexture WeatherTexture { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
     {
         return Model.Value == null ? null : (DrawModule)new W3dFloorDraw(this, context, drawable);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dHordeModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dHordeModelDraw.cs
@@ -12,7 +12,7 @@ public class W3dHordeModelDraw : W3dScriptedModelDraw
     internal W3dHordeModelDraw(
         W3dHordeModelDrawModuleData data,
         Drawable drawable,
-        GameContext context) : base(data, drawable, context)
+        GameEngine context) : base(data, drawable, context)
     {
     }
 
@@ -34,7 +34,7 @@ public class W3dHordeModelDrawModuleData : W3dScriptedModelDrawModuleData
 
     public List<LodOption> LodOptions { get; private set; } = new List<LodOption>();
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
     {
         return new W3dHordeModelDraw(this, drawable, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dHordeModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dHordeModelDraw.cs
@@ -12,7 +12,7 @@ public class W3dHordeModelDraw : W3dScriptedModelDraw
     internal W3dHordeModelDraw(
         W3dHordeModelDrawModuleData data,
         Drawable drawable,
-        GameEngine context) : base(data, drawable, context)
+        GameEngine gameEngine) : base(data, drawable, gameEngine)
     {
     }
 
@@ -34,9 +34,9 @@ public class W3dHordeModelDrawModuleData : W3dScriptedModelDrawModuleData
 
     public List<LodOption> LodOptions { get; private set; } = new List<LodOption>();
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
     {
-        return new W3dHordeModelDraw(this, drawable, context);
+        return new W3dHordeModelDraw(this, drawable, gameEngine);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dLaserDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dLaserDraw.cs
@@ -99,7 +99,7 @@ public sealed class W3dLaserDrawModuleData : DrawModuleData
     [AddedIn(SageGame.Bfme)]
     public Envelope Envelope { get; private set; }
 
-    internal override W3dLaserDraw CreateDrawModule(Drawable drawable, GameEngine context)
+    internal override W3dLaserDraw CreateDrawModule(Drawable drawable, GameEngine gameEngine)
     {
         return new W3dLaserDraw();
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dLaserDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dLaserDraw.cs
@@ -99,7 +99,7 @@ public sealed class W3dLaserDrawModuleData : DrawModuleData
     [AddedIn(SageGame.Bfme)]
     public Envelope Envelope { get; private set; }
 
-    internal override W3dLaserDraw CreateDrawModule(Drawable drawable, GameContext context)
+    internal override W3dLaserDraw CreateDrawModule(Drawable drawable, GameEngine context)
     {
         return new W3dLaserDraw();
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -322,7 +322,7 @@ public class W3dModelDraw : DrawModule
     {
         var animation = ActiveModelInstance.AnimationInstances.Single();
 
-        var desiredDuration = TimeSpan.FromSeconds(frames.Value / Game.LogicFramesPerSecond);
+        var desiredDuration = TimeSpan.FromSeconds(frames.Value / GameEngine.LogicFramesPerSecond);
 
         var speedFactor = (float)(animation.Duration / desiredDuration);
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -21,7 +21,7 @@ namespace OpenSage.Logic.Object;
 public class W3dModelDraw : DrawModule
 {
     private readonly W3dModelDrawModuleData _data;
-    private readonly GameContext _context;
+    private readonly GameEngine _gameEngine;
 
     private ModelConditionState _activeConditionState;
     protected AnimationState _activeAnimationState;
@@ -90,11 +90,11 @@ public class W3dModelDraw : DrawModule
     internal W3dModelDraw(
         W3dModelDrawModuleData data,
         Drawable drawable,
-        GameContext context)
+        GameEngine context)
     {
         _data = data;
         Drawable = drawable;
-        _context = context;
+        _gameEngine = context;
 
         UpdateConditionState(new BitArray<ModelConditionFlag>(), context.Random);
 
@@ -148,7 +148,7 @@ public class W3dModelDraw : DrawModule
 
         if (animationState?.Script != null)
         {
-            _context.Scene3D.Game.Lua.ExecuteDrawModuleLuaCode(this, animationState.Script);
+            _gameEngine.Scene3D.Game.Lua.ExecuteDrawModuleLuaCode(this, animationState.Script);
         }
 
         if (animationState == null
@@ -179,7 +179,7 @@ public class W3dModelDraw : DrawModule
         {
             var flags = animationState.Flags;
             var mode = animationBlock.AnimationMode;
-            var animationInstance = new AnimationInstance(modelInstance.ModelBoneInstances, anim, mode, flags, GameObject, _context.Random);
+            var animationInstance = new AnimationInstance(modelInstance.ModelBoneInstances, anim, mode, flags, GameObject, _gameEngine.Random);
             modelInstance.AnimationInstances.Add(animationInstance);
             animationInstance.Play(animationBlock.AnimationSpeedFactorRange.GetValue(random));
         }
@@ -192,7 +192,7 @@ public class W3dModelDraw : DrawModule
     public void SetTransitionState(string state)
     {
         var transitionState = _data.TransitionStates.FirstOrDefault(x => x.StateName == state);
-        SetActiveAnimationState(transitionState, _context.Random);
+        SetActiveAnimationState(transitionState, _gameEngine.Random);
     }
 
     internal static T FindBestFittingConditionState<T, TFlag>(List<T> conditionStates, BitArray<TFlag> flags)
@@ -265,7 +265,7 @@ public class W3dModelDraw : DrawModule
     {
         // Load model, fallback to default model.
         var model = conditionState.Model?.Value;
-        var modelInstance = model?.CreateInstance(_context.AssetLoadContext) ?? null;
+        var modelInstance = model?.CreateInstance(_gameEngine.AssetLoadContext) ?? null;
 
         if (modelInstance == null)
         {
@@ -289,12 +289,12 @@ public class W3dModelDraw : DrawModule
                 continue;
             }
 
-            particleSystems.Add(_context.ParticleSystems.Create(
+            particleSystems.Add(_gameEngine.ParticleSystems.Create(
                 particleSystemTemplate,
                 () => ref modelInstance.AbsoluteBoneTransforms[bone.Index]));
         }
 
-        var drawState = new W3dModelDrawConditionState(modelInstance, particleSystems, _context);
+        var drawState = new W3dModelDrawConditionState(modelInstance, particleSystems, _gameEngine);
         UpdateBoneVisibilities(conditionState, drawState);
 
         return drawState;
@@ -426,19 +426,19 @@ public class W3dModelDraw : DrawModule
 internal sealed class W3dModelDrawConditionState : DisposableBase
 {
     private readonly IEnumerable<ParticleSystem> _particleSystems;
-    private readonly GameContext _context;
+    private readonly GameEngine _gameEngine;
 
     public readonly ModelInstance Model;
 
     public W3dModelDrawConditionState(
         ModelInstance modelInstance,
         IEnumerable<ParticleSystem> particleSystems,
-        GameContext context)
+        GameEngine context)
     {
         Model = AddDisposable(modelInstance);
 
         _particleSystems = particleSystems;
-        _context = context;
+        _gameEngine = context;
 
         AddDisposeAction(() => Deactivate());
     }
@@ -766,7 +766,7 @@ public class W3dModelDrawModuleData : DrawModuleData, IParseCallbacks
         _transitionStatesGenerals.Clear();
     }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
     {
         return new W3dModelDraw(this, drawable, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -90,13 +90,13 @@ public class W3dModelDraw : DrawModule
     internal W3dModelDraw(
         W3dModelDrawModuleData data,
         Drawable drawable,
-        GameEngine context)
+        GameEngine gameEngine)
     {
         _data = data;
         Drawable = drawable;
-        _gameEngine = context;
+        _gameEngine = gameEngine;
 
-        UpdateConditionState(new BitArray<ModelConditionFlag>(), context.Random);
+        UpdateConditionState(new BitArray<ModelConditionFlag>(), gameEngine.Random);
 
         _unknownSomething = new List<W3dModelDrawSomething>[3];
         for (var i = 0; i < _unknownSomething.Length; i++)
@@ -433,12 +433,12 @@ internal sealed class W3dModelDrawConditionState : DisposableBase
     public W3dModelDrawConditionState(
         ModelInstance modelInstance,
         IEnumerable<ParticleSystem> particleSystems,
-        GameEngine context)
+        GameEngine gameEngine)
     {
         Model = AddDisposable(modelInstance);
 
         _particleSystems = particleSystems;
-        _gameEngine = context;
+        _gameEngine = gameEngine;
 
         AddDisposeAction(() => Deactivate());
     }
@@ -766,9 +766,9 @@ public class W3dModelDrawModuleData : DrawModuleData, IParseCallbacks
         _transitionStatesGenerals.Clear();
     }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
     {
-        return new W3dModelDraw(this, drawable, context);
+        return new W3dModelDraw(this, drawable, gameEngine);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dOverlordTankDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dOverlordTankDraw.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class W3dOverlordTankDraw : W3dTankDraw
 {
-    internal W3dOverlordTankDraw(W3dOverlordTankDrawModuleData data, Drawable drawable, GameContext context)
+    internal W3dOverlordTankDraw(W3dOverlordTankDrawModuleData data, Drawable drawable, GameEngine context)
         : base(data, drawable, context)
     {
     }
@@ -30,7 +30,7 @@ public sealed class W3dOverlordTankDrawModuleData : W3dTankDrawModuleData
     private static new readonly IniParseTable<W3dOverlordTankDrawModuleData> FieldParseTable = W3dTankDrawModuleData.FieldParseTable
         .Concat(new IniParseTable<W3dOverlordTankDrawModuleData>());
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
     {
         return new W3dOverlordTankDraw(this, drawable, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dOverlordTankDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dOverlordTankDraw.cs
@@ -5,8 +5,8 @@ namespace OpenSage.Logic.Object;
 
 public sealed class W3dOverlordTankDraw : W3dTankDraw
 {
-    internal W3dOverlordTankDraw(W3dOverlordTankDrawModuleData data, Drawable drawable, GameEngine context)
-        : base(data, drawable, context)
+    internal W3dOverlordTankDraw(W3dOverlordTankDrawModuleData data, Drawable drawable, GameEngine gameEngine)
+        : base(data, drawable, gameEngine)
     {
     }
 
@@ -30,8 +30,8 @@ public sealed class W3dOverlordTankDrawModuleData : W3dTankDrawModuleData
     private static new readonly IniParseTable<W3dOverlordTankDrawModuleData> FieldParseTable = W3dTankDrawModuleData.FieldParseTable
         .Concat(new IniParseTable<W3dOverlordTankDrawModuleData>());
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
     {
-        return new W3dOverlordTankDraw(this, drawable, context);
+        return new W3dOverlordTankDraw(this, drawable, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dProjectileStreamDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dProjectileStreamDraw.cs
@@ -77,7 +77,7 @@ public sealed class W3dProjectileStreamDrawModuleData : DrawModuleData
     public float ScrollRate { get; private set; }
     public int MaxSegments { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
     {
         return new W3dProjectileStreamDraw();
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dProjectileStreamDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dProjectileStreamDraw.cs
@@ -77,7 +77,7 @@ public sealed class W3dProjectileStreamDrawModuleData : DrawModuleData
     public float ScrollRate { get; private set; }
     public int MaxSegments { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
     {
         return new W3dProjectileStreamDraw();
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dRopeDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dRopeDraw.cs
@@ -86,7 +86,7 @@ public sealed class W3dRopeDrawModuleData : DrawModuleData
 
     private static readonly IniParseTable<W3dRopeDrawModuleData> FieldParseTable = new IniParseTable<W3dRopeDrawModuleData>();
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
     {
         return new W3dRopeDraw();
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dRopeDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dRopeDraw.cs
@@ -86,7 +86,7 @@ public sealed class W3dRopeDrawModuleData : DrawModuleData
 
     private static readonly IniParseTable<W3dRopeDrawModuleData> FieldParseTable = new IniParseTable<W3dRopeDrawModuleData>();
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
     {
         return new W3dRopeDraw();
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dScienceModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dScienceModelDraw.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class W3dScienceModelDraw : W3dModelDraw
 {
-    internal W3dScienceModelDraw(W3dScienceModelDrawModuleData data, Drawable drawable, GameContext context)
+    internal W3dScienceModelDraw(W3dScienceModelDrawModuleData data, Drawable drawable, GameEngine context)
         : base(data, drawable, context)
     {
     }
@@ -30,7 +30,7 @@ public sealed class W3dScienceModelDrawModuleData : W3dModelDrawModuleData
 
     public string RequiredScience { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
     {
         return new W3dScienceModelDraw(this, drawable, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dScienceModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dScienceModelDraw.cs
@@ -5,8 +5,8 @@ namespace OpenSage.Logic.Object;
 
 public sealed class W3dScienceModelDraw : W3dModelDraw
 {
-    internal W3dScienceModelDraw(W3dScienceModelDrawModuleData data, Drawable drawable, GameEngine context)
-        : base(data, drawable, context)
+    internal W3dScienceModelDraw(W3dScienceModelDrawModuleData data, Drawable drawable, GameEngine gameEngine)
+        : base(data, drawable, gameEngine)
     {
     }
 
@@ -30,8 +30,8 @@ public sealed class W3dScienceModelDrawModuleData : W3dModelDrawModuleData
 
     public string RequiredScience { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
     {
-        return new W3dScienceModelDraw(this, drawable, context);
+        return new W3dScienceModelDraw(this, drawable, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dScriptedModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dScriptedModelDraw.cs
@@ -13,7 +13,7 @@ public class W3dScriptedModelDraw : W3dModelDraw
     internal W3dScriptedModelDraw(
         W3dScriptedModelDrawModuleData data,
         Drawable drawable,
-        GameContext context)
+        GameEngine context)
         : base(data, drawable, context)
     {
     }
@@ -79,7 +79,7 @@ public class W3dScriptedModelDrawModuleData : W3dModelDrawModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool RandomTextureFixedRandomIndex { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
     {
         return new W3dScriptedModelDraw(this, drawable, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dScriptedModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dScriptedModelDraw.cs
@@ -13,8 +13,8 @@ public class W3dScriptedModelDraw : W3dModelDraw
     internal W3dScriptedModelDraw(
         W3dScriptedModelDrawModuleData data,
         Drawable drawable,
-        GameEngine context)
-        : base(data, drawable, context)
+        GameEngine gameEngine)
+        : base(data, drawable, gameEngine)
     {
     }
 }
@@ -79,9 +79,9 @@ public class W3dScriptedModelDrawModuleData : W3dModelDrawModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool RandomTextureFixedRandomIndex { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
     {
-        return new W3dScriptedModelDraw(this, drawable, context);
+        return new W3dScriptedModelDraw(this, drawable, gameEngine);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dSupplyDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dSupplyDraw.cs
@@ -11,8 +11,8 @@ public sealed class W3dSupplyDraw : W3dModelDraw
     private readonly Dictionary<string, int> _boxBoneMap;
     private readonly string _bonePrefix;
 
-    internal W3dSupplyDraw(W3dSupplyDrawModuleData data, Drawable drawable, GameEngine context)
-        : base(data, drawable, context)
+    internal W3dSupplyDraw(W3dSupplyDrawModuleData data, Drawable drawable, GameEngine gameEngine)
+        : base(data, drawable, gameEngine)
     {
         _bonePrefix = data.SupplyBonePrefix;
         _boxBoneMap = string.IsNullOrEmpty(data.SupplyBonePrefix)
@@ -58,8 +58,8 @@ public sealed class W3dSupplyDrawModuleData : W3dModelDrawModuleData
 
     public string SupplyBonePrefix { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
     {
-        return new W3dSupplyDraw(this, drawable, context);
+        return new W3dSupplyDraw(this, drawable, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dSupplyDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dSupplyDraw.cs
@@ -11,7 +11,7 @@ public sealed class W3dSupplyDraw : W3dModelDraw
     private readonly Dictionary<string, int> _boxBoneMap;
     private readonly string _bonePrefix;
 
-    internal W3dSupplyDraw(W3dSupplyDrawModuleData data, Drawable drawable, GameContext context)
+    internal W3dSupplyDraw(W3dSupplyDrawModuleData data, Drawable drawable, GameEngine context)
         : base(data, drawable, context)
     {
         _bonePrefix = data.SupplyBonePrefix;
@@ -58,7 +58,7 @@ public sealed class W3dSupplyDrawModuleData : W3dModelDrawModuleData
 
     public string SupplyBonePrefix { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
     {
         return new W3dSupplyDraw(this, drawable, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTankDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTankDraw.cs
@@ -23,12 +23,12 @@ public class W3dTankDraw : W3dModelDraw
         "TREADSR01",
     };
 
-    internal W3dTankDraw(W3dTankDrawModuleData data, Drawable drawable, GameEngine context)
-        : base(data, drawable, context)
+    internal W3dTankDraw(W3dTankDrawModuleData data, Drawable drawable, GameEngine gameEngine)
+        : base(data, drawable, gameEngine)
     {
         _data = data;
-        _treadDebrisLeft = data.TreadDebrisLeft?.Value ?? context.AssetLoadContext.AssetStore.FXParticleSystemTemplates.GetByName("TrackDebrisDirtLeft");
-        _treadDebrisRight = data.TreadDebrisRight?.Value ?? context.AssetLoadContext.AssetStore.FXParticleSystemTemplates.GetByName("TrackDebrisDirtRight");
+        _treadDebrisLeft = data.TreadDebrisLeft?.Value ?? gameEngine.AssetLoadContext.AssetStore.FXParticleSystemTemplates.GetByName("TrackDebrisDirtLeft");
+        _treadDebrisRight = data.TreadDebrisRight?.Value ?? gameEngine.AssetLoadContext.AssetStore.FXParticleSystemTemplates.GetByName("TrackDebrisDirtRight");
 
         _turretBone = FindBoneInstance("Turret");
         _hasTurret = _turretBone != null;
@@ -104,8 +104,8 @@ public class W3dTankDrawModuleData : W3dModelDrawModuleData
     public float TreadDriveSpeedFraction { get; private set; }
     public float TreadPivotSpeedFraction { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
     {
-        return new W3dTankDraw(this, drawable, context);
+        return new W3dTankDraw(this, drawable, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTankDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTankDraw.cs
@@ -23,7 +23,7 @@ public class W3dTankDraw : W3dModelDraw
         "TREADSR01",
     };
 
-    internal W3dTankDraw(W3dTankDrawModuleData data, Drawable drawable, GameContext context)
+    internal W3dTankDraw(W3dTankDrawModuleData data, Drawable drawable, GameEngine context)
         : base(data, drawable, context)
     {
         _data = data;
@@ -104,7 +104,7 @@ public class W3dTankDrawModuleData : W3dModelDrawModuleData
     public float TreadDriveSpeedFraction { get; private set; }
     public float TreadPivotSpeedFraction { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
     {
         return new W3dTankDraw(this, drawable, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTracerDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTracerDraw.cs
@@ -17,7 +17,7 @@ public class W3dTracerDraw : DrawModule
 
     public override IEnumerable<BitArray<ModelConditionFlag>> ModelConditionStates => Array.Empty<BitArray<ModelConditionFlag>>();
 
-    internal W3dTracerDraw(W3dTracerDrawModuleData data, GameContext context)
+    internal W3dTracerDraw(W3dTracerDrawModuleData data, GameEngine context)
     {
         _data = data;
     }
@@ -72,7 +72,7 @@ public sealed class W3dTracerDrawModuleData : DrawModuleData
 
     private static readonly IniParseTable<W3dTracerDrawModuleData> FieldParseTable = new IniParseTable<W3dTracerDrawModuleData>();
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
     {
         return new W3dTracerDraw(this, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTracerDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTracerDraw.cs
@@ -17,7 +17,7 @@ public class W3dTracerDraw : DrawModule
 
     public override IEnumerable<BitArray<ModelConditionFlag>> ModelConditionStates => Array.Empty<BitArray<ModelConditionFlag>>();
 
-    internal W3dTracerDraw(W3dTracerDrawModuleData data, GameEngine context)
+    internal W3dTracerDraw(W3dTracerDrawModuleData data, GameEngine gameEngine)
     {
         _data = data;
     }
@@ -72,8 +72,8 @@ public sealed class W3dTracerDrawModuleData : DrawModuleData
 
     private static readonly IniParseTable<W3dTracerDrawModuleData> FieldParseTable = new IniParseTable<W3dTracerDrawModuleData>();
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
     {
-        return new W3dTracerDraw(this, context);
+        return new W3dTracerDraw(this, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTreeDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTreeDraw.cs
@@ -143,8 +143,8 @@ public sealed class W3dTreeDrawModuleData : DrawModuleData
     [AddedIn(SageGame.Bfme)]
     public string MorphTree { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
     {
-        return new W3dTreeDraw(this, context);
+        return new W3dTreeDraw(this, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTreeDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTreeDraw.cs
@@ -16,17 +16,17 @@ namespace OpenSage.Logic.Object;
 [AddedIn(SageGame.Bfme)]
 public sealed class W3dTreeDraw : DrawModule
 {
-    private readonly GameContext _gameContext;
+    private readonly GameEngine _gameEngine;
     private ModelInstance _modelInstance;
     private readonly W3dTreeDrawModuleData _moduleData;
 
     public override IEnumerable<BitArray<ModelConditionFlag>> ModelConditionStates { get; } = Array.Empty<BitArray<ModelConditionFlag>>();
 
-    internal W3dTreeDraw(W3dTreeDrawModuleData moduleData, GameContext context)
+    internal W3dTreeDraw(W3dTreeDrawModuleData moduleData, GameEngine gameEngine)
     {
-        _gameContext = context;
+        _gameEngine = gameEngine;
         _moduleData = moduleData;
-        _modelInstance = AddDisposable(_moduleData.Model.Value.CreateInstance(_gameContext.AssetLoadContext));
+        _modelInstance = AddDisposable(_moduleData.Model.Value.CreateInstance(_gameEngine.AssetLoadContext));
         //TODO: overwrite texture somehow & take care of other fields
     }
 
@@ -143,7 +143,7 @@ public sealed class W3dTreeDrawModuleData : DrawModuleData
     [AddedIn(SageGame.Bfme)]
     public string MorphTree { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
     {
         return new W3dTreeDraw(this, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
@@ -12,8 +12,8 @@ public sealed class W3dTruckDraw : W3dModelDraw
 
     private readonly (string name, bool affectedBySteering)[] _boneList;
 
-    internal W3dTruckDraw(W3dTruckDrawModuleData data, Drawable drawable, GameEngine context)
-        : base(data, drawable, context)
+    internal W3dTruckDraw(W3dTruckDrawModuleData data, Drawable drawable, GameEngine gameEngine)
+        : base(data, drawable, gameEngine)
     {
         _data = data;
         _boneList = new[] {
@@ -185,8 +185,8 @@ public class W3dTruckDrawModuleData : W3dModelDrawModuleData
     [AddedIn(SageGame.Bfme2Rotwk)]
     public RandomTexture RandomTexture { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
     {
-        return new W3dTruckDraw(this, drawable, context);
+        return new W3dTruckDraw(this, drawable, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
@@ -12,7 +12,7 @@ public sealed class W3dTruckDraw : W3dModelDraw
 
     private readonly (string name, bool affectedBySteering)[] _boneList;
 
-    internal W3dTruckDraw(W3dTruckDrawModuleData data, Drawable drawable, GameContext context)
+    internal W3dTruckDraw(W3dTruckDrawModuleData data, Drawable drawable, GameEngine context)
         : base(data, drawable, context)
     {
         _data = data;
@@ -185,7 +185,7 @@ public class W3dTruckDrawModuleData : W3dModelDrawModuleData
     [AddedIn(SageGame.Bfme2Rotwk)]
     public RandomTexture RandomTexture { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameContext context)
+    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine context)
     {
         return new W3dTruckDraw(this, drawable, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectDefectionHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectDefectionHelper.cs
@@ -6,7 +6,7 @@ internal sealed class ObjectDefectionHelper : ObjectHelperModule
     private uint _frameEnd;
     private bool _unknown;
 
-    public ObjectDefectionHelper(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public ObjectDefectionHelper(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectDefectionHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectDefectionHelper.cs
@@ -6,7 +6,7 @@ internal sealed class ObjectDefectionHelper : ObjectHelperModule
     private uint _frameEnd;
     private bool _unknown;
 
-    public ObjectDefectionHelper(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public ObjectDefectionHelper(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectFiringTrackerHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectFiringTrackerHelper.cs
@@ -7,7 +7,7 @@ internal sealed class ObjectFiringTrackerHelper : UpdateModule
 
     protected override UpdateOrder UpdateOrder => UpdateOrder.Order3;
 
-    public ObjectFiringTrackerHelper(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public ObjectFiringTrackerHelper(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectFiringTrackerHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectFiringTrackerHelper.cs
@@ -7,7 +7,7 @@ internal sealed class ObjectFiringTrackerHelper : UpdateModule
 
     protected override UpdateOrder UpdateOrder => UpdateOrder.Order3;
 
-    public ObjectFiringTrackerHelper(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public ObjectFiringTrackerHelper(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectHelperModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectHelperModule.cs
@@ -2,7 +2,7 @@
 
 internal abstract class ObjectHelperModule : UpdateModule
 {
-    protected ObjectHelperModule(GameObject gameObject, GameContext context) : base(gameObject, context)
+    protected ObjectHelperModule(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectHelperModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectHelperModule.cs
@@ -2,7 +2,7 @@
 
 internal abstract class ObjectHelperModule : UpdateModule
 {
-    protected ObjectHelperModule(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    protected ObjectHelperModule(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectRepulsorHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectRepulsorHelper.cs
@@ -3,7 +3,7 @@
 internal sealed class ObjectRepulsorHelper : ObjectHelperModule
 {
     // TODO
-    public ObjectRepulsorHelper(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public ObjectRepulsorHelper(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectRepulsorHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectRepulsorHelper.cs
@@ -3,7 +3,7 @@
 internal sealed class ObjectRepulsorHelper : ObjectHelperModule
 {
     // TODO
-    public ObjectRepulsorHelper(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public ObjectRepulsorHelper(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectSpecialModelConditionHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectSpecialModelConditionHelper.cs
@@ -8,7 +8,7 @@
 internal sealed class ObjectSpecialModelConditionHelper : ObjectHelperModule
 {
     // TODO
-    public ObjectSpecialModelConditionHelper(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public ObjectSpecialModelConditionHelper(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectSpecialModelConditionHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectSpecialModelConditionHelper.cs
@@ -8,7 +8,7 @@
 internal sealed class ObjectSpecialModelConditionHelper : ObjectHelperModule
 {
     // TODO
-    public ObjectSpecialModelConditionHelper(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public ObjectSpecialModelConditionHelper(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectWeaponStatusHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectWeaponStatusHelper.cs
@@ -5,7 +5,7 @@ internal sealed class ObjectWeaponStatusHelper : ObjectHelperModule
     // TODO
     protected override UpdateOrder UpdateOrder => UpdateOrder.Order3;
 
-    public ObjectWeaponStatusHelper(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public ObjectWeaponStatusHelper(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectWeaponStatusHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectWeaponStatusHelper.cs
@@ -5,7 +5,7 @@ internal sealed class ObjectWeaponStatusHelper : ObjectHelperModule
     // TODO
     protected override UpdateOrder UpdateOrder => UpdateOrder.Order3;
 
-    public ObjectWeaponStatusHelper(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public ObjectWeaponStatusHelper(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/StatusDamageHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/StatusDamageHelper.cs
@@ -2,7 +2,7 @@
 
 internal sealed class StatusDamageHelper : ObjectHelperModule
 {
-    public StatusDamageHelper(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public StatusDamageHelper(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/StatusDamageHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/StatusDamageHelper.cs
@@ -2,7 +2,7 @@
 
 internal sealed class StatusDamageHelper : ObjectHelperModule
 {
-    public StatusDamageHelper(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public StatusDamageHelper(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/SubdualDamageHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/SubdualDamageHelper.cs
@@ -2,7 +2,7 @@
 
 internal sealed class SubdualDamageHelper : ObjectHelperModule
 {
-    public SubdualDamageHelper(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public SubdualDamageHelper(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/SubdualDamageHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/SubdualDamageHelper.cs
@@ -2,7 +2,7 @@
 
 internal sealed class SubdualDamageHelper : ObjectHelperModule
 {
-    public SubdualDamageHelper(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public SubdualDamageHelper(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/TempWeaponBonusHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/TempWeaponBonusHelper.cs
@@ -4,7 +4,7 @@ internal sealed class TempWeaponBonusHelper : ObjectHelperModule
 {
     private int _unknownInt;
 
-    public TempWeaponBonusHelper(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public TempWeaponBonusHelper(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/TempWeaponBonusHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/TempWeaponBonusHelper.cs
@@ -4,7 +4,7 @@ internal sealed class TempWeaponBonusHelper : ObjectHelperModule
 {
     private int _unknownInt;
 
-    public TempWeaponBonusHelper(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public TempWeaponBonusHelper(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Locomotor.cs
+++ b/src/OpenSage.Game/Logic/Object/Locomotor.cs
@@ -95,7 +95,7 @@ public sealed class Locomotor : IPersistableObject
 
     private void ResetDonutTimer()
     {
-        _donutTimer = _gameEngine.GameLogic.CurrentFrame + new LogicFrameSpan((uint)(DonutTimeDelaySeconds * Game.LogicFramesPerSecond));
+        _donutTimer = _gameEngine.GameLogic.CurrentFrame + new LogicFrameSpan((uint)(DonutTimeDelaySeconds * GameEngine.LogicFramesPerSecond));
     }
 
     private bool HasMovementPenalty(BodyDamageType condition)
@@ -433,7 +433,7 @@ public sealed class Locomotor : IPersistableObject
 
         if (wasBraking)
         {
-            const float minVel = AIPathfind.PathfindCellSizeF / Game.LogicFramesPerSecond;
+            const float minVel = AIPathfind.PathfindCellSizeF / GameEngine.LogicFramesPerSecond;
 
             if (obj.IsKindOf(ObjectKinds.Projectile))
             {
@@ -1026,7 +1026,7 @@ public sealed class Locomotor : IPersistableObject
         }
 
         const float FIFTEEN_DEGREES = MathF.PI / 12.0f;
-        const float PROJECT_FRAMES = Game.LogicFramesPerSecond / 2; // Project out 1/2 second.
+        const float PROJECT_FRAMES = GameEngine.LogicFramesPerSecond / 2; // Project out 1/2 second.
         if (MathF.Abs(relAngle) > FIFTEEN_DEGREES)
         {
             // If we're turning more than 10 degrees, check & see if we're moving into "impassable territory"

--- a/src/OpenSage.Game/Logic/Object/Locomotor.cs
+++ b/src/OpenSage.Game/Logic/Object/Locomotor.cs
@@ -66,9 +66,9 @@ public sealed class Locomotor : IPersistableObject
 
     public float MinSpeed => LocomotorTemplate.MinSpeed;
 
-    public Locomotor(GameEngine context, LocomotorTemplate template, float baseSpeed)
+    public Locomotor(GameEngine gameEngine, LocomotorTemplate template, float baseSpeed)
     {
-        _gameEngine = context;
+        _gameEngine = gameEngine;
 
         LocomotorTemplate = template;
 
@@ -81,9 +81,9 @@ public sealed class Locomotor : IPersistableObject
         _preferredHeight = template.PreferredHeight;
         _preferredHeightDamping = template.PreferredHeightDamping;
 
-        _angleOffset = context.Random.NextSingle(-MathF.PI / 6.0f, MathF.PI / 6.0f);
-        _offsetIncrement = (MathF.PI / 40.0f) * (context.Random.NextSingle(0.8f, 1.2f) / template.WanderLengthFactor);
-        SetFlag(LocomotorFlags.OffsetIncreasing, context.Random.NextBoolean());
+        _angleOffset = gameEngine.Random.NextSingle(-MathF.PI / 6.0f, MathF.PI / 6.0f);
+        _offsetIncrement = (MathF.PI / 40.0f) * (gameEngine.Random.NextSingle(0.8f, 1.2f) / template.WanderLengthFactor);
+        SetFlag(LocomotorFlags.OffsetIncreasing, gameEngine.Random.NextBoolean());
 
         ResetDonutTimer();
     }

--- a/src/OpenSage.Game/Logic/Object/LocomotorSet.cs
+++ b/src/OpenSage.Game/Logic/Object/LocomotorSet.cs
@@ -10,10 +10,10 @@ public sealed class LocomotorSet : IPersistableObject
     private readonly List<Locomotor> _locomotors;
     private Surfaces _surfaces;
 
-    public LocomotorSet(GameObject gameObject, GameEngine context)
+    public LocomotorSet(GameObject gameObject, GameEngine gameEngine)
     {
         _gameObject = gameObject;
-        _gameEngine = context;
+        _gameEngine = gameEngine;
         _locomotors = new List<Locomotor>();
     }
 

--- a/src/OpenSage.Game/Logic/Object/LocomotorSet.cs
+++ b/src/OpenSage.Game/Logic/Object/LocomotorSet.cs
@@ -6,14 +6,14 @@ namespace OpenSage.Logic.Object;
 public sealed class LocomotorSet : IPersistableObject
 {
     private readonly GameObject _gameObject;
-    private readonly GameContext _context;
+    private readonly GameEngine _gameEngine;
     private readonly List<Locomotor> _locomotors;
     private Surfaces _surfaces;
 
-    public LocomotorSet(GameObject gameObject, GameContext context)
+    public LocomotorSet(GameObject gameObject, GameEngine context)
     {
         _gameObject = gameObject;
-        _context = context;
+        _gameEngine = context;
         _locomotors = new List<Locomotor>();
     }
 
@@ -26,7 +26,7 @@ public sealed class LocomotorSet : IPersistableObject
             var locomotorTemplate = locomotorTemplateReference.Value;
 
             _locomotors.Add(new Locomotor(
-                _context,
+                _gameEngine,
                 locomotorTemplate,
                 locomotorSetTemplate.Speed));
 
@@ -88,7 +88,7 @@ public sealed class LocomotorSet : IPersistableObject
 
                 var locomotorTemplate = reader.AssetStore.LocomotorTemplates.GetByName(locomotorTemplateName);
 
-                var locomotor = new Locomotor(_context, locomotorTemplate, 100);
+                var locomotor = new Locomotor(_gameEngine, locomotorTemplate, 100);
 
                 reader.PersistObject(locomotor);
 

--- a/src/OpenSage.Game/Logic/Object/LocomotorTemplate.cs
+++ b/src/OpenSage.Game/Logic/Object/LocomotorTemplate.cs
@@ -134,7 +134,7 @@ public sealed class LocomotorTemplate : BaseAsset
 
     private static float ParseFrictionToLogicFrames(IniParser parser)
     {
-        return parser.ParseFloat() * Game.SecondsPerLogicFrame;
+        return parser.ParseFloat() * GameEngine.SecondsPerLogicFrame;
     }
 
     internal const float BigNumber = 99999.0f;

--- a/src/OpenSage.Game/Logic/Object/ObjectCreationList.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectCreationList.cs
@@ -129,11 +129,11 @@ public sealed class CreateDebrisOCNugget : OCNugget
     internal override List<GameObject> Execute(BehaviorUpdateContext context, Vector3? position)
     {
         // TODO: Cache this.
-        var debrisObjectDefinition = context.GameContext.AssetLoadContext.AssetStore.ObjectDefinitions.GetByName("GenericDebris");
+        var debrisObjectDefinition = context.GameEngine.AssetLoadContext.AssetStore.ObjectDefinitions.GetByName("GenericDebris");
 
-        var debrisObject = context.GameContext.GameLogic.CreateObject(debrisObjectDefinition, context.GameObject.Owner);
+        var debrisObject = context.GameEngine.GameLogic.CreateObject(debrisObjectDefinition, context.GameObject.Owner);
 
-        var lifeTime = context.GameContext.GetRandomLogicFrameSpan(MinLifetime, MaxLifetime);
+        var lifeTime = context.GameEngine.GetRandomLogicFrameSpan(MinLifetime, MaxLifetime);
         debrisObject.LifeTime = context.LogicFrame + lifeTime;
 
         debrisObject.UpdateTransform(context.GameObject.Translation + Offset, context.GameObject.Rotation);
@@ -142,7 +142,7 @@ public sealed class CreateDebrisOCNugget : OCNugget
         // Model
         var w3dDebrisDraw = (W3dDebrisDraw)debrisObject.Drawable.DrawModules[0];
         // TODO
-        //var modelName = ModelNames[context.GameContext.Random.Next(ModelNames.Length)];
+        //var modelName = ModelNames[context.GameEngine.Random.Next(ModelNames.Length)];
         var modelName = ModelNames[0];
         w3dDebrisDraw.SetModelName(modelName);
 
@@ -155,8 +155,8 @@ public sealed class CreateDebrisOCNugget : OCNugget
             var forceMultiplier = 200 / 30.0f * Mass; // TODO: Is this right?
             physicsBehavior.ApplyForce(
                 new Vector3(
-                    ((float)context.GameContext.Random.NextDouble() - 0.5f) * DispositionIntensity * forceMultiplier,
-                    ((float)context.GameContext.Random.NextDouble() - 0.5f) * DispositionIntensity * forceMultiplier,
+                    ((float)context.GameEngine.Random.NextDouble() - 0.5f) * DispositionIntensity * forceMultiplier,
+                    ((float)context.GameEngine.Random.NextDouble() - 0.5f) * DispositionIntensity * forceMultiplier,
                     DispositionIntensity * forceMultiplier));
         }
 
@@ -340,7 +340,7 @@ public sealed class CreateObjectOCNugget : OCNugget
         {
             for (var i = 0; i < Count; i++)
             {
-                var newGameObject = context.GameContext.GameLogic.CreateObject(objectName.Value, context.GameObject.Owner);
+                var newGameObject = context.GameEngine.GameLogic.CreateObject(objectName.Value, context.GameObject.Owner);
                 // TODO: Count
                 // TODO: Disposition
                 // TODO: DispositionIntensity
@@ -357,7 +357,7 @@ public sealed class CreateObjectOCNugget : OCNugget
                 var lifetimeUpdate = newGameObject.FindBehavior<LifetimeUpdate>();
                 if (lifetimeUpdate != null)
                 {
-                    var lifetime = context.GameContext.GetRandomLogicFrameSpan(MinLifetime, MaxLifetime);
+                    var lifetime = context.GameEngine.GetRandomLogicFrameSpan(MinLifetime, MaxLifetime);
                     lifetimeUpdate.FrameToDie = context.LogicFrame + lifetime;
                 }
 

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/CashBountyPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/CashBountyPower.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class CashBountyPower : SpecialPowerModule
 {
-    internal CashBountyPower(GameObject gameObject, GameEngine context, CashBountyPowerModuleData moduleData) : base(gameObject, context, moduleData)
+    internal CashBountyPower(GameObject gameObject, GameEngine gameEngine, CashBountyPowerModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -29,8 +29,8 @@ public sealed class CashBountyPowerModuleData : SpecialPowerModuleData
 
     public Percentage Bounty { get; private set; }
 
-    internal override CashBountyPower CreateModule(GameObject gameObject, GameEngine context)
+    internal override CashBountyPower CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new CashBountyPower(gameObject, context, this);
+        return new CashBountyPower(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/CashBountyPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/CashBountyPower.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class CashBountyPower : SpecialPowerModule
 {
-    internal CashBountyPower(GameObject gameObject, GameContext context, CashBountyPowerModuleData moduleData) : base(gameObject, context, moduleData)
+    internal CashBountyPower(GameObject gameObject, GameEngine context, CashBountyPowerModuleData moduleData) : base(gameObject, context, moduleData)
     {
     }
 
@@ -29,7 +29,7 @@ public sealed class CashBountyPowerModuleData : SpecialPowerModuleData
 
     public Percentage Bounty { get; private set; }
 
-    internal override CashBountyPower CreateModule(GameObject gameObject, GameContext context)
+    internal override CashBountyPower CreateModule(GameObject gameObject, GameEngine context)
     {
         return new CashBountyPower(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/CashHackSpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/CashHackSpecialPower.cs
@@ -12,7 +12,7 @@ public sealed class CashHackSpecialPower : SpecialPowerModule
 
     private uint _currentAmount;
 
-    internal CashHackSpecialPower(GameObject gameObject, GameContext context, CashHackSpecialPowerModuleData moduleData) : base(gameObject, context, moduleData)
+    internal CashHackSpecialPower(GameObject gameObject, GameEngine context, CashHackSpecialPowerModuleData moduleData) : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
         _currentAmount = (uint)moduleData.MoneyAmount;
@@ -75,7 +75,7 @@ public sealed class CashHackSpecialPowerModuleData : SpecialPowerModuleData
     /// </summary>
     public int MoneyAmount { get; private set; }
 
-    internal override CashHackSpecialPower CreateModule(GameObject gameObject, GameContext context)
+    internal override CashHackSpecialPower CreateModule(GameObject gameObject, GameEngine context)
     {
         return new CashHackSpecialPower(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/CashHackSpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/CashHackSpecialPower.cs
@@ -12,7 +12,7 @@ public sealed class CashHackSpecialPower : SpecialPowerModule
 
     private uint _currentAmount;
 
-    internal CashHackSpecialPower(GameObject gameObject, GameEngine context, CashHackSpecialPowerModuleData moduleData) : base(gameObject, context, moduleData)
+    internal CashHackSpecialPower(GameObject gameObject, GameEngine gameEngine, CashHackSpecialPowerModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
         _currentAmount = (uint)moduleData.MoneyAmount;
@@ -75,9 +75,9 @@ public sealed class CashHackSpecialPowerModuleData : SpecialPowerModuleData
     /// </summary>
     public int MoneyAmount { get; private set; }
 
-    internal override CashHackSpecialPower CreateModule(GameObject gameObject, GameEngine context)
+    internal override CashHackSpecialPower CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new CashHackSpecialPower(gameObject, context, this);
+        return new CashHackSpecialPower(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/CleanupAreaPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/CleanupAreaPower.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class CleanupAreaPower : SpecialPowerModule
 {
-    internal CleanupAreaPower(GameObject gameObject, GameContext context, CleanupAreaPowerModuleData moduleData) : base(gameObject, context, moduleData)
+    internal CleanupAreaPower(GameObject gameObject, GameEngine context, CleanupAreaPowerModuleData moduleData) : base(gameObject, context, moduleData)
     {
     }
 
@@ -40,7 +40,7 @@ public sealed class CleanupAreaPowerModuleData : SpecialPowerModuleData
 
     public float MaxMoveDistanceFromLocation { get; private set; }
 
-    internal override CleanupAreaPower CreateModule(GameObject gameObject, GameContext context)
+    internal override CleanupAreaPower CreateModule(GameObject gameObject, GameEngine context)
     {
         return new CleanupAreaPower(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/CleanupAreaPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/CleanupAreaPower.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class CleanupAreaPower : SpecialPowerModule
 {
-    internal CleanupAreaPower(GameObject gameObject, GameEngine context, CleanupAreaPowerModuleData moduleData) : base(gameObject, context, moduleData)
+    internal CleanupAreaPower(GameObject gameObject, GameEngine gameEngine, CleanupAreaPowerModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -40,8 +40,8 @@ public sealed class CleanupAreaPowerModuleData : SpecialPowerModuleData
 
     public float MaxMoveDistanceFromLocation { get; private set; }
 
-    internal override CleanupAreaPower CreateModule(GameObject gameObject, GameEngine context)
+    internal override CleanupAreaPower CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new CleanupAreaPower(gameObject, context, this);
+        return new CleanupAreaPower(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/DefectorSpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/DefectorSpecialPower.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class DefectorSpecialPower : SpecialPowerModule
 {
-    internal DefectorSpecialPower(GameObject gameObject, GameContext context, DefectorSpecialPowerModuleData moduleData) : base(gameObject, context, moduleData)
+    internal DefectorSpecialPower(GameObject gameObject, GameEngine context, DefectorSpecialPowerModuleData moduleData) : base(gameObject, context, moduleData)
     {
     }
 
@@ -29,7 +29,7 @@ public sealed class DefectorSpecialPowerModuleData : SpecialPowerModuleData
     private static new readonly IniParseTable<DefectorSpecialPowerModuleData> FieldParseTable = SpecialPowerModuleData.FieldParseTable
         .Concat(new IniParseTable<DefectorSpecialPowerModuleData>());
 
-    internal override DefectorSpecialPower CreateModule(GameObject gameObject, GameContext context)
+    internal override DefectorSpecialPower CreateModule(GameObject gameObject, GameEngine context)
     {
         return new DefectorSpecialPower(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/DefectorSpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/DefectorSpecialPower.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class DefectorSpecialPower : SpecialPowerModule
 {
-    internal DefectorSpecialPower(GameObject gameObject, GameEngine context, DefectorSpecialPowerModuleData moduleData) : base(gameObject, context, moduleData)
+    internal DefectorSpecialPower(GameObject gameObject, GameEngine gameEngine, DefectorSpecialPowerModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -29,8 +29,8 @@ public sealed class DefectorSpecialPowerModuleData : SpecialPowerModuleData
     private static new readonly IniParseTable<DefectorSpecialPowerModuleData> FieldParseTable = SpecialPowerModuleData.FieldParseTable
         .Concat(new IniParseTable<DefectorSpecialPowerModuleData>());
 
-    internal override DefectorSpecialPower CreateModule(GameObject gameObject, GameEngine context)
+    internal override DefectorSpecialPower CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new DefectorSpecialPower(gameObject, context, this);
+        return new DefectorSpecialPower(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/OCLSpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/OCLSpecialPower.cs
@@ -13,7 +13,7 @@ public class OCLSpecialPowerModule : SpecialPowerModule
     private readonly OCLSpecialPowerModuleData _moduleData;
     private ObjectCreationList _activeOcl;
 
-    internal OCLSpecialPowerModule(GameObject gameObject, GameContext context, OCLSpecialPowerModuleData moduleData) : base(gameObject, context, moduleData)
+    internal OCLSpecialPowerModule(GameObject gameObject, GameEngine context, OCLSpecialPowerModuleData moduleData) : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
         _activeOcl = _moduleData.OCL.Value;
@@ -53,8 +53,8 @@ public class OCLSpecialPowerModule : SpecialPowerModule
         }
         else
         {
-            var context = new BehaviorUpdateContext(Context, GameObject);
-            Context.ObjectCreationLists.CreateAtPosition(_activeOcl, context, spawnPosition);
+            var context = new BehaviorUpdateContext(GameEngine, GameObject);
+            GameEngine.ObjectCreationLists.CreateAtPosition(_activeOcl, context, spawnPosition);
         }
 
         if (_moduleData.CreateLocation is OCLCreateLocation.CreateAtEdgeNearSource
@@ -71,8 +71,8 @@ public class OCLSpecialPowerModule : SpecialPowerModule
         // the edge position nearest a position will be a cardinal direction from the position depending on the triangular quadrant
         // we can cut the map in half diagonally in both positions to figure out which coordinate to nullify/max
         // we can do this by comparing one coordinate to another via the aspect ratio of the map
-        var maxX = Context.Terrain.HeightMap.MaxXCoordinate;
-        var maxY = Context.Terrain.HeightMap.MaxYCoordinate;
+        var maxX = GameEngine.Terrain.HeightMap.MaxXCoordinate;
+        var maxY = GameEngine.Terrain.HeightMap.MaxYCoordinate;
         var aspectRatio = (float)maxX / maxY;
         var scaledY = sourcePosition.Y * aspectRatio;
         Vector2 edge;
@@ -101,14 +101,14 @@ public class OCLSpecialPowerModule : SpecialPowerModule
             edge = new Vector2(0, sourcePosition.Y);
         }
 
-        return Context.Terrain.HeightMap.GetPositionWithHeight(edge);
+        return GameEngine.Terrain.HeightMap.GetPositionWithHeight(edge);
     }
 
     private Vector3 GetEdgeFarthestFromPosition(Vector3 targetPosition)
     {
         // the edge position furthest from the target is a map corner opposite the target position quadrant
-        var maxX = Context.Terrain.HeightMap.MaxXCoordinate;
-        var maxY = Context.Terrain.HeightMap.MaxYCoordinate;
+        var maxX = GameEngine.Terrain.HeightMap.MaxXCoordinate;
+        var maxY = GameEngine.Terrain.HeightMap.MaxYCoordinate;
         Vector2 corner;
         if (targetPosition.X > maxX / 2f)
         {
@@ -134,7 +134,7 @@ public class OCLSpecialPowerModule : SpecialPowerModule
             corner = new Vector2(maxX, maxY);
         }
 
-        return Context.Terrain.HeightMap.GetPositionWithHeight(corner);
+        return GameEngine.Terrain.HeightMap.GetPositionWithHeight(corner);
     }
 
     internal override void Load(StatePersister reader)
@@ -209,7 +209,7 @@ public sealed class OCLSpecialPowerModuleData : SpecialPowerModuleData
     [AddedIn(SageGame.Bfme2)]
     public WeatherType ChangeWeather { get; private set; }
 
-    internal override OCLSpecialPowerModule CreateModule(GameObject gameObject, GameContext context)
+    internal override OCLSpecialPowerModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new OCLSpecialPowerModule(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/OCLSpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/OCLSpecialPower.cs
@@ -13,7 +13,7 @@ public class OCLSpecialPowerModule : SpecialPowerModule
     private readonly OCLSpecialPowerModuleData _moduleData;
     private ObjectCreationList _activeOcl;
 
-    internal OCLSpecialPowerModule(GameObject gameObject, GameEngine context, OCLSpecialPowerModuleData moduleData) : base(gameObject, context, moduleData)
+    internal OCLSpecialPowerModule(GameObject gameObject, GameEngine gameEngine, OCLSpecialPowerModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
         _activeOcl = _moduleData.OCL.Value;
@@ -209,9 +209,9 @@ public sealed class OCLSpecialPowerModuleData : SpecialPowerModuleData
     [AddedIn(SageGame.Bfme2)]
     public WeatherType ChangeWeather { get; private set; }
 
-    internal override OCLSpecialPowerModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override OCLSpecialPowerModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new OCLSpecialPowerModule(gameObject, context, this);
+        return new OCLSpecialPowerModule(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialAbility.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialAbility.cs
@@ -6,7 +6,7 @@ public sealed class SpecialAbilityModule : SpecialPowerModule
 {
     // TODO
 
-    internal SpecialAbilityModule(GameObject gameObject, GameEngine context, SpecialAbilityModuleData moduleData) : base(gameObject, context, moduleData)
+    internal SpecialAbilityModule(GameObject gameObject, GameEngine gameEngine, SpecialAbilityModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -27,8 +27,8 @@ public sealed class SpecialAbilityModuleData : SpecialPowerModuleData
     private static new readonly IniParseTable<SpecialAbilityModuleData> FieldParseTable = SpecialPowerModuleData.FieldParseTable
         .Concat(new IniParseTable<SpecialAbilityModuleData>());
 
-    internal override SpecialAbilityModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override SpecialAbilityModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SpecialAbilityModule(gameObject, context, this);
+        return new SpecialAbilityModule(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialAbility.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialAbility.cs
@@ -6,7 +6,7 @@ public sealed class SpecialAbilityModule : SpecialPowerModule
 {
     // TODO
 
-    internal SpecialAbilityModule(GameObject gameObject, GameContext context, SpecialAbilityModuleData moduleData) : base(gameObject, context, moduleData)
+    internal SpecialAbilityModule(GameObject gameObject, GameEngine context, SpecialAbilityModuleData moduleData) : base(gameObject, context, moduleData)
     {
     }
 
@@ -27,7 +27,7 @@ public sealed class SpecialAbilityModuleData : SpecialPowerModuleData
     private static new readonly IniParseTable<SpecialAbilityModuleData> FieldParseTable = SpecialPowerModuleData.FieldParseTable
         .Concat(new IniParseTable<SpecialAbilityModuleData>());
 
-    internal override SpecialAbilityModule CreateModule(GameObject gameObject, GameContext context)
+    internal override SpecialAbilityModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new SpecialAbilityModule(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialPower.cs
@@ -33,7 +33,7 @@ public class SpecialPowerModule : BehaviorModule, IUpgradableScienceModule
 
     public SpecialPowerType SpecialPowerType => _moduleData.SpecialPower.Value.Type;
 
-    internal SpecialPowerModule(GameObject gameObject, GameContext context, SpecialPowerModuleData moduleData) : base(gameObject, context)
+    internal SpecialPowerModule(GameObject gameObject, GameEngine gameEngine, SpecialPowerModuleData moduleData) : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
         _reloadFrames = _moduleData.SpecialPower.Value.ReloadTime;
@@ -79,7 +79,7 @@ public class SpecialPowerModule : BehaviorModule, IUpgradableScienceModule
             }
         }
 
-        var progress = 1 - Math.Clamp((availableAtFrame.Value - Math.Min(availableAtFrame.Value, Context.GameLogic.CurrentFrame.Value)) / (float)_reloadFrames.Value, 0, 1);
+        var progress = 1 - Math.Clamp((availableAtFrame.Value - Math.Min(availableAtFrame.Value, GameEngine.GameLogic.CurrentFrame.Value)) / (float)_reloadFrames.Value, 0, 1);
         _ready = progress >= 1;
         return progress;
     }
@@ -115,7 +115,7 @@ public class SpecialPowerModule : BehaviorModule, IUpgradableScienceModule
             return; // this is handled by SpecialPowerCreate
         }
 
-        _availableAtFrame = Context.GameLogic.CurrentFrame;
+        _availableAtFrame = GameEngine.GameLogic.CurrentFrame;
         if (_moduleData.SpecialPower.Value.SharedSyncedTimer)
         {
             var player = GameObject.Owner;
@@ -131,7 +131,7 @@ public class SpecialPowerModule : BehaviorModule, IUpgradableScienceModule
 
     public void ResetCountdown()
     {
-        _availableAtFrame = Context.GameLogic.CurrentFrame + _moduleData.SpecialPower.Value.ReloadTime;
+        _availableAtFrame = GameEngine.GameLogic.CurrentFrame + _moduleData.SpecialPower.Value.ReloadTime;
         _ready = false;
 
         if (_moduleData.SpecialPower.Value.SharedSyncedTimer)
@@ -143,8 +143,8 @@ public class SpecialPowerModule : BehaviorModule, IUpgradableScienceModule
     internal virtual void Activate(Vector3 position)
     {
         var specialPower = _moduleData.SpecialPower.Value;
-        Context.AudioSystem.PlayAudioEvent(specialPower.InitiateSound?.Value);
-        Context.AudioSystem.PlayAudioEvent(position, specialPower.InitiateAtLocationSound?.Value);
+        GameEngine.AudioSystem.PlayAudioEvent(specialPower.InitiateSound?.Value);
+        GameEngine.AudioSystem.PlayAudioEvent(position, specialPower.InitiateAtLocationSound?.Value);
         ResetCountdown();
     }
 
@@ -281,7 +281,7 @@ public class SpecialPowerModuleData : BehaviorModuleData
     [AddedIn(SageGame.Bfme2)]
     public ObjectFilter RequirementsFilterStrategic { get; private set; }
 
-    internal override SpecialPowerModule CreateModule(GameObject gameObject, GameContext context)
+    internal override SpecialPowerModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new SpecialPowerModule(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialPower.cs
@@ -281,8 +281,8 @@ public class SpecialPowerModuleData : BehaviorModuleData
     [AddedIn(SageGame.Bfme2)]
     public ObjectFilter RequirementsFilterStrategic { get; private set; }
 
-    internal override SpecialPowerModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override SpecialPowerModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SpecialPowerModule(gameObject, context, this);
+        return new SpecialPowerModule(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -90,7 +90,7 @@ public class AIUpdate : UpdateModule
 
     protected override UpdateOrder UpdateOrder => UpdateOrder.Order0;
 
-    internal AIUpdate(GameObject gameObject, GameContext context, AIUpdateModuleData moduleData)
+    internal AIUpdate(GameObject gameObject, GameEngine context, AIUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         ModuleData = moduleData;
@@ -110,7 +110,7 @@ public class AIUpdate : UpdateModule
         }
     }
 
-    private protected virtual AIUpdateStateMachine CreateStateMachine() => new(GameObject, Context, this);
+    private protected virtual AIUpdateStateMachine CreateStateMachine() => new(GameObject, GameEngine, this);
 
     internal void SetLocomotor(LocomotorSetType type)
     {
@@ -153,7 +153,7 @@ public class AIUpdate : UpdateModule
         if (!GameObject.Definition.KindOf.Get(ObjectKinds.Aircraft) && targetPoint != GameObject.Translation)
         {
             var start = GameObject.Translation;
-            var path = Context.Navigation.CalculatePath(start, targetPoint, out var endIsPassable);
+            var path = GameEngine.Navigation.CalculatePath(start, targetPoint, out var endIsPassable);
             if (path.Count > 0)
             {
                 path.RemoveAt(0);
@@ -264,7 +264,7 @@ public class AIUpdate : UpdateModule
 
         if (GameObject.ModelConditionFlags.Get(ModelConditionFlag.Moving))
         {
-            context.GameContext.Quadtree.Update(GameObject);
+            context.GameEngine.Quadtree.Update(GameObject);
         }
 
         if (CurrentLocomotor != null)
@@ -561,7 +561,7 @@ public class AIUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public int BurningDeathTime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new AIUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -90,14 +90,14 @@ public class AIUpdate : UpdateModule
 
     protected override UpdateOrder UpdateOrder => UpdateOrder.Order0;
 
-    internal AIUpdate(GameObject gameObject, GameEngine context, AIUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal AIUpdate(GameObject gameObject, GameEngine gameEngine, AIUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         ModuleData = moduleData;
 
         TargetPoints = new List<Vector3>();
 
-        _locomotorSet = new LocomotorSet(gameObject, context);
+        _locomotorSet = new LocomotorSet(gameObject, gameEngine);
         _currentLocomotorSetType = (LocomotorSetType)(-1);
 
         SetLocomotor(LocomotorSetType.Normal);
@@ -106,7 +106,7 @@ public class AIUpdate : UpdateModule
         // and might be overridden in a derived class, causing it to be unintialised despite the assignment above.
         if (moduleData.Turret != null)
         {
-            _turretAIUpdate = moduleData.Turret.CreateTurretAIUpdate(GameObject, context);
+            _turretAIUpdate = moduleData.Turret.CreateTurretAIUpdate(gameObject, gameEngine);
         }
     }
 
@@ -561,9 +561,9 @@ public class AIUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public int BurningDeathTime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new AIUpdate(gameObject, context, this);
+        return new AIUpdate(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AnimalAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AnimalAIUpdate.cs
@@ -8,7 +8,7 @@ public class AnimalAIUpdate : AIUpdate
 {
     internal override AnimalAIUpdateModuleData ModuleData { get; }
 
-    internal AnimalAIUpdate(GameObject gameObject, GameContext context, AnimalAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
+    internal AnimalAIUpdate(GameObject gameObject, GameEngine context, AnimalAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
     {
         ModuleData = moduleData;
     }
@@ -39,7 +39,7 @@ public sealed class AnimalAIUpdateModuleData : AIUpdateModuleData
     public int UpdateTimer { get; private set; }
     public bool AfraidOfCastles { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new AnimalAIUpdate(gameObject, context, this); ;
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AnimalAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AnimalAIUpdate.cs
@@ -8,7 +8,7 @@ public class AnimalAIUpdate : AIUpdate
 {
     internal override AnimalAIUpdateModuleData ModuleData { get; }
 
-    internal AnimalAIUpdate(GameObject gameObject, GameEngine context, AnimalAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
+    internal AnimalAIUpdate(GameObject gameObject, GameEngine gameEngine, AnimalAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
     }
@@ -39,8 +39,8 @@ public sealed class AnimalAIUpdateModuleData : AIUpdateModuleData
     public int UpdateTimer { get; private set; }
     public bool AfraidOfCastles { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new AnimalAIUpdate(gameObject, context, this); ;
+        return new AnimalAIUpdate(gameObject, gameEngine, this); ;
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cs
@@ -9,8 +9,8 @@ public sealed class AssaultTransportAIUpdate : AIUpdate
 
     private readonly List<AssaultTransportMember> _members = new();
 
-    internal AssaultTransportAIUpdate(GameObject gameObject, GameEngine context, AssaultTransportAIUpdateModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal AssaultTransportAIUpdate(GameObject gameObject, GameEngine gameEngine, AssaultTransportAIUpdateModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
     }
@@ -63,8 +63,8 @@ public sealed class AssaultTransportAIUpdateModuleData : AIUpdateModuleData
 
     public float MembersGetHealedAtLifeRatio { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new AssaultTransportAIUpdate(gameObject, context, this);
+        return new AssaultTransportAIUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cs
@@ -9,7 +9,7 @@ public sealed class AssaultTransportAIUpdate : AIUpdate
 
     private readonly List<AssaultTransportMember> _members = new();
 
-    internal AssaultTransportAIUpdate(GameObject gameObject, GameContext context, AssaultTransportAIUpdateModuleData moduleData)
+    internal AssaultTransportAIUpdate(GameObject gameObject, GameEngine context, AssaultTransportAIUpdateModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         ModuleData = moduleData;
@@ -63,7 +63,7 @@ public sealed class AssaultTransportAIUpdateModuleData : AIUpdateModuleData
 
     public float MembersGetHealedAtLifeRatio { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new AssaultTransportAIUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/ChinookAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/ChinookAIUpdate.cs
@@ -14,12 +14,12 @@ public class ChinookAIUpdate : SupplyTruckAIUpdate
     private ChinookState _state;
     private uint _airfieldToRepairAt;
 
-    internal ChinookAIUpdate(GameObject gameObject, GameContext context, ChinookAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
+    internal ChinookAIUpdate(GameObject gameObject, GameEngine context, ChinookAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
     {
         ModuleData = moduleData;
     }
 
-    private protected override ChinookAIUpdateStateMachine CreateStateMachine() => new(GameObject, Context, this);
+    private protected override ChinookAIUpdateStateMachine CreateStateMachine() => new(GameObject, GameEngine, this);
 
     protected override int GetAdditionalValuePerSupplyBox(ScopedAssetCollection<UpgradeTemplate> upgrades)
     {
@@ -67,7 +67,7 @@ internal sealed class ChinookAIUpdateStateMachine : AIUpdateStateMachine
 {
     public override ChinookAIUpdate AIUpdate { get; }
 
-    public ChinookAIUpdateStateMachine(GameObject gameObject, GameContext context, ChinookAIUpdate aiUpdate)
+    public ChinookAIUpdateStateMachine(GameObject gameObject, GameEngine context, ChinookAIUpdate aiUpdate)
         : base(gameObject, context, aiUpdate)
     {
         AIUpdate = aiUpdate;
@@ -134,7 +134,7 @@ public sealed class ChinookAIUpdateModuleData : SupplyTruckAIUpdateModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public string RotorWashParticleSystem { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new ChinookAIUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/ChinookAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/ChinookAIUpdate.cs
@@ -14,7 +14,7 @@ public class ChinookAIUpdate : SupplyTruckAIUpdate
     private ChinookState _state;
     private uint _airfieldToRepairAt;
 
-    internal ChinookAIUpdate(GameObject gameObject, GameEngine context, ChinookAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
+    internal ChinookAIUpdate(GameObject gameObject, GameEngine gameEngine, ChinookAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
     }
@@ -67,8 +67,8 @@ internal sealed class ChinookAIUpdateStateMachine : AIUpdateStateMachine
 {
     public override ChinookAIUpdate AIUpdate { get; }
 
-    public ChinookAIUpdateStateMachine(GameObject gameObject, GameEngine context, ChinookAIUpdate aiUpdate)
-        : base(gameObject, context, aiUpdate)
+    public ChinookAIUpdateStateMachine(GameObject gameObject, GameEngine gameEngine, ChinookAIUpdate aiUpdate)
+        : base(gameObject, gameEngine, aiUpdate)
     {
         AIUpdate = aiUpdate;
 
@@ -134,8 +134,8 @@ public sealed class ChinookAIUpdateModuleData : SupplyTruckAIUpdateModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public string RotorWashParticleSystem { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new ChinookAIUpdate(gameObject, context, this);
+        return new ChinookAIUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DeployStyleAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DeployStyleAIUpdate.cs
@@ -21,7 +21,7 @@ public class DeployStyleAIUpdate : AIUpdate
 
     private readonly UnknownStateData _unknownStateData = new();
 
-    internal DeployStyleAIUpdate(GameObject gameObject, GameContext context, DeployStyleAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
+    internal DeployStyleAIUpdate(GameObject gameObject, GameEngine context, DeployStyleAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
     {
         ModuleData = moduleData;
     }
@@ -103,7 +103,7 @@ public sealed class DeployStyleAIUpdateModuleData : AIUpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public string DeployedAttributeModifier { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new DeployStyleAIUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DeployStyleAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DeployStyleAIUpdate.cs
@@ -21,7 +21,7 @@ public class DeployStyleAIUpdate : AIUpdate
 
     private readonly UnknownStateData _unknownStateData = new();
 
-    internal DeployStyleAIUpdate(GameObject gameObject, GameEngine context, DeployStyleAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
+    internal DeployStyleAIUpdate(GameObject gameObject, GameEngine gameEngine, DeployStyleAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
     }
@@ -103,8 +103,8 @@ public sealed class DeployStyleAIUpdateModuleData : AIUpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public string DeployedAttributeModifier { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new DeployStyleAIUpdate(gameObject, context, this);
+        return new DeployStyleAIUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAIUpdate.cs
@@ -14,11 +14,11 @@ public sealed class DozerAIUpdate : AIUpdate, IBuilderAIUpdate
 
     private readonly DozerAndWorkerState _state;
 
-    internal DozerAIUpdate(GameObject gameObject, GameEngine context, DozerAIUpdateModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal DozerAIUpdate(GameObject gameObject, GameEngine gameEngine, DozerAIUpdateModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
-        _state = new DozerAndWorkerState(gameObject, context, this);
+        _state = new DozerAndWorkerState(gameObject, gameEngine, this);
     }
 
     internal override void Stop()
@@ -92,8 +92,8 @@ public sealed class DozerAIUpdateModuleData : AIUpdateModuleData, IBuilderAIUpda
     public LogicFrameSpan BoredTime { get; private set; }
     public int BoredRange { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new DozerAIUpdate(gameObject, context, this);
+        return new DozerAIUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAIUpdate.cs
@@ -14,7 +14,7 @@ public sealed class DozerAIUpdate : AIUpdate, IBuilderAIUpdate
 
     private readonly DozerAndWorkerState _state;
 
-    internal DozerAIUpdate(GameObject gameObject, GameContext context, DozerAIUpdateModuleData moduleData)
+    internal DozerAIUpdate(GameObject gameObject, GameEngine context, DozerAIUpdateModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         ModuleData = moduleData;
@@ -43,14 +43,14 @@ public sealed class DozerAIUpdate : AIUpdate, IBuilderAIUpdate
         // note that the order here is important, as SetTargetPoint will clear any existing buildTarget
         // TODO: target should not be directly on the building, but rather a point along the foundation perimeter
         SetTargetPoint(gameObject.Translation);
-        _state.SetBuildTarget(gameObject, Context.GameLogic.CurrentFrame.Value);
+        _state.SetBuildTarget(gameObject, GameEngine.GameLogic.CurrentFrame.Value);
     }
 
     public void SetRepairTarget(GameObject gameObject)
     {
         // note that the order here is important, as SetTargetPoint will clear any existing repairTarget
         SetTargetPoint(gameObject.Translation);
-        _state.SetRepairTarget(gameObject, Context.GameLogic.CurrentFrame.Value);
+        _state.SetRepairTarget(gameObject, GameEngine.GameLogic.CurrentFrame.Value);
     }
 
     internal override void SetTargetPoint(Vector3 targetPoint)
@@ -92,7 +92,7 @@ public sealed class DozerAIUpdateModuleData : AIUpdateModuleData, IBuilderAIUpda
     public LogicFrameSpan BoredTime { get; private set; }
     public int BoredRange { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new DozerAIUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAndWorkerState.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAndWorkerState.cs
@@ -13,7 +13,7 @@ internal sealed class DozerAndWorkerState : IPersistableObject
     public GameObject? RepairTarget => TryGetRepairTarget(out var repairTarget) ? repairTarget : null;
 
     private readonly GameObject _gameObject;
-    private readonly GameContext _context;
+    private readonly GameEngine _gameEngine;
     private readonly AIUpdate _aiUpdate;
     private readonly IBuilderAIUpdateData _moduleData;
 
@@ -23,13 +23,13 @@ internal sealed class DozerAndWorkerState : IPersistableObject
     private readonly DozerSomething2[] _unknownList2 = new DozerSomething2[9]; // these seem to be in groups of 3, one group for each target
     private int _unknown4;
 
-    public DozerAndWorkerState(GameObject gameObject, GameContext context, AIUpdate aiUpdate)
+    public DozerAndWorkerState(GameObject gameObject, GameEngine gameEngine, AIUpdate aiUpdate)
     {
         _gameObject = gameObject;
-        _context = context;
+        _gameEngine = gameEngine;
         _aiUpdate = aiUpdate;
         _moduleData = (IBuilderAIUpdateData)aiUpdate.ModuleData; // todo: remove this cast in the future
-        _stateMachine = new BuilderStateMachine(gameObject, context, gameObject.AIUpdate);
+        _stateMachine = new BuilderStateMachine(gameObject, gameEngine, gameObject.AIUpdate);
     }
 
     // todo: This is really state _machine_ behavior, and should be moved there when we better understand the fields
@@ -67,7 +67,7 @@ internal sealed class DozerAndWorkerState : IPersistableObject
             if (buildTarget is { BuildProgress: >= 1 })
             {
                 ClearDozerTasks();
-                _context.AudioSystem.PlayAudioEvent(_gameObject, _gameObject.Definition.VoiceTaskComplete.Value);
+                _gameEngine.AudioSystem.PlayAudioEvent(_gameObject, _gameObject.Definition.VoiceTaskComplete.Value);
             }
         }
     }
@@ -98,7 +98,7 @@ internal sealed class DozerAndWorkerState : IPersistableObject
         var id = _dozerTargets[0].ObjectId;
         if (id > 0)
         {
-            gameObject = _context.GameLogic.GetObjectById(id);
+            gameObject = _gameEngine.GameLogic.GetObjectById(id);
             return true;
         }
 
@@ -125,7 +125,7 @@ internal sealed class DozerAndWorkerState : IPersistableObject
         var id = _dozerTargets[1].ObjectId;
         if (id > 0)
         {
-            gameObject = _context.GameLogic.GetObjectById(id);
+            gameObject = _gameEngine.GameLogic.GetObjectById(id);
             return true;
         }
 
@@ -204,7 +204,7 @@ internal sealed class DozerAndWorkerState : IPersistableObject
 
     internal sealed class BuilderStateMachine : StateMachineBase
     {
-        public BuilderStateMachine(GameObject gameObject, GameContext context, AIUpdate aiUpdate) : base(gameObject, context, aiUpdate)
+        public BuilderStateMachine(GameObject gameObject, GameEngine context, AIUpdate aiUpdate) : base(gameObject, context, aiUpdate)
         {
             AddState(0, new BuilderUnknown0State(this));
             AddState(1, new BuilderUnknown1State(this));

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAndWorkerState.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAndWorkerState.cs
@@ -204,7 +204,7 @@ internal sealed class DozerAndWorkerState : IPersistableObject
 
     internal sealed class BuilderStateMachine : StateMachineBase
     {
-        public BuilderStateMachine(GameObject gameObject, GameEngine context, AIUpdate aiUpdate) : base(gameObject, context, aiUpdate)
+        public BuilderStateMachine(GameObject gameObject, GameEngine gameEngine, AIUpdate aiUpdate) : base(gameObject, gameEngine, aiUpdate)
         {
             AddState(0, new BuilderUnknown0State(this));
             AddState(1, new BuilderUnknown1State(this));

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
@@ -13,8 +13,8 @@ public class FoundationAIUpdate : AIUpdate
     private LogicFrameSpan _updateInterval;
 
     //TODO: rather notify this when the corresponding order is processed and update again when the object is dead/destroyed
-    internal FoundationAIUpdate(GameObject gameObject, GameEngine context, FoundationAIUpdateModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal FoundationAIUpdate(GameObject gameObject, GameEngine gameEngine, FoundationAIUpdateModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
         _updateInterval = new LogicFrameSpan((uint)MathF.Ceiling(Game.LogicFramesPerSecond / 2)); // 0.5s, we do not have to check every frame
@@ -66,8 +66,8 @@ public class FoundationAIUpdateModuleData : AIUpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public int BuildVariation { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new FoundationAIUpdate(gameObject, context, this);
+        return new FoundationAIUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
@@ -13,7 +13,7 @@ public class FoundationAIUpdate : AIUpdate
     private LogicFrameSpan _updateInterval;
 
     //TODO: rather notify this when the corresponding order is processed and update again when the object is dead/destroyed
-    internal FoundationAIUpdate(GameObject gameObject, GameContext context, FoundationAIUpdateModuleData moduleData)
+    internal FoundationAIUpdate(GameObject gameObject, GameEngine context, FoundationAIUpdateModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         ModuleData = moduleData;
@@ -34,7 +34,7 @@ public class FoundationAIUpdate : AIUpdate
 
         waitUntil = context.LogicFrame + interval;
 
-        var collidingObjects = context.GameContext.Game.PartitionCellManager.QueryObjects(
+        var collidingObjects = context.GameEngine.Game.PartitionCellManager.QueryObjects(
             obj,
             obj.Translation,
             obj.Geometry.BoundingCircleRadius,
@@ -66,7 +66,7 @@ public class FoundationAIUpdateModuleData : AIUpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public int BuildVariation { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new FoundationAIUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
@@ -17,7 +17,7 @@ public class FoundationAIUpdate : AIUpdate
         : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
-        _updateInterval = new LogicFrameSpan((uint)MathF.Ceiling(Game.LogicFramesPerSecond / 2)); // 0.5s, we do not have to check every frame
+        _updateInterval = new LogicFrameSpan((uint)MathF.Ceiling(GameEngine.LogicFramesPerSecond / 2)); // 0.5s, we do not have to check every frame
     }
 
     internal override void Update(BehaviorUpdateContext context)

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/HackInternetAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/HackInternetAIUpdate.cs
@@ -14,7 +14,7 @@ public class HackInternetAIUpdate : AIUpdate
 
     private UnknownStateData? _packingUpData;
 
-    internal HackInternetAIUpdate(GameObject gameObject, GameEngine context, HackInternetAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
+    internal HackInternetAIUpdate(GameObject gameObject, GameEngine gameEngine, HackInternetAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
     }
@@ -94,8 +94,8 @@ internal sealed class HackInternetAIUpdateStateMachine : AIUpdateStateMachine
 {
     public override HackInternetAIUpdate AIUpdate { get; }
 
-    public HackInternetAIUpdateStateMachine(GameObject gameObject, GameEngine context, HackInternetAIUpdate aiUpdate)
-        : base(gameObject, context, aiUpdate)
+    public HackInternetAIUpdateStateMachine(GameObject gameObject, GameEngine gameEngine, HackInternetAIUpdate aiUpdate)
+        : base(gameObject, gameEngine, aiUpdate)
     {
         AIUpdate = aiUpdate;
 
@@ -104,10 +104,10 @@ internal sealed class HackInternetAIUpdateStateMachine : AIUpdateStateMachine
         AddState(StopHackingInternetState.StateId, new StopHackingInternetState(this));
     }
 
-    internal LogicFrameSpan GetVariableFrames(LogicFrameSpan time, GameEngine context)
+    internal LogicFrameSpan GetVariableFrames(LogicFrameSpan time, GameEngine gameEngine)
     {
         // take a random float, *2 for 0 - 2, -1 for -1 - 1, *variance for our actual variance factor
-        return new LogicFrameSpan((uint)(time.Value + time.Value * ((context.Random.NextSingle() * 2 - 1) * AIUpdate.ModuleData.PackUnpackVariationFactor)));
+        return new LogicFrameSpan((uint)(time.Value + time.Value * ((gameEngine.Random.NextSingle() * 2 - 1) * AIUpdate.ModuleData.PackUnpackVariationFactor)));
     }
 }
 
@@ -164,8 +164,8 @@ public sealed class HackInternetAIUpdateModuleData : AIUpdateModuleData
     /// </example>
     public float PackUnpackVariationFactor { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new HackInternetAIUpdate(gameObject, context, this);
+        return new HackInternetAIUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/HackInternetAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/HackInternetAIUpdate.cs
@@ -14,12 +14,12 @@ public class HackInternetAIUpdate : AIUpdate
 
     private UnknownStateData? _packingUpData;
 
-    internal HackInternetAIUpdate(GameObject gameObject, GameContext context, HackInternetAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
+    internal HackInternetAIUpdate(GameObject gameObject, GameEngine context, HackInternetAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
     {
         ModuleData = moduleData;
     }
 
-    private protected override HackInternetAIUpdateStateMachine CreateStateMachine() => new(GameObject, Context, this);
+    private protected override HackInternetAIUpdateStateMachine CreateStateMachine() => new(GameObject, GameEngine, this);
 
     private protected override void RunUpdate(BehaviorUpdateContext context)
     {
@@ -94,7 +94,7 @@ internal sealed class HackInternetAIUpdateStateMachine : AIUpdateStateMachine
 {
     public override HackInternetAIUpdate AIUpdate { get; }
 
-    public HackInternetAIUpdateStateMachine(GameObject gameObject, GameContext context, HackInternetAIUpdate aiUpdate)
+    public HackInternetAIUpdateStateMachine(GameObject gameObject, GameEngine context, HackInternetAIUpdate aiUpdate)
         : base(gameObject, context, aiUpdate)
     {
         AIUpdate = aiUpdate;
@@ -104,7 +104,7 @@ internal sealed class HackInternetAIUpdateStateMachine : AIUpdateStateMachine
         AddState(StopHackingInternetState.StateId, new StopHackingInternetState(this));
     }
 
-    internal LogicFrameSpan GetVariableFrames(LogicFrameSpan time, GameContext context)
+    internal LogicFrameSpan GetVariableFrames(LogicFrameSpan time, GameEngine context)
     {
         // take a random float, *2 for 0 - 2, -1 for -1 - 1, *variance for our actual variance factor
         return new LogicFrameSpan((uint)(time.Value + time.Value * ((context.Random.NextSingle() * 2 - 1) * AIUpdate.ModuleData.PackUnpackVariationFactor)));
@@ -164,7 +164,7 @@ public sealed class HackInternetAIUpdateModuleData : AIUpdateModuleData
     /// </example>
     public float PackUnpackVariationFactor { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new HackInternetAIUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/JetAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/JetAIUpdate.cs
@@ -56,14 +56,14 @@ public sealed class JetAIUpdate : AIUpdate
         MovingBackToHangar
     }
 
-    internal JetAIUpdate(GameObject gameObject, GameContext context, JetAIUpdateModuleData moduleData)
+    internal JetAIUpdate(GameObject gameObject, GameEngine context, JetAIUpdateModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         ModuleData = moduleData;
         CurrentJetAIState = JetAIState.Parked;
     }
 
-    private protected override JetAIUpdateStateMachine CreateStateMachine() => new(GameObject, Context, this);
+    private protected override JetAIUpdateStateMachine CreateStateMachine() => new(GameObject, GameEngine, this);
 
     internal override void Load(StatePersister reader)
     {
@@ -136,7 +136,7 @@ public sealed class JetAIUpdate : AIUpdate
 
         var trans = GameObject.Translation;
 
-        var terrainHeight = context.GameContext.Terrain.HeightMap.GetHeight(trans.X, trans.Y);
+        var terrainHeight = context.GameEngine.Terrain.HeightMap.GetHeight(trans.X, trans.Y);
 
         switch (CurrentJetAIState)
         {
@@ -331,7 +331,7 @@ internal sealed class JetAIUpdateStateMachine : AIUpdateStateMachine
 {
     public override JetAIUpdate AIUpdate { get; }
 
-    public JetAIUpdateStateMachine(GameObject gameObject, GameContext context, JetAIUpdate aiUpdate)
+    public JetAIUpdateStateMachine(GameObject gameObject, GameEngine context, JetAIUpdate aiUpdate)
         : base(gameObject, context, aiUpdate)
     {
         AIUpdate = aiUpdate;
@@ -415,7 +415,7 @@ public sealed class JetAIUpdateModuleData : AIUpdateModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public Percentage TakeoffDistForMaxLift { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new JetAIUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/JetAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/JetAIUpdate.cs
@@ -56,8 +56,8 @@ public sealed class JetAIUpdate : AIUpdate
         MovingBackToHangar
     }
 
-    internal JetAIUpdate(GameObject gameObject, GameEngine context, JetAIUpdateModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal JetAIUpdate(GameObject gameObject, GameEngine gameEngine, JetAIUpdateModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
         CurrentJetAIState = JetAIState.Parked;
@@ -331,8 +331,8 @@ internal sealed class JetAIUpdateStateMachine : AIUpdateStateMachine
 {
     public override JetAIUpdate AIUpdate { get; }
 
-    public JetAIUpdateStateMachine(GameObject gameObject, GameEngine context, JetAIUpdate aiUpdate)
-        : base(gameObject, context, aiUpdate)
+    public JetAIUpdateStateMachine(GameObject gameObject, GameEngine gameEngine, JetAIUpdate aiUpdate)
+        : base(gameObject, gameEngine, aiUpdate)
     {
         AIUpdate = aiUpdate;
 
@@ -415,8 +415,8 @@ public sealed class JetAIUpdateModuleData : AIUpdateModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public Percentage TakeoffDistForMaxLift { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new JetAIUpdate(gameObject, context, this);
+        return new JetAIUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/MissileAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/MissileAIUpdate.cs
@@ -31,7 +31,7 @@ public sealed class MissileAIUpdate : AIUpdate
 
     internal FXList DetonationFX { get; set; }
 
-    internal MissileAIUpdate(GameObject gameObject, GameContext context, MissileAIUpdateModuleData moduleData)
+    internal MissileAIUpdate(GameObject gameObject, GameEngine context, MissileAIUpdateModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         ModuleData = moduleData;
@@ -55,7 +55,7 @@ public sealed class MissileAIUpdate : AIUpdate
                         new FXListExecutionContext(
                             GameObject.Rotation,
                             GameObject.Translation,
-                            context.GameContext));
+                            context.GameEngine));
 
                     if (ModuleData.DistanceToTravelBeforeTurning > 0)
                     {
@@ -197,7 +197,7 @@ public sealed class MissileAIUpdateModuleData : AIUpdateModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public int DistanceScatterWhenJammed { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new MissileAIUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/MissileAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/MissileAIUpdate.cs
@@ -31,8 +31,8 @@ public sealed class MissileAIUpdate : AIUpdate
 
     internal FXList DetonationFX { get; set; }
 
-    internal MissileAIUpdate(GameObject gameObject, GameEngine context, MissileAIUpdateModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal MissileAIUpdate(GameObject gameObject, GameEngine gameEngine, MissileAIUpdateModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
 
@@ -197,8 +197,8 @@ public sealed class MissileAIUpdateModuleData : AIUpdateModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public int DistanceScatterWhenJammed { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new MissileAIUpdate(gameObject, context, this);
+        return new MissileAIUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyAIUpdate.cs
@@ -40,7 +40,7 @@ public abstract class SupplyAIUpdate : AIUpdate
 
     protected virtual int GetAdditionalValuePerSupplyBox(ScopedAssetCollection<UpgradeTemplate> upgrades) => 0;
 
-    internal SupplyAIUpdate(GameObject gameObject, GameEngine context, SupplyAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
+    internal SupplyAIUpdate(GameObject gameObject, GameEngine gameEngine, SupplyAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
         SupplyGatherState = SupplyGatherStates.Default;

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyAIUpdate.cs
@@ -40,7 +40,7 @@ public abstract class SupplyAIUpdate : AIUpdate
 
     protected virtual int GetAdditionalValuePerSupplyBox(ScopedAssetCollection<UpgradeTemplate> upgrades) => 0;
 
-    internal SupplyAIUpdate(GameObject gameObject, GameContext context, SupplyAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
+    internal SupplyAIUpdate(GameObject gameObject, GameEngine context, SupplyAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
     {
         ModuleData = moduleData;
         SupplyGatherState = SupplyGatherStates.Default;
@@ -74,7 +74,7 @@ public abstract class SupplyAIUpdate : AIUpdate
     {
         if (_currentSourceDockUpdate?.GetBox() == true && !_currentSourceDockUpdate.HasBoxes())
         {
-            Context.AudioSystem.PlayAudioEvent(GameObject, ModuleData.SuppliesDepletedVoice.Value);
+            GameEngine.AudioSystem.PlayAudioEvent(GameObject, ModuleData.SuppliesDepletedVoice.Value);
         }
     }
 
@@ -238,7 +238,7 @@ public abstract class SupplyAIUpdate : AIUpdate
                 {
                     SupplyGatherState = SupplyGatherStates.FinishedDumpingSupplies;
 
-                    var assetStore = context.GameContext.AssetLoadContext.AssetStore;
+                    var assetStore = context.GameEngine.AssetLoadContext.AssetStore;
                     var bonusAmountPerBox = GetAdditionalValuePerSupplyBox(assetStore.Upgrades);
                     var amountDeposited = _currentTargetDockUpdate.DumpBoxes(assetStore, ref _numBoxes, bonusAmountPerBox);
                     GameObject.ActiveCashEvent = new CashEvent(amountDeposited, GameObject.Owner.Color);

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cs
@@ -12,7 +12,7 @@ public class SupplyTruckAIUpdate : SupplyAIUpdate
     private int _unknownInt;
     private bool _unknownBool;
 
-    internal SupplyTruckAIUpdate(GameObject gameObject, GameContext context, SupplyTruckAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
+    internal SupplyTruckAIUpdate(GameObject gameObject, GameEngine context, SupplyTruckAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
     {
         ModuleData = moduleData;
         _stateMachine = new SupplyAIUpdateStateMachine(gameObject, context, this);
@@ -40,7 +40,7 @@ public class SupplyTruckAIUpdateModuleData : SupplyAIUpdateModuleData
     internal new static readonly IniParseTable<SupplyTruckAIUpdateModuleData> FieldParseTable = SupplyAIUpdateModuleData.FieldParseTable
         .Concat(new IniParseTable<SupplyTruckAIUpdateModuleData> { });
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new SupplyTruckAIUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cs
@@ -12,10 +12,10 @@ public class SupplyTruckAIUpdate : SupplyAIUpdate
     private int _unknownInt;
     private bool _unknownBool;
 
-    internal SupplyTruckAIUpdate(GameObject gameObject, GameEngine context, SupplyTruckAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
+    internal SupplyTruckAIUpdate(GameObject gameObject, GameEngine gameEngine, SupplyTruckAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
-        _stateMachine = new SupplyAIUpdateStateMachine(gameObject, context, this);
+        _stateMachine = new SupplyAIUpdateStateMachine(gameObject, gameEngine, this);
     }
 
     internal override void Load(StatePersister reader)
@@ -40,8 +40,8 @@ public class SupplyTruckAIUpdateModuleData : SupplyAIUpdateModuleData
     internal new static readonly IniParseTable<SupplyTruckAIUpdateModuleData> FieldParseTable = SupplyAIUpdateModuleData.FieldParseTable
         .Concat(new IniParseTable<SupplyTruckAIUpdateModuleData> { });
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SupplyTruckAIUpdate(gameObject, context, this);
+        return new SupplyTruckAIUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TransportAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TransportAIUpdate.cs
@@ -6,7 +6,7 @@ public sealed class TransportAIUpdate : AIUpdate
 {
     internal override TransportAIUpdateModuleData ModuleData { get; }
 
-    internal TransportAIUpdate(GameObject gameObject, GameContext context, TransportAIUpdateModuleData moduleData)
+    internal TransportAIUpdate(GameObject gameObject, GameEngine context, TransportAIUpdateModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         ModuleData = moduleData;
@@ -32,7 +32,7 @@ public sealed class TransportAIUpdateModuleData : AIUpdateModuleData
     private new static readonly IniParseTable<TransportAIUpdateModuleData> FieldParseTable = AIUpdateModuleData.FieldParseTable
         .Concat(new IniParseTable<TransportAIUpdateModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new TransportAIUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TransportAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TransportAIUpdate.cs
@@ -6,8 +6,8 @@ public sealed class TransportAIUpdate : AIUpdate
 {
     internal override TransportAIUpdateModuleData ModuleData { get; }
 
-    internal TransportAIUpdate(GameObject gameObject, GameEngine context, TransportAIUpdateModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal TransportAIUpdate(GameObject gameObject, GameEngine gameEngine, TransportAIUpdateModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
     }
@@ -32,8 +32,8 @@ public sealed class TransportAIUpdateModuleData : AIUpdateModuleData
     private new static readonly IniParseTable<TransportAIUpdateModuleData> FieldParseTable = AIUpdateModuleData.FieldParseTable
         .Concat(new IniParseTable<TransportAIUpdateModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new TransportAIUpdate(gameObject, context, this);
+        return new TransportAIUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TurretAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TurretAIUpdate.cs
@@ -31,7 +31,7 @@ public class TurretAIUpdate : UpdateModule
         Recentering
     }
 
-    internal TurretAIUpdate(GameObject gameObject, GameContext context, TurretAIUpdateModuleData moduleData)
+    internal TurretAIUpdate(GameObject gameObject, GameEngine context, TurretAIUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -75,7 +75,7 @@ public class TurretAIUpdate : UpdateModule
                 {
                     if (!FoundTargetWhileScanning(context, autoAcquireEnemiesWhenIdle))
                     {
-                        var scanInterval = context.GameContext.GetRandomLogicFrameSpan(
+                        var scanInterval = context.GameEngine.GetRandomLogicFrameSpan(
                             _moduleData.MinIdleScanInterval,
                             _moduleData.MaxIdleScanInterval);
                         _waitUntil = context.LogicFrame + scanInterval;
@@ -160,14 +160,14 @@ public class TurretAIUpdate : UpdateModule
         return false;
 
         //var attacksBuildings = autoAcquireEnemiesWhenIdle?.Get(AutoAcquireEnemiesType.AttackBuildings) ?? true;
-        //var scanRange = _gameObject.CurrentWeapon.Template.AttackRange;
+        //var scanRange = GameObject.CurrentWeapon.Template.AttackRange;
 
         //var restrictedByScanAngle = _moduleData.MinIdleScanAngle != 0 && _moduleData.MaxIdleScanAngle != 0;
-        //var scanAngleOffset = context.GameContext.Random.NextDouble() *
+        //var scanAngleOffset = context.GameEngine.Random.NextDouble() *
         //                (_moduleData.MaxIdleScanAngle - _moduleData.MinIdleScanAngle) +
         //                _moduleData.MinIdleScanAngle;
 
-        //var nearbyObjects = context.GameContext.Scene3D.Quadtree.FindNearby(_gameObject, _gameObject.Transform, scanRange);
+        //var nearbyObjects = context.GameEngine.Scene3D.Quadtree.FindNearby(GameObject, GameObject.Transform, scanRange);
         //foreach (var obj in nearbyObjects)
         //{
         //    if (obj.Definition.KindOf.Get(ObjectKinds.Structure) && !attacksBuildings)
@@ -178,10 +178,10 @@ public class TurretAIUpdate : UpdateModule
         //    if (restrictedByScanAngle)
         //    {
         //        // TODO: test with GLAVehicleTechnicalChassisOne
-        //        var deltaTranslation = obj.Translation - _gameObject.Translation;
+        //        var deltaTranslation = obj.Translation - GameObject.Translation;
         //        var direction = deltaTranslation.Vector2XY();
         //        var angleToObject = MathUtility.GetYawFromDirection(direction);
-        //        var angleDelta = MathUtility.CalculateAngleDelta(angleToObject, _gameObject.EulerAngles.Z + MathUtility.ToRadians(_moduleData.NaturalTurretAngle));
+        //        var angleDelta = MathUtility.CalculateAngleDelta(angleToObject, GameObject.EulerAngles.Z + MathUtility.ToRadians(_moduleData.NaturalTurretAngle));
 
         //        if (angleDelta < -scanAngleOffset || scanAngleOffset < angleDelta)
         //        {
@@ -189,7 +189,7 @@ public class TurretAIUpdate : UpdateModule
         //        }
         //    }
 
-        //    _gameObject.CurrentWeapon.SetTarget(new WeaponTarget(obj));
+        //    GameObject.CurrentWeapon.SetTarget(new WeaponTarget(obj));
         //    return true;
         //}
 
@@ -318,7 +318,7 @@ public sealed class TurretAIUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2Rotwk)]
     public int TurretMaxDeflectionACW { get; private set; }
 
-    internal TurretAIUpdate CreateTurretAIUpdate(GameObject gameObject, GameContext context)
+    internal TurretAIUpdate CreateTurretAIUpdate(GameObject gameObject, GameEngine context)
     {
         return new TurretAIUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TurretAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TurretAIUpdate.cs
@@ -31,8 +31,8 @@ public class TurretAIUpdate : UpdateModule
         Recentering
     }
 
-    internal TurretAIUpdate(GameObject gameObject, GameEngine context, TurretAIUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal TurretAIUpdate(GameObject gameObject, GameEngine gameEngine, TurretAIUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
 
@@ -318,9 +318,9 @@ public sealed class TurretAIUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2Rotwk)]
     public int TurretMaxDeflectionACW { get; private set; }
 
-    internal TurretAIUpdate CreateTurretAIUpdate(GameObject gameObject, GameEngine context)
+    internal TurretAIUpdate CreateTurretAIUpdate(GameObject gameObject, GameEngine gameEngine)
     {
-        return new TurretAIUpdate(gameObject, context, this);
+        return new TurretAIUpdate(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WanderAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WanderAIUpdate.cs
@@ -6,7 +6,7 @@ public sealed class WanderAIUpdate : AIUpdate
 {
     internal override WanderAIUpdateModuleData ModuleData { get; }
 
-    internal WanderAIUpdate(GameObject gameObject, GameContext context, WanderAIUpdateModuleData moduleData)
+    internal WanderAIUpdate(GameObject gameObject, GameEngine context, WanderAIUpdateModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         ModuleData = moduleData;
@@ -32,7 +32,7 @@ public sealed class WanderAIUpdateModuleData : AIUpdateModuleData
     private new static readonly IniParseTable<WanderAIUpdateModuleData> FieldParseTable = AIUpdateModuleData.FieldParseTable
         .Concat(new IniParseTable<WanderAIUpdateModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new WanderAIUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WanderAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WanderAIUpdate.cs
@@ -6,8 +6,8 @@ public sealed class WanderAIUpdate : AIUpdate
 {
     internal override WanderAIUpdateModuleData ModuleData { get; }
 
-    internal WanderAIUpdate(GameObject gameObject, GameEngine context, WanderAIUpdateModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal WanderAIUpdate(GameObject gameObject, GameEngine gameEngine, WanderAIUpdateModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
     }
@@ -32,8 +32,8 @@ public sealed class WanderAIUpdateModuleData : AIUpdateModuleData
     private new static readonly IniParseTable<WanderAIUpdateModuleData> FieldParseTable = AIUpdateModuleData.FieldParseTable
         .Concat(new IniParseTable<WanderAIUpdateModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new WanderAIUpdate(gameObject, context, this);
+        return new WanderAIUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
@@ -23,7 +23,7 @@ public class WorkerAIUpdate : SupplyAIUpdate, IBuilderAIUpdate
     private int _unknown6;
     private readonly WorkerAIUpdateStateMachine3 _stateMachine3;
 
-    internal WorkerAIUpdate(GameObject gameObject, GameContext context, WorkerAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
+    internal WorkerAIUpdate(GameObject gameObject, GameEngine context, WorkerAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
     {
         ModuleData = moduleData;
         _state = new DozerAndWorkerState(gameObject, context, this);
@@ -50,7 +50,7 @@ public class WorkerAIUpdate : SupplyAIUpdate, IBuilderAIUpdate
         // note that the order here is important, as SetTargetPoint will clear any existing buildTarget
         // TODO: target should not be directly on the building, but rather a point along the foundation perimeter
         SetTargetPoint(gameObject.Translation);
-        _state.SetBuildTarget(gameObject, Context.GameLogic.CurrentFrame.Value);
+        _state.SetBuildTarget(gameObject, GameEngine.GameLogic.CurrentFrame.Value);
         ResetSupplyState();
     }
 
@@ -58,7 +58,7 @@ public class WorkerAIUpdate : SupplyAIUpdate, IBuilderAIUpdate
     {
         // note that the order here is important, as SetTargetPoint will clear any existing repairTarget
         SetTargetPoint(gameObject.Translation);
-        _state.SetRepairTarget(gameObject, Context.GameLogic.CurrentFrame.Value);
+        _state.SetRepairTarget(gameObject, GameEngine.GameLogic.CurrentFrame.Value);
         ResetSupplyState();
     }
 
@@ -96,7 +96,7 @@ public class WorkerAIUpdate : SupplyAIUpdate, IBuilderAIUpdate
     {
         if (ModuleData.HarvestTrees)
         {
-            var nearbyTrees = context.GameContext.Game.PartitionCellManager.QueryObjects(
+            var nearbyTrees = context.GameEngine.Game.PartitionCellManager.QueryObjects(
                 context.GameObject,
                 context.GameObject.Translation,
                 ModuleData.SupplyWarehouseScanDistance,
@@ -117,7 +117,7 @@ public class WorkerAIUpdate : SupplyAIUpdate, IBuilderAIUpdate
                     continue;
                 }
 
-                var distance = context.GameContext.Game.PartitionCellManager.GetDistanceBetweenObjectsSquared(context.GameObject, tree);
+                var distance = context.GameEngine.Game.PartitionCellManager.GetDistanceBetweenObjectsSquared(context.GameObject, tree);
 
                 if (distance < closestDistance)
                 {
@@ -150,7 +150,7 @@ public class WorkerAIUpdate : SupplyAIUpdate, IBuilderAIUpdate
     {
         if (ModuleData.HarvestTrees && CurrentSupplySource.Definition.KindOf.Get(ObjectKinds.Tree))
         {
-            CurrentSupplySource.Supply -= context.GameContext.AssetLoadContext.AssetStore.GameData.Current.ValuePerSupplyBox;
+            CurrentSupplySource.Supply -= context.GameEngine.AssetLoadContext.AssetStore.GameData.Current.ValuePerSupplyBox;
             if (CurrentSupplySource.Supply <= 0)
             {
                 CurrentSupplySource.Update();
@@ -224,7 +224,7 @@ public class WorkerAIUpdate : SupplyAIUpdate, IBuilderAIUpdate
     {
         public override WorkerAIUpdate AIUpdate { get; }
 
-        public WorkerAIUpdateStateMachine3(GameObject gameObject, GameContext context, WorkerAIUpdate aiUpdate) : base(gameObject, context, aiUpdate)
+        public WorkerAIUpdateStateMachine3(GameObject gameObject, GameEngine context, WorkerAIUpdate aiUpdate) : base(gameObject, context, aiUpdate)
         {
             AIUpdate = aiUpdate;
 
@@ -284,7 +284,7 @@ public sealed class WorkerAIUpdateModuleData : SupplyAIUpdateModuleData, IBuilde
     [AddedIn(SageGame.Bfme)]
     public LogicFrameSpan HarvestActionTime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new WorkerAIUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
@@ -23,12 +23,12 @@ public class WorkerAIUpdate : SupplyAIUpdate, IBuilderAIUpdate
     private int _unknown6;
     private readonly WorkerAIUpdateStateMachine3 _stateMachine3;
 
-    internal WorkerAIUpdate(GameObject gameObject, GameEngine context, WorkerAIUpdateModuleData moduleData) : base(gameObject, context, moduleData)
+    internal WorkerAIUpdate(GameObject gameObject, GameEngine gameEngine, WorkerAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
-        _state = new DozerAndWorkerState(gameObject, context, this);
-        _supplyAIUpdateStateMachine = new SupplyAIUpdateStateMachine(gameObject, context, this);
-        _stateMachine3 = new WorkerAIUpdateStateMachine3(gameObject, context, this);
+        _state = new DozerAndWorkerState(gameObject, gameEngine, this);
+        _supplyAIUpdateStateMachine = new SupplyAIUpdateStateMachine(gameObject, gameEngine, this);
+        _stateMachine3 = new WorkerAIUpdateStateMachine3(gameObject, gameEngine, this);
     }
 
     internal override void Stop()
@@ -224,7 +224,7 @@ public class WorkerAIUpdate : SupplyAIUpdate, IBuilderAIUpdate
     {
         public override WorkerAIUpdate AIUpdate { get; }
 
-        public WorkerAIUpdateStateMachine3(GameObject gameObject, GameEngine context, WorkerAIUpdate aiUpdate) : base(gameObject, context, aiUpdate)
+        public WorkerAIUpdateStateMachine3(GameObject gameObject, GameEngine gameEngine, WorkerAIUpdate aiUpdate) : base(gameObject, gameEngine, aiUpdate)
         {
             AIUpdate = aiUpdate;
 
@@ -284,8 +284,8 @@ public sealed class WorkerAIUpdateModuleData : SupplyAIUpdateModuleData, IBuilde
     [AddedIn(SageGame.Bfme)]
     public LogicFrameSpan HarvestActionTime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new WorkerAIUpdate(gameObject, context, this);
+        return new WorkerAIUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AssistedTargetingUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AssistedTargetingUpdate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class AssistedTargetingUpdate : UpdateModule
 {
-    public AssistedTargetingUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public AssistedTargetingUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -36,7 +36,7 @@ public sealed class AssistedTargetingUpdateModuleData : UpdateModuleData
     public string LaserFromAssisted { get; private set; }
     public string LaserToTarget { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new AssistedTargetingUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AssistedTargetingUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AssistedTargetingUpdate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class AssistedTargetingUpdate : UpdateModule
 {
-    public AssistedTargetingUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public AssistedTargetingUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -36,8 +36,8 @@ public sealed class AssistedTargetingUpdateModuleData : UpdateModuleData
     public string LaserFromAssisted { get; private set; }
     public string LaserToTarget { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new AssistedTargetingUpdate(gameObject, context);
+        return new AssistedTargetingUpdate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
@@ -13,7 +13,7 @@ internal sealed class AutoDepositUpdate : UpdateModule
     private bool _shouldGrantInitialCaptureBonus = true; // this always starts as true, even if there is no capture bonus
     private bool _unknownBool2 = true;
 
-    internal AutoDepositUpdate(GameObject gameObject, GameContext context, AutoDepositUpdateModuleData moduleData)
+    internal AutoDepositUpdate(GameObject gameObject, GameEngine context, AutoDepositUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -144,7 +144,7 @@ public sealed class AutoDepositUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool OnlyWhenGarrisoned { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new AutoDepositUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
@@ -13,8 +13,8 @@ internal sealed class AutoDepositUpdate : UpdateModule
     private bool _shouldGrantInitialCaptureBonus = true; // this always starts as true, even if there is no capture bonus
     private bool _unknownBool2 = true;
 
-    internal AutoDepositUpdate(GameObject gameObject, GameEngine context, AutoDepositUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal AutoDepositUpdate(GameObject gameObject, GameEngine gameEngine, AutoDepositUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -144,8 +144,8 @@ public sealed class AutoDepositUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool OnlyWhenGarrisoned { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new AutoDepositUpdate(gameObject, context, this);
+        return new AutoDepositUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AutoFindHealingUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoFindHealingUpdate.cs
@@ -6,8 +6,8 @@ public sealed class AutoFindHealingUpdate : UpdateModule
 {
     private readonly AutoFindHealingUpdateModuleData _moduleData;
 
-    public AutoFindHealingUpdate(GameObject gameObject, GameEngine context, AutoFindHealingUpdateModuleData moduleData)
-        : base(gameObject, context)
+    public AutoFindHealingUpdate(GameObject gameObject, GameEngine gameEngine, AutoFindHealingUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -60,8 +60,8 @@ public sealed class AutoFindHealingUpdateModuleData : UpdateModuleData
     public float NeverHeal { get; private set; }
     public float AlwaysHeal { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new AutoFindHealingUpdate(gameObject, context, this);
+        return new AutoFindHealingUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/AutoFindHealingUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoFindHealingUpdate.cs
@@ -6,7 +6,7 @@ public sealed class AutoFindHealingUpdate : UpdateModule
 {
     private readonly AutoFindHealingUpdateModuleData _moduleData;
 
-    public AutoFindHealingUpdate(GameObject gameObject, GameContext context, AutoFindHealingUpdateModuleData moduleData)
+    public AutoFindHealingUpdate(GameObject gameObject, GameEngine context, AutoFindHealingUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -60,7 +60,7 @@ public sealed class AutoFindHealingUpdateModuleData : UpdateModuleData
     public float NeverHeal { get; private set; }
     public float AlwaysHeal { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new AutoFindHealingUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/BannerCarrierUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BannerCarrierUpdate.cs
@@ -8,7 +8,7 @@ public class BannerCarrierUpdate : UpdateModule
 {
     private BannerCarrierUpdateModuleData _moduleData;
 
-    public BannerCarrierUpdate(GameObject gameObject, GameContext context, BannerCarrierUpdateModuleData moduleData)
+    public BannerCarrierUpdate(GameObject gameObject, GameEngine context, BannerCarrierUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -58,7 +58,7 @@ public sealed class BannerCarrierUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public string UpgradeRequired { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new BannerCarrierUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/BannerCarrierUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BannerCarrierUpdate.cs
@@ -8,8 +8,8 @@ public class BannerCarrierUpdate : UpdateModule
 {
     private BannerCarrierUpdateModuleData _moduleData;
 
-    public BannerCarrierUpdate(GameObject gameObject, GameEngine context, BannerCarrierUpdateModuleData moduleData)
-        : base(gameObject, context)
+    public BannerCarrierUpdate(GameObject gameObject, GameEngine gameEngine, BannerCarrierUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -58,9 +58,9 @@ public sealed class BannerCarrierUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public string UpgradeRequired { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new BannerCarrierUpdate(gameObject, context, this);
+        return new BannerCarrierUpdate(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/BaseRegenerateUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BaseRegenerateUpdate.cs
@@ -6,7 +6,7 @@ public sealed class BaseRegenerateUpdate : UpdateModule, IDamageModule
 {
     protected override LogicFrameSpan FramesBetweenUpdates => LogicFrameSpan.OneSecond;
 
-    internal BaseRegenerateUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    internal BaseRegenerateUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
         SetNextUpdateFrame(new LogicFrame(uint.MaxValue));
     }
@@ -16,13 +16,13 @@ public sealed class BaseRegenerateUpdate : UpdateModule, IDamageModule
     /// </summary>
     public void OnDamage(in DamageData damageData)
     {
-        var currentFrame = Context.GameLogic.CurrentFrame;
-        SetNextUpdateFrame(currentFrame + Context.AssetLoadContext.AssetStore.GameData.Current.BaseRegenDelay);
+        var currentFrame = GameEngine.GameLogic.CurrentFrame;
+        SetNextUpdateFrame(currentFrame + GameEngine.AssetLoadContext.AssetStore.GameData.Current.BaseRegenDelay);
     }
 
     private protected override void RunUpdate(BehaviorUpdateContext context)
     {
-        GameObject.HealDirectly(Context.AssetLoadContext.AssetStore.GameData.Current.BaseRegenHealthPercentPerSecond);
+        GameObject.HealDirectly(GameEngine.AssetLoadContext.AssetStore.GameData.Current.BaseRegenHealthPercentPerSecond);
 
         if (GameObject.IsFullHealth)
         {
@@ -51,7 +51,7 @@ public sealed class BaseRegenerateUpdateModuleData : UpdateModuleData
 
     private static readonly IniParseTable<BaseRegenerateUpdateModuleData> FieldParseTable = new IniParseTable<BaseRegenerateUpdateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new BaseRegenerateUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/BaseRegenerateUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BaseRegenerateUpdate.cs
@@ -6,7 +6,7 @@ public sealed class BaseRegenerateUpdate : UpdateModule, IDamageModule
 {
     protected override LogicFrameSpan FramesBetweenUpdates => LogicFrameSpan.OneSecond;
 
-    internal BaseRegenerateUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    internal BaseRegenerateUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
         SetNextUpdateFrame(new LogicFrame(uint.MaxValue));
     }
@@ -51,8 +51,8 @@ public sealed class BaseRegenerateUpdateModuleData : UpdateModuleData
 
     private static readonly IniParseTable<BaseRegenerateUpdateModuleData> FieldParseTable = new IniParseTable<BaseRegenerateUpdateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new BaseRegenerateUpdate(gameObject, context);
+        return new BaseRegenerateUpdate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/BattlePlanUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BattlePlanUpdate.cs
@@ -31,7 +31,7 @@ public sealed class BattlePlanUpdate : UpdateModule
 
     private int _unknownInt;
 
-    internal BattlePlanUpdate(GameObject gameObject, GameContext context, BattlePlanUpdateModuleData moduleData)
+    internal BattlePlanUpdate(GameObject gameObject, GameEngine context, BattlePlanUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -178,9 +178,9 @@ public sealed class BattlePlanUpdate : UpdateModule
 
     private void DisableAffectedUnits()
     {
-        var disabledUntilFrame = Context.GameLogic.CurrentFrame + _moduleData.BattlePlanChangeParalyzeTime;
+        var disabledUntilFrame = GameEngine.GameLogic.CurrentFrame + _moduleData.BattlePlanChangeParalyzeTime;
         // if deactivating, set disabled_paralyzed to affected units based on kind, frames is current frame + property
-        foreach (var gameObject in Context.GameLogic.Objects)
+        foreach (var gameObject in GameEngine.GameLogic.Objects)
         {
             if (gameObject.Owner == GameObject.Owner && // we must own the object
                 gameObject.Definition.KindOf.Intersects(_moduleData.ValidMemberKindOf) && // and it should be one of these kinds
@@ -201,7 +201,7 @@ public sealed class BattlePlanUpdate : UpdateModule
             BattlePlanType.SearchAndDestroy => _moduleData.SearchAndDestroyPlanUnpackSound,
             _ => null,
         };
-        Context.AudioSystem.PlayAudioEvent(sound?.Value);
+        GameEngine.AudioSystem.PlayAudioEvent(sound?.Value);
     }
 
     private void PlayPackSound()
@@ -213,7 +213,7 @@ public sealed class BattlePlanUpdate : UpdateModule
             BattlePlanType.SearchAndDestroy => _moduleData.SearchAndDestroyPlanPackSound,
             _ => null,
         };
-        Context.AudioSystem.PlayAudioEvent(sound?.Value);
+        GameEngine.AudioSystem.PlayAudioEvent(sound?.Value);
     }
 
     private void PlayAnnouncementSound()
@@ -225,7 +225,7 @@ public sealed class BattlePlanUpdate : UpdateModule
             BattlePlanType.SearchAndDestroy => _moduleData.SearchAndDestroyAnnouncement,
             _ => null,
         };
-        Context.AudioSystem.PlayAudioEvent(sound?.Value);
+        GameEngine.AudioSystem.PlayAudioEvent(sound?.Value);
     }
 
     private void SetStateChangeCompleteFrame(LogicFrame currentFrame)
@@ -408,7 +408,7 @@ public sealed class BattlePlanUpdateModuleData : UpdateModuleData
     // Revealing
     public LazyAssetReference<ObjectDefinition> VisionObjectName { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new BattlePlanUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/BattlePlanUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BattlePlanUpdate.cs
@@ -31,8 +31,8 @@ public sealed class BattlePlanUpdate : UpdateModule
 
     private int _unknownInt;
 
-    internal BattlePlanUpdate(GameObject gameObject, GameEngine context, BattlePlanUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal BattlePlanUpdate(GameObject gameObject, GameEngine gameEngine, BattlePlanUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -408,9 +408,9 @@ public sealed class BattlePlanUpdateModuleData : UpdateModuleData
     // Revealing
     public LazyAssetReference<ObjectDefinition> VisionObjectName { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new BattlePlanUpdate(gameObject, context, this);
+        return new BattlePlanUpdate(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/BoneFXUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BoneFXUpdate.cs
@@ -9,7 +9,7 @@ public sealed class BoneFXUpdate : UpdateModule
     private readonly List<uint> _particleSystemIds = new();
     private readonly int[] _unknownInts = new int[96];
 
-    public BoneFXUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public BoneFXUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -98,7 +98,7 @@ public sealed class BoneFXUpdateModuleData : UpdateModuleData
 
     public BoneFXUpdateParticleSystem PristineParticleSystem6 { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new BoneFXUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/BoneFXUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BoneFXUpdate.cs
@@ -9,7 +9,7 @@ public sealed class BoneFXUpdate : UpdateModule
     private readonly List<uint> _particleSystemIds = new();
     private readonly int[] _unknownInts = new int[96];
 
-    public BoneFXUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public BoneFXUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -98,9 +98,9 @@ public sealed class BoneFXUpdateModuleData : UpdateModuleData
 
     public BoneFXUpdateParticleSystem PristineParticleSystem6 { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new BoneFXUpdate(gameObject, context);
+        return new BoneFXUpdate(gameObject, gameEngine);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/CleanupHazardUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/CleanupHazardUpdate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class CleanupHazardUpdate : UpdateModule
 {
-    public CleanupHazardUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public CleanupHazardUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -38,8 +38,8 @@ public sealed class CleanupHazardUpdateModuleData : UpdateModuleData
     public int ScanRate { get; private set; }
     public float ScanRange { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new CleanupHazardUpdate(gameObject, context);
+        return new CleanupHazardUpdate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/CleanupHazardUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/CleanupHazardUpdate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class CleanupHazardUpdate : UpdateModule
 {
-    public CleanupHazardUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public CleanupHazardUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -38,7 +38,7 @@ public sealed class CleanupHazardUpdateModuleData : UpdateModuleData
     public int ScanRate { get; private set; }
     public float ScanRange { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new CleanupHazardUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/CommandButtonHuntUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/CommandButtonHuntUpdate.cs
@@ -6,7 +6,7 @@ public sealed class CommandButtonHuntUpdate : UpdateModule
 {
     private string _commandButtonName;
 
-    public CommandButtonHuntUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public CommandButtonHuntUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -31,7 +31,7 @@ public sealed class CommandButtonHuntUpdateModuleData : UpdateModuleData
 
     private static readonly IniParseTable<CommandButtonHuntUpdateModuleData> FieldParseTable = new IniParseTable<CommandButtonHuntUpdateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new CommandButtonHuntUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/CommandButtonHuntUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/CommandButtonHuntUpdate.cs
@@ -6,7 +6,7 @@ public sealed class CommandButtonHuntUpdate : UpdateModule
 {
     private string _commandButtonName;
 
-    public CommandButtonHuntUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public CommandButtonHuntUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -31,8 +31,8 @@ public sealed class CommandButtonHuntUpdateModuleData : UpdateModuleData
 
     private static readonly IniParseTable<CommandButtonHuntUpdateModuleData> FieldParseTable = new IniParseTable<CommandButtonHuntUpdateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new CommandButtonHuntUpdate(gameObject, context);
+        return new CommandButtonHuntUpdate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
@@ -10,7 +10,7 @@ internal class DeletionUpdate : UpdateModule
 
     private LogicFrame _frameToDelete;
 
-    public DeletionUpdate(GameObject gameObject, GameContext context, DeletionUpdateModuleData moduleData)
+    public DeletionUpdate(GameObject gameObject, GameEngine context, DeletionUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -23,7 +23,7 @@ internal class DeletionUpdate : UpdateModule
     {
         if (context.LogicFrame >= _frameToDelete)
         {
-            context.GameContext.GameLogic.DestroyObject(GameObject);
+            context.GameEngine.GameLogic.DestroyObject(GameObject);
         }
     }
 
@@ -57,7 +57,7 @@ public sealed class DeletionUpdateModuleData : UpdateModuleData
     public LogicFrameSpan MinLifetime { get; private set; }
     public LogicFrameSpan MaxLifetime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new DeletionUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
@@ -10,12 +10,12 @@ internal class DeletionUpdate : UpdateModule
 
     private LogicFrame _frameToDelete;
 
-    public DeletionUpdate(GameObject gameObject, GameEngine context, DeletionUpdateModuleData moduleData)
-        : base(gameObject, context)
+    public DeletionUpdate(GameObject gameObject, GameEngine gameEngine, DeletionUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
 
-        _frameToDelete = context.GameLogic.CurrentFrame + context.GetRandomLogicFrameSpan(_moduleData.MinLifetime, _moduleData.MaxLifetime);
+        _frameToDelete = gameEngine.GameLogic.CurrentFrame + gameEngine.GetRandomLogicFrameSpan(_moduleData.MinLifetime, _moduleData.MaxLifetime);
         SetNextUpdateFrame(_frameToDelete);
     }
 
@@ -57,8 +57,8 @@ public sealed class DeletionUpdateModuleData : UpdateModuleData
     public LogicFrameSpan MinLifetime { get; private set; }
     public LogicFrameSpan MaxLifetime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new DeletionUpdate(gameObject, context, this);
+        return new DeletionUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/DockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DockUpdate.cs
@@ -23,7 +23,7 @@ public abstract class DockUpdate : UpdateModule
     private uint _unknownObjectId;
     private ushort _unknownInt1;
 
-    protected DockUpdate(GameObject gameObject, GameContext context, DockUpdateModuleData moduleData)
+    protected DockUpdate(GameObject gameObject, GameEngine context, DockUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;

--- a/src/OpenSage.Game/Logic/Object/Update/DockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DockUpdate.cs
@@ -23,8 +23,8 @@ public abstract class DockUpdate : UpdateModule
     private uint _unknownObjectId;
     private ushort _unknownInt1;
 
-    protected DockUpdate(GameObject gameObject, GameEngine context, DockUpdateModuleData moduleData)
-        : base(gameObject, context)
+    protected DockUpdate(GameObject gameObject, GameEngine gameEngine, DockUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
         _unitsApproaching = new Queue<SupplyAIUpdate>();

--- a/src/OpenSage.Game/Logic/Object/Update/DynamicShroudClearingRangeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DynamicShroudClearingRangeUpdate.cs
@@ -15,7 +15,7 @@ public sealed class DynamicShroudClearingRangeUpdate : UpdateModule
     private float _unknown9;
     private float _unknownFloat;
 
-    public DynamicShroudClearingRangeUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public DynamicShroudClearingRangeUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -79,8 +79,8 @@ public sealed class DynamicShroudClearingRangeUpdateModuleData : UpdateModuleDat
 
     public RadiusDecalTemplate GridDecalTemplate { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new DynamicShroudClearingRangeUpdate(gameObject, context);
+        return new DynamicShroudClearingRangeUpdate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/DynamicShroudClearingRangeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DynamicShroudClearingRangeUpdate.cs
@@ -15,7 +15,7 @@ public sealed class DynamicShroudClearingRangeUpdate : UpdateModule
     private float _unknown9;
     private float _unknownFloat;
 
-    public DynamicShroudClearingRangeUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public DynamicShroudClearingRangeUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -79,7 +79,7 @@ public sealed class DynamicShroudClearingRangeUpdateModuleData : UpdateModuleDat
 
     public RadiusDecalTemplate GridDecalTemplate { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new DynamicShroudClearingRangeUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
@@ -15,7 +15,7 @@ public class ExperienceUpdate : UpdateModule
 
     public bool ObjectGainsExperience { get; private set; }
 
-    internal ExperienceUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    internal ExperienceUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
         _initial = true;
     }
@@ -63,7 +63,7 @@ public class ExperienceUpdate : UpdateModule
             _nextLevel.LevelUpFX.Value?.Execute(new FXListExecutionContext(
                 context.GameObject.Rotation,
                 context.GameObject.Translation,
-                context.GameContext));
+                context.GameEngine));
         }
 
         GameObject.ExperienceValue -= _nextLevel.RequiredExperience;
@@ -150,7 +150,7 @@ public class ExperienceUpdate : UpdateModule
 
     private List<ExperienceLevel> FindRelevantExperienceLevels(BehaviorUpdateContext context)
     {
-        var experienceLevels = context.GameContext.AssetLoadContext.AssetStore.ExperienceLevels;
+        var experienceLevels = context.GameEngine.AssetLoadContext.AssetStore.ExperienceLevels;
         var levels = experienceLevels.Where(x => x.TargetNames != null && x.TargetNames.Contains(GameObject.Definition.Name)).ToList();
         levels.Sort((x, y) => x.Rank.CompareTo(y.Rank));
         return levels.Count > 0 ? levels : null;

--- a/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
@@ -15,7 +15,7 @@ public class ExperienceUpdate : UpdateModule
 
     public bool ObjectGainsExperience { get; private set; }
 
-    internal ExperienceUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    internal ExperienceUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
         _initial = true;
     }

--- a/src/OpenSage.Game/Logic/Object/Update/FireSpreadUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FireSpreadUpdate.cs
@@ -7,7 +7,7 @@ namespace OpenSage.Logic.Object;
 public sealed class FireSpreadUpdate : UpdateModule
 {
     // TODO
-    public FireSpreadUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public FireSpreadUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -38,8 +38,8 @@ public sealed class FireSpreadUpdateModuleData : UpdateModuleData
     public TimeSpan MaxSpreadDelay { get; private set; }
     public int SpreadTryRange { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new FireSpreadUpdate(gameObject, context);
+        return new FireSpreadUpdate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/FireSpreadUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FireSpreadUpdate.cs
@@ -7,7 +7,7 @@ namespace OpenSage.Logic.Object;
 public sealed class FireSpreadUpdate : UpdateModule
 {
     // TODO
-    public FireSpreadUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public FireSpreadUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -38,7 +38,7 @@ public sealed class FireSpreadUpdateModuleData : UpdateModuleData
     public TimeSpan MaxSpreadDelay { get; private set; }
     public int SpreadTryRange { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new FireSpreadUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/FireWeaponUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FireWeaponUpdate.cs
@@ -22,7 +22,7 @@ public sealed class FireWeaponUpdate : UpdateModule
     private uint _unknownUInt4;
     private uint _unknownUInt5;
 
-    public FireWeaponUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public FireWeaponUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -111,9 +111,9 @@ public sealed class FireWeaponUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public WeaponNugget FireWeaponNugget { get; private set; }
 
-    internal override FireWeaponUpdate CreateModule(GameObject gameObject, GameEngine context)
+    internal override FireWeaponUpdate CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new FireWeaponUpdate(gameObject, context);
+        return new FireWeaponUpdate(gameObject, gameEngine);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/FireWeaponUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FireWeaponUpdate.cs
@@ -22,7 +22,7 @@ public sealed class FireWeaponUpdate : UpdateModule
     private uint _unknownUInt4;
     private uint _unknownUInt5;
 
-    public FireWeaponUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public FireWeaponUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -111,7 +111,7 @@ public sealed class FireWeaponUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public WeaponNugget FireWeaponNugget { get; private set; }
 
-    internal override FireWeaponUpdate CreateModule(GameObject gameObject, GameContext context)
+    internal override FireWeaponUpdate CreateModule(GameObject gameObject, GameEngine context)
     {
         return new FireWeaponUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/FlammableUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FlammableUpdate.cs
@@ -12,8 +12,8 @@ public sealed class FlammableUpdate : UpdateModule
     private float _remainingDamageBeforeCatchingFire;
     private uint _startedTakingFlameDamageFrame;
 
-    internal FlammableUpdate(GameObject gameObject, GameEngine context, FlammableUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal FlammableUpdate(GameObject gameObject, GameEngine gameEngine, FlammableUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
         _remainingDamageBeforeCatchingFire = moduleData.FlameDamageLimit;
@@ -144,8 +144,8 @@ public sealed class FlammableUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public DamageType DamageType { get; internal set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new FlammableUpdate(gameObject, context, this);
+        return new FlammableUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/FlammableUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FlammableUpdate.cs
@@ -12,7 +12,7 @@ public sealed class FlammableUpdate : UpdateModule
     private float _remainingDamageBeforeCatchingFire;
     private uint _startedTakingFlameDamageFrame;
 
-    internal FlammableUpdate(GameObject gameObject, GameContext context, FlammableUpdateModuleData moduleData)
+    internal FlammableUpdate(GameObject gameObject, GameEngine context, FlammableUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -144,7 +144,7 @@ public sealed class FlammableUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public DamageType DamageType { get; internal set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new FlammableUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/HijackerUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/HijackerUpdate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class HijackerUpdate : UpdateModule
 {
-    public HijackerUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public HijackerUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -31,7 +31,7 @@ public sealed class HijackerUpdateModuleData : UpdateModuleData
 
     public string ParachuteName { get; private set; }
 
-    internal override HijackerUpdate CreateModule(GameObject gameObject, GameContext context)
+    internal override HijackerUpdate CreateModule(GameObject gameObject, GameEngine context)
     {
         return new HijackerUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/HijackerUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/HijackerUpdate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class HijackerUpdate : UpdateModule
 {
-    public HijackerUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public HijackerUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -31,8 +31,8 @@ public sealed class HijackerUpdateModuleData : UpdateModuleData
 
     public string ParachuteName { get; private set; }
 
-    internal override HijackerUpdate CreateModule(GameObject gameObject, GameEngine context)
+    internal override HijackerUpdate CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new HijackerUpdate(gameObject, context);
+        return new HijackerUpdate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/HordeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/HordeUpdate.cs
@@ -16,7 +16,7 @@ public sealed class HordeUpdate : UpdateModule
 
     protected override LogicFrameSpan FramesBetweenUpdates => _moduleData.UpdateRate;
 
-    internal HordeUpdate(GameObject gameObject, GameContext context, HordeUpdateModuleData moduleData)
+    internal HordeUpdate(GameObject gameObject, GameEngine context, HordeUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -24,7 +24,7 @@ public sealed class HordeUpdate : UpdateModule
 
     private protected override void RunUpdate(BehaviorUpdateContext context)
     {
-        var nearby = Context.Scene3D.Quadtree.FindNearby(GameObject, GameObject.Transform, _moduleData.Radius);
+        var nearby = GameEngine.Scene3D.Quadtree.FindNearby(GameObject, GameObject.Transform, _moduleData.Radius);
         var nearbyInConstraints = nearby.Where(MatchesAlliance).Where(MatchesType).Select(o => o.FindBehavior<HordeUpdate>()).ToList();
 
         if (nearbyInConstraints.Count >= _moduleData.Count - 1) // this list doesn't include us, but count does
@@ -40,7 +40,7 @@ public sealed class HordeUpdate : UpdateModule
         {
             // check if there are others who are in a horde near us
             // I don't think this behavior is strictly correct, but it seems the simplest way to implement this logic in the spirit of the data names and descriptions
-            var nearbyRubOff = Context.Scene3D.Quadtree.FindNearby(GameObject, GameObject.Transform, _moduleData.RubOffRadius);
+            var nearbyRubOff = GameEngine.Scene3D.Quadtree.FindNearby(GameObject, GameObject.Transform, _moduleData.RubOffRadius);
             var nearbyRubOffInConstraints = nearbyRubOff.Where(MatchesAlliance).Where(MatchesType).Count(o => o.FindBehavior<HordeUpdate>() is { _isInHorde: true });
             if (nearbyRubOffInConstraints < _moduleData.Count - 1) // this list doesn't include us, but count does
             {
@@ -64,7 +64,7 @@ public sealed class HordeUpdate : UpdateModule
     }
 
     // todo: should this be hardcoded?
-    private UpgradeTemplate? NationalismUpgrade => Context.AssetLoadContext.AssetStore.Upgrades.GetLazyAssetReferenceByName("Upgrade_Nationalism")?.Value;
+    private UpgradeTemplate? NationalismUpgrade => GameEngine.AssetLoadContext.AssetStore.Upgrades.GetLazyAssetReferenceByName("Upgrade_Nationalism")?.Value;
 
     private bool HasNationalism => NationalismUpgrade != null && GameObject.Owner.HasUpgrade(NationalismUpgrade);
 
@@ -160,7 +160,7 @@ public sealed class HordeUpdateModuleData : UpdateModuleData
     /// </summary>
     public WeaponBonusType Action { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new HordeUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/HordeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/HordeUpdate.cs
@@ -16,8 +16,8 @@ public sealed class HordeUpdate : UpdateModule
 
     protected override LogicFrameSpan FramesBetweenUpdates => _moduleData.UpdateRate;
 
-    internal HordeUpdate(GameObject gameObject, GameEngine context, HordeUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal HordeUpdate(GameObject gameObject, GameEngine gameEngine, HordeUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -160,8 +160,8 @@ public sealed class HordeUpdateModuleData : UpdateModuleData
     /// </summary>
     public WeaponBonusType Action { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new HordeUpdate(gameObject, context, this);
+        return new HordeUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
@@ -15,7 +15,7 @@ internal sealed class LifetimeUpdate : UpdateModule
         set => _frameToDie = value;
     }
 
-    public LifetimeUpdate(GameObject gameObject, GameContext context, LifetimeUpdateModuleData moduleData)
+    public LifetimeUpdate(GameObject gameObject, GameEngine context, LifetimeUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -69,7 +69,7 @@ public sealed class LifetimeUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme)]
     public DeathType DeathType { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new LifetimeUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
@@ -15,16 +15,16 @@ internal sealed class LifetimeUpdate : UpdateModule
         set => _frameToDie = value;
     }
 
-    public LifetimeUpdate(GameObject gameObject, GameEngine context, LifetimeUpdateModuleData moduleData)
-        : base(gameObject, context)
+    public LifetimeUpdate(GameObject gameObject, GameEngine gameEngine, LifetimeUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
 
-        var lifetimeFrames = context.Random.Next(
+        var lifetimeFrames = gameEngine.Random.Next(
             (int)moduleData.MinLifetime.Value,
             (int)moduleData.MaxLifetime.Value);
 
-        _frameToDie = context.GameLogic.CurrentFrame + new LogicFrameSpan((uint)lifetimeFrames);
+        _frameToDie = gameEngine.GameLogic.CurrentFrame + new LogicFrameSpan((uint)lifetimeFrames);
     }
 
     internal override void Update(BehaviorUpdateContext context)
@@ -69,8 +69,8 @@ public sealed class LifetimeUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme)]
     public DeathType DeathType { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new LifetimeUpdate(gameObject, context, this);
+        return new LifetimeUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/OCLUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/OCLUpdate.cs
@@ -7,7 +7,7 @@ public sealed class OCLUpdate : UpdateModule
 {
     private bool _unknownBool;
 
-    public OCLUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public OCLUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -56,9 +56,9 @@ public sealed class OCLUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public int Amount { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new OCLUpdate(gameObject, context);
+        return new OCLUpdate(gameObject, gameEngine);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/OCLUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/OCLUpdate.cs
@@ -7,7 +7,7 @@ public sealed class OCLUpdate : UpdateModule
 {
     private bool _unknownBool;
 
-    public OCLUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public OCLUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -56,7 +56,7 @@ public sealed class OCLUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public int Amount { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new OCLUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ParticleUplinkCannonUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ParticleUplinkCannonUpdate.cs
@@ -52,8 +52,8 @@ public sealed class ParticleUplinkCannonUpdate : UpdateModule
 
     private readonly ParticleUplinkCannonUpdateModuleData _moduleData;
 
-    internal ParticleUplinkCannonUpdate(GameObject gameObject, GameEngine context, ParticleUplinkCannonUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal ParticleUplinkCannonUpdate(GameObject gameObject, GameEngine gameEngine, ParticleUplinkCannonUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -264,8 +264,8 @@ public sealed class ParticleUplinkCannonUpdateModuleData : UpdateModuleData
 
     public LazyAssetReference<ObjectDefinition> DamagePulseRemnantObjectName { get; private set; }
 
-    internal override ParticleUplinkCannonUpdate CreateModule(GameObject gameObject, GameEngine context)
+    internal override ParticleUplinkCannonUpdate CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new ParticleUplinkCannonUpdate(gameObject, context, this);
+        return new ParticleUplinkCannonUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/ParticleUplinkCannonUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ParticleUplinkCannonUpdate.cs
@@ -52,7 +52,7 @@ public sealed class ParticleUplinkCannonUpdate : UpdateModule
 
     private readonly ParticleUplinkCannonUpdateModuleData _moduleData;
 
-    internal ParticleUplinkCannonUpdate(GameObject gameObject, GameContext context, ParticleUplinkCannonUpdateModuleData moduleData)
+    internal ParticleUplinkCannonUpdate(GameObject gameObject, GameEngine context, ParticleUplinkCannonUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -264,7 +264,7 @@ public sealed class ParticleUplinkCannonUpdateModuleData : UpdateModuleData
 
     public LazyAssetReference<ObjectDefinition> DamagePulseRemnantObjectName { get; private set; }
 
-    internal override ParticleUplinkCannonUpdate CreateModule(GameObject gameObject, GameContext context)
+    internal override ParticleUplinkCannonUpdate CreateModule(GameObject gameObject, GameEngine context)
     {
         return new ParticleUplinkCannonUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/PowerPlantUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/PowerPlantUpdate.cs
@@ -12,7 +12,7 @@ public sealed class PowerPlantUpdate : UpdateModule
 
     private LogicFrame _rodsExtendedEndFrame;
 
-    internal PowerPlantUpdate(GameObject gameObject, GameContext context, PowerPlantUpdateModuleData moduleData)
+    internal PowerPlantUpdate(GameObject gameObject, GameEngine context, PowerPlantUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -24,7 +24,7 @@ public sealed class PowerPlantUpdate : UpdateModule
 
         GameObject.Drawable.ModelConditionFlags.Set(ModelConditionFlag.PowerPlantUpgrading, true);
 
-        _rodsExtendedEndFrame = Context.GameLogic.CurrentFrame + _moduleData.RodsExtendTime;
+        _rodsExtendedEndFrame = GameEngine.GameLogic.CurrentFrame + _moduleData.RodsExtendTime;
     }
 
     // China powerplant overcharge needs to be able to turn off
@@ -93,7 +93,7 @@ public sealed class PowerPlantUpdateModuleData : UpdateModuleData
 
     public LogicFrameSpan RodsExtendTime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new PowerPlantUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/PowerPlantUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/PowerPlantUpdate.cs
@@ -12,8 +12,8 @@ public sealed class PowerPlantUpdate : UpdateModule
 
     private LogicFrame _rodsExtendedEndFrame;
 
-    internal PowerPlantUpdate(GameObject gameObject, GameEngine context, PowerPlantUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal PowerPlantUpdate(GameObject gameObject, GameEngine gameEngine, PowerPlantUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -93,8 +93,8 @@ public sealed class PowerPlantUpdateModuleData : UpdateModuleData
 
     public LogicFrameSpan RodsExtendTime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new PowerPlantUpdate(gameObject, context, this);
+        return new PowerPlantUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/DefaultProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/DefaultProductionExitUpdate.cs
@@ -9,7 +9,7 @@ public sealed class DefaultProductionExitUpdate : UpdateModule, IHasRallyPoint, 
 
     private readonly DefaultProductionExitUpdateModuleData _moduleData;
 
-    internal DefaultProductionExitUpdate(GameObject gameObject, GameContext context, DefaultProductionExitUpdateModuleData moduleData)
+    internal DefaultProductionExitUpdate(GameObject gameObject, GameEngine context, DefaultProductionExitUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -52,7 +52,7 @@ public sealed class DefaultProductionExitUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public bool UseSpawnRallyPoint { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new DefaultProductionExitUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/DefaultProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/DefaultProductionExitUpdate.cs
@@ -9,8 +9,8 @@ public sealed class DefaultProductionExitUpdate : UpdateModule, IHasRallyPoint, 
 
     private readonly DefaultProductionExitUpdateModuleData _moduleData;
 
-    internal DefaultProductionExitUpdate(GameObject gameObject, GameEngine context, DefaultProductionExitUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal DefaultProductionExitUpdate(GameObject gameObject, GameEngine gameEngine, DefaultProductionExitUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -52,8 +52,8 @@ public sealed class DefaultProductionExitUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public bool UseSpawnRallyPoint { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new DefaultProductionExitUpdate(gameObject, context, this);
+        return new DefaultProductionExitUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/QueueProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/QueueProductionExitUpdate.cs
@@ -12,8 +12,8 @@ public sealed class QueueProductionExitUpdate : UpdateModule, IHasRallyPoint, IP
     private LogicFrameSpan _framesUntilNextSpawn;
     private readonly QueueProductionExitUpdateModuleData _moduleData;
 
-    internal QueueProductionExitUpdate(GameObject gameObject, GameEngine context, QueueProductionExitUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal QueueProductionExitUpdate(GameObject gameObject, GameEngine gameEngine, QueueProductionExitUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
         _framesUntilNextSpawn = moduleData.ExitDelay;
@@ -101,8 +101,8 @@ public sealed class QueueProductionExitUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool UseReturnToFormation { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new QueueProductionExitUpdate(gameObject, context, this);
+        return new QueueProductionExitUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/QueueProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/QueueProductionExitUpdate.cs
@@ -12,7 +12,7 @@ public sealed class QueueProductionExitUpdate : UpdateModule, IHasRallyPoint, IP
     private LogicFrameSpan _framesUntilNextSpawn;
     private readonly QueueProductionExitUpdateModuleData _moduleData;
 
-    internal QueueProductionExitUpdate(GameObject gameObject, GameContext context, QueueProductionExitUpdateModuleData moduleData)
+    internal QueueProductionExitUpdate(GameObject gameObject, GameEngine context, QueueProductionExitUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -101,7 +101,7 @@ public sealed class QueueProductionExitUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool UseReturnToFormation { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new QueueProductionExitUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SpawnPointProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SpawnPointProductionExitUpdate.cs
@@ -10,7 +10,7 @@ public sealed class SpawnPointProductionExitUpdate : UpdateModule, IProductionEx
     private readonly SpawnPointProductionExitUpdateModuleData _moduleData;
     private int _nextIndex;
 
-    internal SpawnPointProductionExitUpdate(GameObject gameObject, GameContext context, SpawnPointProductionExitUpdateModuleData moduleData)
+    internal SpawnPointProductionExitUpdate(GameObject gameObject, GameEngine context, SpawnPointProductionExitUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -55,7 +55,7 @@ public sealed class SpawnPointProductionExitUpdateModuleData : UpdateModuleData
 
     public string SpawnPointBoneName { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new SpawnPointProductionExitUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SpawnPointProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SpawnPointProductionExitUpdate.cs
@@ -10,8 +10,8 @@ public sealed class SpawnPointProductionExitUpdate : UpdateModule, IProductionEx
     private readonly SpawnPointProductionExitUpdateModuleData _moduleData;
     private int _nextIndex;
 
-    internal SpawnPointProductionExitUpdate(GameObject gameObject, GameEngine context, SpawnPointProductionExitUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal SpawnPointProductionExitUpdate(GameObject gameObject, GameEngine gameEngine, SpawnPointProductionExitUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
 
@@ -55,8 +55,8 @@ public sealed class SpawnPointProductionExitUpdateModuleData : UpdateModuleData
 
     public string SpawnPointBoneName { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SpawnPointProductionExitUpdate(gameObject, context, this);
+        return new SpawnPointProductionExitUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SupplyCenterProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SupplyCenterProductionExitUpdate.cs
@@ -9,8 +9,8 @@ public sealed class SupplyCenterProductionExitUpdate : UpdateModule, IHasRallyPo
 
     private readonly SupplyCenterProductionExitUpdateModuleData _moduleData;
 
-    internal SupplyCenterProductionExitUpdate(GameObject gameObject, GameEngine context, SupplyCenterProductionExitUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal SupplyCenterProductionExitUpdate(GameObject gameObject, GameEngine gameEngine, SupplyCenterProductionExitUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -55,8 +55,8 @@ public sealed class SupplyCenterProductionExitUpdateModuleData : UpdateModuleDat
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public int GrantTemporaryStealth { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SupplyCenterProductionExitUpdate(gameObject, context, this);
+        return new SupplyCenterProductionExitUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SupplyCenterProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SupplyCenterProductionExitUpdate.cs
@@ -9,7 +9,7 @@ public sealed class SupplyCenterProductionExitUpdate : UpdateModule, IHasRallyPo
 
     private readonly SupplyCenterProductionExitUpdateModuleData _moduleData;
 
-    internal SupplyCenterProductionExitUpdate(GameObject gameObject, GameContext context, SupplyCenterProductionExitUpdateModuleData moduleData)
+    internal SupplyCenterProductionExitUpdate(GameObject gameObject, GameEngine context, SupplyCenterProductionExitUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -55,7 +55,7 @@ public sealed class SupplyCenterProductionExitUpdateModuleData : UpdateModuleDat
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public int GrantTemporaryStealth { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new SupplyCenterProductionExitUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -44,7 +44,7 @@ public sealed class ProductionUpdate : UpdateModule
 
     public IReadOnlyList<ProductionJob> ProductionQueue => _productionQueue;
 
-    internal ProductionUpdate(GameObject gameObject, GameContext context, ProductionUpdateModuleData moduleData)
+    internal ProductionUpdate(GameObject gameObject, GameEngine context, ProductionUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -113,7 +113,7 @@ public sealed class ProductionUpdate : UpdateModule
                                 if (front.UpgradeDefinition.ResearchSound != null)
                                 {
                                     // todo: if null, trigger DialogEvent EvaUSA_UpgradeComplete?
-                                    context.GameContext.AudioSystem.PlayAudioEvent(front.UpgradeDefinition.ResearchSound.Value);
+                                    context.GameEngine.AudioSystem.PlayAudioEvent(front.UpgradeDefinition.ResearchSound.Value);
                                 }
 
                                 break;
@@ -153,7 +153,7 @@ public sealed class ProductionUpdate : UpdateModule
     {
         _doorIndex = doorIndex;
         Logger.Info($"Door closing for {_moduleData.DoorCloseTime}");
-        SetDoorStateEndFrame(DoorState.Closing, Context.GameLogic.CurrentFrame + _moduleData.DoorCloseTime);
+        SetDoorStateEndFrame(DoorState.Closing, GameEngine.GameLogic.CurrentFrame + _moduleData.DoorCloseTime);
         // TODO: What is ModelConditionFlag.Door1WaitingToClose?
     }
 
@@ -345,13 +345,13 @@ public sealed class ProductionUpdate : UpdateModule
 
         ProductionExit.ProduceUnit();
 
-        var producedUnit = Context.GameLogic.CreateObject(objectDefinition, GameObject.Owner);
+        var producedUnit = GameEngine.GameLogic.CreateObject(objectDefinition, GameObject.Owner);
         producedUnit.Owner = GameObject.Owner;
         producedUnit.ParentHorde = ParentHorde;
 
         if (playAudio)
         {
-            Context.Scene3D.Audio.PlayAudioEvent(producedUnit, producedUnit.Definition.UnitSpecificSounds?.VoiceCreate?.Value);
+            GameEngine.Scene3D.Audio.PlayAudioEvent(producedUnit, producedUnit.Definition.UnitSpecificSounds?.VoiceCreate?.Value);
         }
 
         if (!_moduleData.GiveNoXP)
@@ -411,7 +411,7 @@ public sealed class ProductionUpdate : UpdateModule
             producedUnit.AIUpdate.AddTargetPoint(GameObject.RallyPoint.Value);
         }
 
-        Context.AudioSystem.PlayAudioEvent(producedUnit, producedUnit.Definition.SoundMoveStart.Value);
+        GameEngine.AudioSystem.PlayAudioEvent(producedUnit, producedUnit.Definition.SoundMoveStart.Value);
 
         HandleHordeCreation(producedUnit);
         HandleHarvesterUnitCreation(GameObject, producedUnit);
@@ -711,7 +711,7 @@ public sealed class ProductionUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public List<ProductionModifier> ProductionModifiers { get; } = new List<ProductionModifier>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new ProductionUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -44,8 +44,8 @@ public sealed class ProductionUpdate : UpdateModule
 
     public IReadOnlyList<ProductionJob> ProductionQueue => _productionQueue;
 
-    internal ProductionUpdate(GameObject gameObject, GameEngine context, ProductionUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal ProductionUpdate(GameObject gameObject, GameEngine gameEngine, ProductionUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -711,9 +711,9 @@ public sealed class ProductionUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public List<ProductionModifier> ProductionModifiers { get; } = new List<ProductionModifier>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new ProductionUpdate(gameObject, context, this);
+        return new ProductionUpdate(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/ProjectileStreamUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProjectileStreamUpdate.cs
@@ -9,7 +9,7 @@ public sealed class ProjectileStreamUpdate : UpdateModule
     private uint _unknownInt2;
     private uint _unknownObjectId;
 
-    public ProjectileStreamUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public ProjectileStreamUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -43,8 +43,8 @@ public sealed class ProjectileStreamUpdateModuleData : UpdateModuleData
 
     private static readonly IniParseTable<ProjectileStreamUpdateModuleData> FieldParseTable = new IniParseTable<ProjectileStreamUpdateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new ProjectileStreamUpdate(gameObject, context);
+        return new ProjectileStreamUpdate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/ProjectileStreamUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProjectileStreamUpdate.cs
@@ -9,7 +9,7 @@ public sealed class ProjectileStreamUpdate : UpdateModule
     private uint _unknownInt2;
     private uint _unknownObjectId;
 
-    public ProjectileStreamUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public ProjectileStreamUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -43,7 +43,7 @@ public sealed class ProjectileStreamUpdateModuleData : UpdateModuleData
 
     private static readonly IniParseTable<ProjectileStreamUpdateModuleData> FieldParseTable = new IniParseTable<ProjectileStreamUpdateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new ProjectileStreamUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/RadarUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RadarUpdate.cs
@@ -8,7 +8,7 @@ public sealed class RadarUpdate : UpdateModule
     private bool _isRadarExtending;
     private bool _isRadarExtended;
 
-    public RadarUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public RadarUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -37,8 +37,8 @@ public sealed class RadarUpdateModuleData : UpdateModuleData
 
     public int RadarExtendTime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new RadarUpdate(gameObject, context);
+        return new RadarUpdate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/RadarUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RadarUpdate.cs
@@ -8,7 +8,7 @@ public sealed class RadarUpdate : UpdateModule
     private bool _isRadarExtending;
     private bool _isRadarExtended;
 
-    public RadarUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public RadarUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -37,7 +37,7 @@ public sealed class RadarUpdateModuleData : UpdateModuleData
 
     public int RadarExtendTime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new RadarUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/RebuildHoleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RebuildHoleUpdate.cs
@@ -26,8 +26,8 @@ public sealed class RebuildHoleUpdate : UpdateModule
     private string _structureObjectName; // the structure we're rebuilding
     private ObjectDefinition StructureObjectDefinition => GameEngine.Game.AssetStore.ObjectDefinitions.GetByName(_structureObjectName);
 
-    internal RebuildHoleUpdate(GameObject gameObject, GameEngine context, RebuildHoleUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal RebuildHoleUpdate(GameObject gameObject, GameEngine gameEngine, RebuildHoleUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
 
@@ -197,8 +197,8 @@ public sealed class RebuildHoleUpdateModuleData : UpdateModuleData
 
     public Percentage HoleHealthRegenPercentPerSecond { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new RebuildHoleUpdate(gameObject, context, this);
+        return new RebuildHoleUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/RebuildHoleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RebuildHoleUpdate.cs
@@ -31,7 +31,7 @@ public sealed class RebuildHoleUpdate : UpdateModule
     {
         _moduleData = moduleData;
 
-        _healPercentagePerFrame = new Percentage((float)moduleData.HoleHealthRegenPercentPerSecond / Game.LogicFramesPerSecond);
+        _healPercentagePerFrame = new Percentage((float)moduleData.HoleHealthRegenPercentPerSecond / GameEngine.LogicFramesPerSecond);
         _workerObjectName = moduleData.WorkerObjectDefinition.Value.Name;
 
         ResetConstructionCounter();

--- a/src/OpenSage.Game/Logic/Object/Update/RebuildHoleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RebuildHoleUpdate.cs
@@ -22,11 +22,11 @@ public sealed class RebuildHoleUpdate : UpdateModule
     private LogicFrameSpan _framesUntilConstructionBegins;
 
     private string _workerObjectName; // the worker to spawn to build the structure
-    private ObjectDefinition WorkerObjectDefinition => Context.Game.AssetStore.ObjectDefinitions.GetByName(_workerObjectName);
+    private ObjectDefinition WorkerObjectDefinition => GameEngine.Game.AssetStore.ObjectDefinitions.GetByName(_workerObjectName);
     private string _structureObjectName; // the structure we're rebuilding
-    private ObjectDefinition StructureObjectDefinition => Context.Game.AssetStore.ObjectDefinitions.GetByName(_structureObjectName);
+    private ObjectDefinition StructureObjectDefinition => GameEngine.Game.AssetStore.ObjectDefinitions.GetByName(_structureObjectName);
 
-    internal RebuildHoleUpdate(GameObject gameObject, GameContext context, RebuildHoleUpdateModuleData moduleData)
+    internal RebuildHoleUpdate(GameObject gameObject, GameEngine context, RebuildHoleUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -73,21 +73,21 @@ public sealed class RebuildHoleUpdate : UpdateModule
         if (_workerId == 0)
         {
             // spawn worker first
-            worker = Context.GameLogic.CreateObject(WorkerObjectDefinition, GameObject.Owner);
+            worker = GameEngine.GameLogic.CreateObject(WorkerObjectDefinition, GameObject.Owner);
             worker.SetTransformMatrix(GameObject.TransformMatrix);
             worker.SetSelectable(false); // we have no control over this worker
             _workerId = worker.ID;
         }
         else
         {
-            worker = Context.GameLogic.GetObjectById(_workerId);
+            worker = GameEngine.GameLogic.GetObjectById(_workerId);
         }
 
         GameObject structure;
         if (_structureId == 0)
         {
             // spawn structure after spawning worker
-            structure = Context.GameLogic.CreateObject(StructureObjectDefinition, GameObject.Owner);
+            structure = GameEngine.GameLogic.CreateObject(StructureObjectDefinition, GameObject.Owner);
             structure.SetTransformMatrix(GameObject.TransformMatrix);
             // todo: some special property that disables the cancel construction button?
             _structureId = structure.ID;
@@ -98,7 +98,7 @@ public sealed class RebuildHoleUpdate : UpdateModule
         }
         else
         {
-            structure = Context.GameLogic.GetObjectById(_structureId);
+            structure = GameEngine.GameLogic.GetObjectById(_structureId);
         }
 
         if (worker == null || worker.IsDead)
@@ -142,8 +142,8 @@ public sealed class RebuildHoleUpdate : UpdateModule
 
     internal override void OnDie(BehaviorUpdateContext context, DeathType deathType, BitArray<ObjectStatus> status)
     {
-        var worker = Context.GameLogic.GetObjectById(_workerId);
-        var structure = Context.GameLogic.GetObjectById(_structureId);
+        var worker = GameEngine.GameLogic.GetObjectById(_workerId);
+        var structure = GameEngine.GameLogic.GetObjectById(_structureId);
         worker?.Destroy();
         structure?.Destroy();
         base.OnDie(context, deathType, status);
@@ -197,7 +197,7 @@ public sealed class RebuildHoleUpdateModuleData : UpdateModuleData
 
     public Percentage HoleHealthRegenPercentPerSecond { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new RebuildHoleUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/RepairDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RepairDockUpdate.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 public sealed class RepairDockUpdate : DockUpdate
 {
-    internal RepairDockUpdate(GameObject gameObject, GameEngine context, RepairDockUpdateModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal RepairDockUpdate(GameObject gameObject, GameEngine gameEngine, RepairDockUpdateModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
 
     }
@@ -38,8 +38,8 @@ public sealed class RepairDockUpdateModuleData : DockUpdateModuleData
 
     public int TimeForFullHeal { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new RepairDockUpdate(gameObject, context, this);
+        return new RepairDockUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/RepairDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RepairDockUpdate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class RepairDockUpdate : DockUpdate
 {
-    internal RepairDockUpdate(GameObject gameObject, GameContext context, RepairDockUpdateModuleData moduleData)
+    internal RepairDockUpdate(GameObject gameObject, GameEngine context, RepairDockUpdateModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
 
@@ -38,7 +38,7 @@ public sealed class RepairDockUpdateModuleData : DockUpdateModuleData
 
     public int TimeForFullHeal { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new RepairDockUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/SlavedUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SlavedUpdate.cs
@@ -36,8 +36,8 @@ public class SlavedUpdateModule : UpdateModule
 
     private FXParticleSystemTemplate _particleTemplate;
 
-    internal SlavedUpdateModule(GameObject gameObject, GameEngine context, SlavedUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal SlavedUpdateModule(GameObject gameObject, GameEngine gameEngine, SlavedUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -293,8 +293,8 @@ public sealed class SlavedUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public int FadeTime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SlavedUpdateModule(gameObject, context, this);
+        return new SlavedUpdateModule(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/SlavedUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SlavedUpdate.cs
@@ -124,7 +124,7 @@ public class SlavedUpdateModule : UpdateModule
                 case RepairStatus.ZIP_AROUND:
                 case RepairStatus.IN_TRANSITION:
                 case RepairStatus.WELDING:
-                    _master.Health += (Fix64)(_moduleData.RepairRatePerSecond / Game.LogicFramesPerSecond);
+                    _master.Health += (Fix64)(_moduleData.RepairRatePerSecond / GameEngine.LogicFramesPerSecond);
                     if (_master.Health > _master.MaxHealth)
                     {
                         _master.Health = _master.MaxHealth;

--- a/src/OpenSage.Game/Logic/Object/Update/SlavedUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SlavedUpdate.cs
@@ -36,7 +36,7 @@ public class SlavedUpdateModule : UpdateModule
 
     private FXParticleSystemTemplate _particleTemplate;
 
-    internal SlavedUpdateModule(GameObject gameObject, GameContext context, SlavedUpdateModuleData moduleData)
+    internal SlavedUpdateModule(GameObject gameObject, GameEngine context, SlavedUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -77,16 +77,16 @@ public class SlavedUpdateModule : UpdateModule
                     if (!isMoving)
                     {
                         _repairStatus = RepairStatus.READY;
-                        var readyDuration = context.GameContext.GetRandomLogicFrameSpan(_moduleData.RepairMinReadyTime, _moduleData.RepairMaxReadyTime);
+                        var readyDuration = context.GameEngine.GetRandomLogicFrameSpan(_moduleData.RepairMinReadyTime, _moduleData.RepairMaxReadyTime);
                         _waitUntil = context.LogicFrame + readyDuration;
                     }
                     break;
                 case RepairStatus.READY:
                     if (context.LogicFrame >= _waitUntil)
                     {
-                        var range = (float)(context.GameContext.Random.NextDouble() * _moduleData.RepairRange);
-                        var height = (float)(context.GameContext.Random.NextDouble() * (_moduleData.RepairMaxAltitude - _moduleData.RepairMinAltitude) + _moduleData.RepairMinAltitude);
-                        var angle = (float)(context.GameContext.Random.NextDouble() * (Math.PI * 2));
+                        var range = (float)(context.GameEngine.Random.NextDouble() * _moduleData.RepairRange);
+                        var height = (float)(context.GameEngine.Random.NextDouble() * (_moduleData.RepairMaxAltitude - _moduleData.RepairMinAltitude) + _moduleData.RepairMinAltitude);
+                        var angle = (float)(context.GameEngine.Random.NextDouble() * (Math.PI * 2));
 
                         var offset = Vector3.Transform(new Vector3(range, 0.0f, height), Quaternion.CreateFromAxisAngle(Vector3.UnitZ, angle));
                         GameObject.AIUpdate.SetTargetPoint(_master.Translation + offset);
@@ -100,13 +100,13 @@ public class SlavedUpdateModule : UpdateModule
                         var transform = modelInstance.AbsoluteBoneTransforms[bone.Index];
                         _particleTemplate ??= _moduleData.RepairWeldingSys.Value;
 
-                        var particleSystem = context.GameContext.ParticleSystems.Create(
+                        var particleSystem = context.GameEngine.ParticleSystems.Create(
                             _particleTemplate,
                             transform);
 
                         particleSystem.Activate();
 
-                        var weldDuration = context.GameContext.GetRandomLogicFrameSpan(_moduleData.RepairMinWeldTime, _moduleData.RepairMaxWeldTime);
+                        var weldDuration = context.GameEngine.GetRandomLogicFrameSpan(_moduleData.RepairMinWeldTime, _moduleData.RepairMaxWeldTime);
                         _waitUntil = context.LogicFrame + weldDuration;
                         _repairStatus = RepairStatus.WELDING;
                     }
@@ -174,7 +174,7 @@ public class SlavedUpdateModule : UpdateModule
         }
 
         // prior to bfme2, die on master death seems to be the default?
-        if (_master.IsDead && (Context.Game.SageGame is not SageGame.Bfme2 || _moduleData.DieOnMastersDeath))
+        if (_master.IsDead && (GameEngine.Game.SageGame is not SageGame.Bfme2 || _moduleData.DieOnMastersDeath))
         {
             GameObject.Die(DeathType.Exploded);
         }
@@ -293,7 +293,7 @@ public sealed class SlavedUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public int FadeTime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new SlavedUpdateModule(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/SpecialAbilityUpdate/SpecialAbilityUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SpecialAbilityUpdate/SpecialAbilityUpdate.cs
@@ -13,7 +13,7 @@ public class SpecialAbilityUpdate : UpdateModule
     private bool _unknownBool3;
     private float _unknownFloat;
 
-    public SpecialAbilityUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public SpecialAbilityUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -214,8 +214,8 @@ public class SpecialAbilityUpdateModuleData : UpdateModuleData
 
     public int FreezeAfterTriggerDuration { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SpecialAbilityUpdate(gameObject, context);
+        return new SpecialAbilityUpdate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/SpecialAbilityUpdate/SpecialAbilityUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SpecialAbilityUpdate/SpecialAbilityUpdate.cs
@@ -13,7 +13,7 @@ public class SpecialAbilityUpdate : UpdateModule
     private bool _unknownBool3;
     private float _unknownFloat;
 
-    public SpecialAbilityUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public SpecialAbilityUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -214,7 +214,7 @@ public class SpecialAbilityUpdateModuleData : UpdateModuleData
 
     public int FreezeAfterTriggerDuration { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new SpecialAbilityUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/SpectreGunshipDeploymentUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SpectreGunshipDeploymentUpdate.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 [AddedIn(SageGame.CncGeneralsZeroHour)]
 public sealed class SpectreGunshipDeploymentUpdate : UpdateModule
 {
-    public SpectreGunshipDeploymentUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public SpectreGunshipDeploymentUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -41,8 +41,8 @@ public sealed class SpectreGunshipDeploymentUpdateModuleData : BehaviorModuleDat
     public int AttackAreaRadius { get; private set; }
     public OCLCreateLocation CreateLocation { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SpectreGunshipDeploymentUpdate(gameObject, context);
+        return new SpectreGunshipDeploymentUpdate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/SpectreGunshipDeploymentUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SpectreGunshipDeploymentUpdate.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 [AddedIn(SageGame.CncGeneralsZeroHour)]
 public sealed class SpectreGunshipDeploymentUpdate : UpdateModule
 {
-    public SpectreGunshipDeploymentUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public SpectreGunshipDeploymentUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -41,7 +41,7 @@ public sealed class SpectreGunshipDeploymentUpdateModuleData : BehaviorModuleDat
     public int AttackAreaRadius { get; private set; }
     public OCLCreateLocation CreateLocation { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new SpectreGunshipDeploymentUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/StealthDetectorUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StealthDetectorUpdate.cs
@@ -12,7 +12,7 @@ public sealed class StealthDetectorUpdate : UpdateModule
 
     protected override LogicFrameSpan FramesBetweenUpdates => _moduleData.DetectionRate;
 
-    public StealthDetectorUpdate(GameObject gameObject, GameContext context, StealthDetectorUpdateModuleData moduleData)
+    public StealthDetectorUpdate(GameObject gameObject, GameEngine context, StealthDetectorUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -96,7 +96,7 @@ public sealed class StealthDetectorUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public string RequiredUpgrade { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new StealthDetectorUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/StealthDetectorUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StealthDetectorUpdate.cs
@@ -12,8 +12,8 @@ public sealed class StealthDetectorUpdate : UpdateModule
 
     protected override LogicFrameSpan FramesBetweenUpdates => _moduleData.DetectionRate;
 
-    public StealthDetectorUpdate(GameObject gameObject, GameEngine context, StealthDetectorUpdateModuleData moduleData)
-        : base(gameObject, context)
+    public StealthDetectorUpdate(GameObject gameObject, GameEngine gameEngine, StealthDetectorUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
         Active = !_moduleData.InitiallyDisabled;
@@ -96,8 +96,8 @@ public sealed class StealthDetectorUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public string RequiredUpgrade { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new StealthDetectorUpdate(gameObject, context, this);
+        return new StealthDetectorUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/StealthUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StealthUpdate.cs
@@ -10,7 +10,7 @@ public sealed class StealthUpdate : UpdateModule
     private float _unknownFloat1;
     private float _unknownFloat2;
 
-    public StealthUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public StealthUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -180,8 +180,8 @@ public sealed class StealthUpdateModuleData : BehaviorModuleData
     [AddedIn(SageGame.Bfme2)]
     public string[] RequiredUpgradeNames { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new StealthUpdate(gameObject, context);
+        return new StealthUpdate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/StealthUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StealthUpdate.cs
@@ -10,7 +10,7 @@ public sealed class StealthUpdate : UpdateModule
     private float _unknownFloat1;
     private float _unknownFloat2;
 
-    public StealthUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public StealthUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -180,7 +180,7 @@ public sealed class StealthUpdateModuleData : BehaviorModuleData
     [AddedIn(SageGame.Bfme2)]
     public string[] RequiredUpgradeNames { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new StealthUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/StickyBombUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StickyBombUpdate.cs
@@ -8,7 +8,7 @@ public sealed class StickyBombUpdate : UpdateModule
     private uint _unknown2;
     private uint _unknown3;
 
-    public StickyBombUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public StickyBombUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -47,7 +47,7 @@ public sealed class StickyBombUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public string GeometryBasedDamageFX { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new StickyBombUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/StickyBombUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StickyBombUpdate.cs
@@ -8,7 +8,7 @@ public sealed class StickyBombUpdate : UpdateModule
     private uint _unknown2;
     private uint _unknown3;
 
-    public StickyBombUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public StickyBombUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -47,8 +47,8 @@ public sealed class StickyBombUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public string GeometryBasedDamageFX { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new StickyBombUpdate(gameObject, context);
+        return new StickyBombUpdate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/StructureCollapseUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StructureCollapseUpdate.cs
@@ -7,7 +7,7 @@ public class StructureCollapseUpdate : UpdateModule
 {
     private readonly StructureCollapseUpdateModuleData _moduleData;
 
-    public StructureCollapseUpdate(GameObject gameObject, GameContext context, StructureCollapseUpdateModuleData moduleData)
+    public StructureCollapseUpdate(GameObject gameObject, GameEngine context, StructureCollapseUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -64,7 +64,7 @@ public sealed class StructureCollapseUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme)]
     public int CollapseHeight { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new StructureCollapseUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/StructureCollapseUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StructureCollapseUpdate.cs
@@ -7,8 +7,8 @@ public class StructureCollapseUpdate : UpdateModule
 {
     private readonly StructureCollapseUpdateModuleData _moduleData;
 
-    public StructureCollapseUpdate(GameObject gameObject, GameEngine context, StructureCollapseUpdateModuleData moduleData)
-        : base(gameObject, context)
+    public StructureCollapseUpdate(GameObject gameObject, GameEngine gameEngine, StructureCollapseUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -64,9 +64,9 @@ public sealed class StructureCollapseUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme)]
     public int CollapseHeight { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new StructureCollapseUpdate(gameObject, context, this);
+        return new StructureCollapseUpdate(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/StructureToppleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StructureToppleUpdate.cs
@@ -7,7 +7,7 @@ public sealed class StructureToppleUpdate : UpdateModule
 {
     private float _unknownFloat;
 
-    public StructureToppleUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public StructureToppleUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -77,9 +77,9 @@ public sealed class StructureToppleUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme)]
     public int ForceToppleAngle { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new StructureToppleUpdate(gameObject, context);
+        return new StructureToppleUpdate(gameObject, gameEngine);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/StructureToppleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StructureToppleUpdate.cs
@@ -7,7 +7,7 @@ public sealed class StructureToppleUpdate : UpdateModule
 {
     private float _unknownFloat;
 
-    public StructureToppleUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public StructureToppleUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -77,7 +77,7 @@ public sealed class StructureToppleUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme)]
     public int ForceToppleAngle { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new StructureToppleUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/SupplyCenterDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SupplyCenterDockUpdate.cs
@@ -8,7 +8,7 @@ public class SupplyCenterDockUpdate : DockUpdate
 {
     private SupplyCenterDockUpdateModuleData _moduleData;
 
-    internal SupplyCenterDockUpdate(GameObject gameObject, GameContext context, SupplyCenterDockUpdateModuleData moduleData)
+    internal SupplyCenterDockUpdate(GameObject gameObject, GameEngine context, SupplyCenterDockUpdateModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -75,7 +75,7 @@ public sealed class SupplyCenterDockUpdateModuleData : DockUpdateModuleData
     [AddedIn(SageGame.Bfme)]
     public float ValueMultiplier { get; private set; } = 1.0f;
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new SupplyCenterDockUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/SupplyCenterDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SupplyCenterDockUpdate.cs
@@ -8,8 +8,8 @@ public class SupplyCenterDockUpdate : DockUpdate
 {
     private SupplyCenterDockUpdateModuleData _moduleData;
 
-    internal SupplyCenterDockUpdate(GameObject gameObject, GameEngine context, SupplyCenterDockUpdateModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal SupplyCenterDockUpdate(GameObject gameObject, GameEngine gameEngine, SupplyCenterDockUpdateModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -75,8 +75,8 @@ public sealed class SupplyCenterDockUpdateModuleData : DockUpdateModuleData
     [AddedIn(SageGame.Bfme)]
     public float ValueMultiplier { get; private set; } = 1.0f;
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SupplyCenterDockUpdate(gameObject, context, this);
+        return new SupplyCenterDockUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/SupplyWarehouseDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SupplyWarehouseDockUpdate.cs
@@ -7,8 +7,8 @@ public class SupplyWarehouseDockUpdate : DockUpdate
     private SupplyWarehouseDockUpdateModuleData _moduleData;
     private int _currentBoxes;
 
-    internal SupplyWarehouseDockUpdate(GameObject gameObject, GameEngine context, SupplyWarehouseDockUpdateModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal SupplyWarehouseDockUpdate(GameObject gameObject, GameEngine gameEngine, SupplyWarehouseDockUpdateModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
         _currentBoxes = _moduleData.StartingBoxes;
@@ -73,8 +73,8 @@ public sealed class SupplyWarehouseDockUpdateModuleData : DockUpdateModuleData
     /// </summary>
     public bool DeleteWhenEmpty { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SupplyWarehouseDockUpdate(gameObject, context, this);
+        return new SupplyWarehouseDockUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/SupplyWarehouseDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SupplyWarehouseDockUpdate.cs
@@ -7,7 +7,7 @@ public class SupplyWarehouseDockUpdate : DockUpdate
     private SupplyWarehouseDockUpdateModuleData _moduleData;
     private int _currentBoxes;
 
-    internal SupplyWarehouseDockUpdate(GameObject gameObject, GameContext context, SupplyWarehouseDockUpdateModuleData moduleData)
+    internal SupplyWarehouseDockUpdate(GameObject gameObject, GameEngine context, SupplyWarehouseDockUpdateModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -73,7 +73,7 @@ public sealed class SupplyWarehouseDockUpdateModuleData : DockUpdateModuleData
     /// </summary>
     public bool DeleteWhenEmpty { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new SupplyWarehouseDockUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ToppleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ToppleUpdate.cs
@@ -71,7 +71,7 @@ public sealed class ToppleUpdate : UpdateModule, ICollideModule
 
     internal bool IsAbleToBeToppled => _toppleState == ToppleState.Upright;
 
-    internal ToppleUpdate(GameObject gameObject, GameContext context, ToppleUpdateModuleData moduleData)
+    internal ToppleUpdate(GameObject gameObject, GameEngine context, ToppleUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -150,7 +150,7 @@ public sealed class ToppleUpdate : UpdateModule, ICollideModule
 
                 if (_moduleData.KillStumpWhenToppled)
                 {
-                    var stump = Context.GameLogic.GetObjectById(_stumpId);
+                    var stump = GameEngine.GameLogic.GetObjectById(_stumpId);
                     if (stump != null)
                     {
                         DeathByToppling(stump);
@@ -166,7 +166,7 @@ public sealed class ToppleUpdate : UpdateModule, ICollideModule
                         new FXListExecutionContext(
                             GameObject.Rotation,
                             GameObject.Translation,
-                            Context));
+                            GameEngine));
                 }
             }
         }
@@ -243,7 +243,7 @@ public sealed class ToppleUpdate : UpdateModule, ICollideModule
 
         _toppleDirection = Vector3.Normalize(toppleDirection);
 
-        Context.Game.Scripting.AdjustToppleDirection(GameObject, _toppleDirection);
+        GameEngine.Game.Scripting.AdjustToppleDirection(GameObject, _toppleDirection);
 
         _angularVelocity = toppleSpeed * _moduleData.InitialVelocityPercent;
         _angularAcceleration = toppleSpeed * _moduleData.InitialAccelPercent;
@@ -274,7 +274,7 @@ public sealed class ToppleUpdate : UpdateModule, ICollideModule
             // waiting for the topple to finish... since we might be in a
             // slightly different position when toppled, which can confuse
             // the pathfinder and not de-obstacle everything correctly.
-            Context.AI.Pathfinder.RemoveObjectFromPathfindMap(GameObject);
+            GameEngine.AI.Pathfinder.RemoveObjectFromPathfindMap(GameObject);
         }
 
         // Desired angle is toppleAngle +/- PI/2, whichever is cloesr to currentAngle.
@@ -295,12 +295,12 @@ public sealed class ToppleUpdate : UpdateModule, ICollideModule
             new FXListExecutionContext(
                 GameObject.Rotation,
                 GameObject.Translation,
-                Context));
+                GameEngine));
 
         // If this is a tree, create a stump.
         if (_moduleData.StumpName != null)
         {
-            var stump = Context.GameLogic.CreateObject(_moduleData.StumpName.Value, null);
+            var stump = GameEngine.GameLogic.CreateObject(_moduleData.StumpName.Value, null);
             stump.UpdateTransform(GameObject.Translation, GameObject.Rotation);
             _stumpId = stump.ID;
 
@@ -428,7 +428,7 @@ public sealed class ToppleUpdateModuleData : UpdateModuleData
     public Percentage InitialAccelPercent { get; private set; } = new Percentage(StartAccelerationPercent);
     public LazyAssetReference<ObjectDefinition> StumpName { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new ToppleUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ToppleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ToppleUpdate.cs
@@ -71,8 +71,8 @@ public sealed class ToppleUpdate : UpdateModule, ICollideModule
 
     internal bool IsAbleToBeToppled => _toppleState == ToppleState.Upright;
 
-    internal ToppleUpdate(GameObject gameObject, GameEngine context, ToppleUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal ToppleUpdate(GameObject gameObject, GameEngine gameEngine, ToppleUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
 
@@ -428,8 +428,8 @@ public sealed class ToppleUpdateModuleData : UpdateModuleData
     public Percentage InitialAccelPercent { get; private set; } = new Percentage(StartAccelerationPercent);
     public LazyAssetReference<ObjectDefinition> StumpName { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new ToppleUpdate(gameObject, context, this);
+        return new ToppleUpdate(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
@@ -14,8 +14,8 @@ public abstract class UpdateModule : BehaviorModule, IUpdateModule
 
     UpdateOrder IUpdateModule.UpdatePhase => UpdateOrder;
 
-    protected UpdateModule(GameObject gameObject, GameContext context)
-        : base(gameObject, context)
+    protected UpdateModule(GameObject gameObject, GameEngine gameEngine)
+        : base(gameObject, gameEngine)
     {
         _nextUpdateFrame.UpdateOrder = UpdateOrder;
     }
@@ -54,7 +54,7 @@ public abstract class UpdateModule : BehaviorModule, IUpdateModule
         // If we are already awake, don't reset our wake frame. See GameLogic::friend_awakenUpdateModule.
         if (GameObject != null)
         {
-            var now = Context.GameLogic.CurrentFrame.Value;
+            var now = GameEngine.GameLogic.CurrentFrame.Value;
             if (_nextUpdateFrame.Frame == now && frame.Value == now + 1)
             {
                 return;
@@ -67,7 +67,7 @@ public abstract class UpdateModule : BehaviorModule, IUpdateModule
     // Yes, protected. Modules should only wake themselves up.
     protected void SetWakeFrame(UpdateSleepTime wakeDelay)
     {
-        SetNextUpdateFrame(Context.GameLogic.CurrentFrame + wakeDelay.FrameSpan);
+        SetNextUpdateFrame(GameEngine.GameLogic.CurrentFrame + wakeDelay.FrameSpan);
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Update/WaveGuideUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/WaveGuideUpdate.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 public sealed class WaveGuideUpdate : UpdateModule
 {
     // TODO
-    public WaveGuideUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
+    public WaveGuideUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -64,8 +64,8 @@ public sealed class WaveGuideUpdateModuleData : UpdateModuleData
     public float BridgeParticleAngleFudge { get; private set; }
     public string LoopingSound { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new WaveGuideUpdate(gameObject, context);
+        return new WaveGuideUpdate(gameObject, gameEngine);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Update/WaveGuideUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/WaveGuideUpdate.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 public sealed class WaveGuideUpdate : UpdateModule
 {
     // TODO
-    public WaveGuideUpdate(GameObject gameObject, GameContext context) : base(gameObject, context)
+    public WaveGuideUpdate(GameObject gameObject, GameEngine context) : base(gameObject, context)
     {
     }
 
@@ -64,7 +64,7 @@ public sealed class WaveGuideUpdateModuleData : UpdateModuleData
     public float BridgeParticleAngleFudge { get; private set; }
     public string LoopingSound { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new WaveGuideUpdate(gameObject, context);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/WeaponSetUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/WeaponSetUpdate.cs
@@ -8,7 +8,7 @@ public sealed class WeaponSetUpdate : UpdateModule
 {
     private readonly WeaponSetUpdateModuleData _moduleData;
 
-    internal WeaponSetUpdate(GameObject gameObject, GameContext context, WeaponSetUpdateModuleData moduleData)
+    internal WeaponSetUpdate(GameObject gameObject, GameEngine context, WeaponSetUpdateModuleData moduleData)
         : base(gameObject, context)
     {
         _moduleData = moduleData;
@@ -26,7 +26,7 @@ public sealed class WeaponSetUpdateModuleData : UpdateModuleData
     public List<WeaponSlotTurretData> WeaponSlotTurrets { get; } = new List<WeaponSlotTurretData>();
     public List<WeaponSlotHierarchicalTurretData> WeaponSlotHierarchicalTurrets { get; } = new List<WeaponSlotHierarchicalTurretData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new WeaponSetUpdate(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/WeaponSetUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/WeaponSetUpdate.cs
@@ -8,8 +8,8 @@ public sealed class WeaponSetUpdate : UpdateModule
 {
     private readonly WeaponSetUpdateModuleData _moduleData;
 
-    internal WeaponSetUpdate(GameObject gameObject, GameEngine context, WeaponSetUpdateModuleData moduleData)
-        : base(gameObject, context)
+    internal WeaponSetUpdate(GameObject gameObject, GameEngine gameEngine, WeaponSetUpdateModuleData moduleData)
+        : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
@@ -26,9 +26,9 @@ public sealed class WeaponSetUpdateModuleData : UpdateModuleData
     public List<WeaponSlotTurretData> WeaponSlotTurrets { get; } = new List<WeaponSlotTurretData>();
     public List<WeaponSlotHierarchicalTurretData> WeaponSlotHierarchicalTurrets { get; } = new List<WeaponSlotHierarchicalTurretData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new WeaponSetUpdate(gameObject, context, this);
+        return new WeaponSetUpdate(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ArmorUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ArmorUpgrade.cs
@@ -7,8 +7,8 @@ internal sealed class ArmorUpgrade : UpgradeModule
 {
     private readonly ArmorUpgradeModuleData _moduleData;
 
-    internal ArmorUpgrade(GameObject gameObject, GameEngine context, ArmorUpgradeModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal ArmorUpgrade(GameObject gameObject, GameEngine gameEngine, ArmorUpgradeModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -55,8 +55,8 @@ public sealed class ArmorUpgradeModuleData : UpgradeModuleData
     [AddedIn(SageGame.Bfme)]
     public bool IgnoreArmorUpgrade { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new ArmorUpgrade(gameObject, context, this);
+        return new ArmorUpgrade(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ArmorUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ArmorUpgrade.cs
@@ -7,7 +7,7 @@ internal sealed class ArmorUpgrade : UpgradeModule
 {
     private readonly ArmorUpgradeModuleData _moduleData;
 
-    internal ArmorUpgrade(GameObject gameObject, GameContext context, ArmorUpgradeModuleData moduleData)
+    internal ArmorUpgrade(GameObject gameObject, GameEngine context, ArmorUpgradeModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -55,7 +55,7 @@ public sealed class ArmorUpgradeModuleData : UpgradeModuleData
     [AddedIn(SageGame.Bfme)]
     public bool IgnoreArmorUpgrade { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new ArmorUpgrade(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/CommandSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/CommandSetUpgrade.cs
@@ -8,8 +8,8 @@ internal class CommandSetUpgrade : UpgradeModule
 {
     private readonly CommandSetUpgradeModuleData _moduleData;
 
-    public CommandSetUpgrade(GameObject gameObject, GameEngine context, CommandSetUpgradeModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    public CommandSetUpgrade(GameObject gameObject, GameEngine gameEngine, CommandSetUpgradeModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -57,8 +57,8 @@ public sealed class CommandSetUpgradeModuleData : UpgradeModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public string TriggerAlt { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new CommandSetUpgrade(gameObject, context, this);
+        return new CommandSetUpgrade(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/CommandSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/CommandSetUpgrade.cs
@@ -8,7 +8,7 @@ internal class CommandSetUpgrade : UpgradeModule
 {
     private readonly CommandSetUpgradeModuleData _moduleData;
 
-    public CommandSetUpgrade(GameObject gameObject, GameContext context, CommandSetUpgradeModuleData moduleData)
+    public CommandSetUpgrade(GameObject gameObject, GameEngine context, CommandSetUpgradeModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -57,7 +57,7 @@ public sealed class CommandSetUpgradeModuleData : UpgradeModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public string TriggerAlt { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new CommandSetUpgrade(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ExperienceScalarUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ExperienceScalarUpgrade.cs
@@ -6,8 +6,8 @@ internal sealed class ExperienceScalarUpgrade : UpgradeModule
 {
     private readonly ExperienceScalarUpgradeModuleData _moduleData;
 
-    internal ExperienceScalarUpgrade(GameObject gameObject, GameEngine context, ExperienceScalarUpgradeModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal ExperienceScalarUpgrade(GameObject gameObject, GameEngine gameEngine, ExperienceScalarUpgradeModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -39,8 +39,8 @@ public sealed class ExperienceScalarUpgradeModuleData : UpgradeModuleData
 
     public float AddXPScalar { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new ExperienceScalarUpgrade(gameObject, context, this);
+        return new ExperienceScalarUpgrade(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ExperienceScalarUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ExperienceScalarUpgrade.cs
@@ -6,7 +6,7 @@ internal sealed class ExperienceScalarUpgrade : UpgradeModule
 {
     private readonly ExperienceScalarUpgradeModuleData _moduleData;
 
-    internal ExperienceScalarUpgrade(GameObject gameObject, GameContext context, ExperienceScalarUpgradeModuleData moduleData)
+    internal ExperienceScalarUpgrade(GameObject gameObject, GameEngine context, ExperienceScalarUpgradeModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -39,7 +39,7 @@ public sealed class ExperienceScalarUpgradeModuleData : UpgradeModuleData
 
     public float AddXPScalar { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new ExperienceScalarUpgrade(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/GeometryUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/GeometryUpgrade.cs
@@ -8,8 +8,8 @@ internal class GeometryUpgrade : UpgradeModule
 {
     private readonly GeometryUpgradeModuleData _moduleData;
 
-    internal GeometryUpgrade(GameObject gameObject, GameEngine context, GeometryUpgradeModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal GeometryUpgrade(GameObject gameObject, GameEngine gameEngine, GeometryUpgradeModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -57,8 +57,8 @@ public sealed class GeometryUpgradeModuleData : UpgradeModuleData
     public string RampMesh1 { get; private set; } // e.g. P2 where is that defined?
     public string RampMesh2 { get; private set; } // e.g. P3 where is that defined?
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new GeometryUpgrade(gameObject, context, this);
+        return new GeometryUpgrade(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/GeometryUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/GeometryUpgrade.cs
@@ -8,7 +8,7 @@ internal class GeometryUpgrade : UpgradeModule
 {
     private readonly GeometryUpgradeModuleData _moduleData;
 
-    internal GeometryUpgrade(GameObject gameObject, GameContext context, GeometryUpgradeModuleData moduleData)
+    internal GeometryUpgrade(GameObject gameObject, GameEngine context, GeometryUpgradeModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -57,7 +57,7 @@ public sealed class GeometryUpgradeModuleData : UpgradeModuleData
     public string RampMesh1 { get; private set; } // e.g. P2 where is that defined?
     public string RampMesh2 { get; private set; } // e.g. P3 where is that defined?
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new GeometryUpgrade(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/GrantScienceUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/GrantScienceUpgrade.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class GrantScienceUpgrade : UpgradeModule
 {
-    public GrantScienceUpgrade(GameObject gameObject, GameContext context, UpgradeModuleData moduleData)
+    public GrantScienceUpgrade(GameObject gameObject, GameEngine context, UpgradeModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
     }
@@ -31,7 +31,7 @@ public sealed class GrantScienceUpgradeModuleData : UpgradeModuleData
 
     public string GrantScience { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new GrantScienceUpgrade(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/GrantScienceUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/GrantScienceUpgrade.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class GrantScienceUpgrade : UpgradeModule
 {
-    public GrantScienceUpgrade(GameObject gameObject, GameEngine context, UpgradeModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    public GrantScienceUpgrade(GameObject gameObject, GameEngine gameEngine, UpgradeModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -31,8 +31,8 @@ public sealed class GrantScienceUpgradeModuleData : UpgradeModuleData
 
     public string GrantScience { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new GrantScienceUpgrade(gameObject, context, this);
+        return new GrantScienceUpgrade(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/LocomotorSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/LocomotorSetUpgrade.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class LocomotorSetUpgrade : UpgradeModule
 {
-    public LocomotorSetUpgrade(GameObject gameObject, GameContext context, LocomotorSetUpgradeModuleData moduleData)
+    public LocomotorSetUpgrade(GameObject gameObject, GameEngine context, LocomotorSetUpgradeModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
     }
@@ -30,7 +30,7 @@ public sealed class LocomotorSetUpgradeModuleData : UpgradeModuleData
     private static new readonly IniParseTable<LocomotorSetUpgradeModuleData> FieldParseTable = UpgradeModuleData.FieldParseTable
         .Concat(new IniParseTable<LocomotorSetUpgradeModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new LocomotorSetUpgrade(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/LocomotorSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/LocomotorSetUpgrade.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class LocomotorSetUpgrade : UpgradeModule
 {
-    public LocomotorSetUpgrade(GameObject gameObject, GameEngine context, LocomotorSetUpgradeModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    public LocomotorSetUpgrade(GameObject gameObject, GameEngine gameEngine, LocomotorSetUpgradeModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -30,8 +30,8 @@ public sealed class LocomotorSetUpgradeModuleData : UpgradeModuleData
     private static new readonly IniParseTable<LocomotorSetUpgradeModuleData> FieldParseTable = UpgradeModuleData.FieldParseTable
         .Concat(new IniParseTable<LocomotorSetUpgradeModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new LocomotorSetUpgrade(gameObject, context, this);
+        return new LocomotorSetUpgrade(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/MaxHealthUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/MaxHealthUpgrade.cs
@@ -7,8 +7,8 @@ internal sealed class MaxHealthUpgrade : UpgradeModule
 {
     private readonly MaxHealthUpgradeModuleData _moduleData;
 
-    internal MaxHealthUpgrade(GameObject gameObject, GameEngine context, MaxHealthUpgradeModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal MaxHealthUpgrade(GameObject gameObject, GameEngine gameEngine, MaxHealthUpgradeModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -55,9 +55,9 @@ public sealed class MaxHealthUpgradeModuleData : UpgradeModuleData
     public float AddMaxHealth { get; private set; }
     public MaxHealthChangeType ChangeType { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new MaxHealthUpgrade(gameObject, context, this);
+        return new MaxHealthUpgrade(gameObject, gameEngine, this);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/MaxHealthUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/MaxHealthUpgrade.cs
@@ -7,7 +7,7 @@ internal sealed class MaxHealthUpgrade : UpgradeModule
 {
     private readonly MaxHealthUpgradeModuleData _moduleData;
 
-    internal MaxHealthUpgrade(GameObject gameObject, GameContext context, MaxHealthUpgradeModuleData moduleData)
+    internal MaxHealthUpgrade(GameObject gameObject, GameEngine context, MaxHealthUpgradeModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -55,7 +55,7 @@ public sealed class MaxHealthUpgradeModuleData : UpgradeModuleData
     public float AddMaxHealth { get; private set; }
     public MaxHealthChangeType ChangeType { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new MaxHealthUpgrade(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
@@ -8,7 +8,7 @@ internal sealed class ObjectCreationUpgrade : UpgradeModule
 {
     private readonly ObjectCreationUpgradeModuleData _moduleData;
 
-    internal ObjectCreationUpgrade(GameObject gameObject, GameContext context, ObjectCreationUpgradeModuleData moduleData)
+    internal ObjectCreationUpgrade(GameObject gameObject, GameEngine context, ObjectCreationUpgradeModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -17,7 +17,7 @@ internal sealed class ObjectCreationUpgrade : UpgradeModule
     protected override void OnUpgrade()
     {
         // TODO: Get rid of this context thing.
-        var context = new BehaviorUpdateContext(Context, GameObject);
+        var context = new BehaviorUpdateContext(GameEngine, GameObject);
 
         foreach (var item in _moduleData.UpgradeObject.Value.Nuggets)
         {
@@ -93,7 +93,7 @@ public sealed class ObjectCreationUpgradeModuleData : UpgradeModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool UseBuildingProduction { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new ObjectCreationUpgrade(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
@@ -8,8 +8,8 @@ internal sealed class ObjectCreationUpgrade : UpgradeModule
 {
     private readonly ObjectCreationUpgradeModuleData _moduleData;
 
-    internal ObjectCreationUpgrade(GameObject gameObject, GameEngine context, ObjectCreationUpgradeModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal ObjectCreationUpgrade(GameObject gameObject, GameEngine gameEngine, ObjectCreationUpgradeModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -93,8 +93,8 @@ public sealed class ObjectCreationUpgradeModuleData : UpgradeModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool UseBuildingProduction { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new ObjectCreationUpgrade(gameObject, context, this);
+        return new ObjectCreationUpgrade(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/PowerPlantUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/PowerPlantUpgrade.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class PowerPlantUpgrade : UpgradeModule
 {
-    internal PowerPlantUpgrade(GameObject gameObject, GameContext context, PowerPlantUpgradeModuleData moduleData)
+    internal PowerPlantUpgrade(GameObject gameObject, GameEngine context, PowerPlantUpgradeModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
     }
@@ -40,7 +40,7 @@ public sealed class PowerPlantUpgradeModuleData : UpgradeModuleData
     private static new readonly IniParseTable<PowerPlantUpgradeModuleData> FieldParseTable = UpgradeModuleData.FieldParseTable
         .Concat(new IniParseTable<PowerPlantUpgradeModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new PowerPlantUpgrade(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/PowerPlantUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/PowerPlantUpgrade.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class PowerPlantUpgrade : UpgradeModule
 {
-    internal PowerPlantUpgrade(GameObject gameObject, GameEngine context, PowerPlantUpgradeModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal PowerPlantUpgrade(GameObject gameObject, GameEngine gameEngine, PowerPlantUpgradeModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -40,8 +40,8 @@ public sealed class PowerPlantUpgradeModuleData : UpgradeModuleData
     private static new readonly IniParseTable<PowerPlantUpgradeModuleData> FieldParseTable = UpgradeModuleData.FieldParseTable
         .Concat(new IniParseTable<PowerPlantUpgradeModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new PowerPlantUpgrade(gameObject, context, this);
+        return new PowerPlantUpgrade(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/RadarUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/RadarUpgrade.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class RadarUpgrade : UpgradeModule
 {
-    internal RadarUpgrade(GameObject gameObject, GameEngine context, RadarUpgradeModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal RadarUpgrade(GameObject gameObject, GameEngine gameEngine, RadarUpgradeModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -35,8 +35,8 @@ public sealed class RadarUpgradeModuleData : UpgradeModuleData
 
     public bool DisableProof { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new RadarUpgrade(gameObject, context, this);
+        return new RadarUpgrade(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/RadarUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/RadarUpgrade.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class RadarUpgrade : UpgradeModule
 {
-    internal RadarUpgrade(GameObject gameObject, GameContext context, RadarUpgradeModuleData moduleData)
+    internal RadarUpgrade(GameObject gameObject, GameEngine context, RadarUpgradeModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
     }
@@ -35,7 +35,7 @@ public sealed class RadarUpgradeModuleData : UpgradeModuleData
 
     public bool DisableProof { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new RadarUpgrade(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/StealthUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/StealthUpgrade.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class StealthUpgrade : UpgradeModule
 {
-    public StealthUpgrade(GameObject gameObject, GameEngine context, StealthUpgradeModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    public StealthUpgrade(GameObject gameObject, GameEngine gameEngine, StealthUpgradeModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -31,8 +31,8 @@ public sealed class StealthUpgradeModuleData : UpgradeModuleData
     private static new readonly IniParseTable<StealthUpgradeModuleData> FieldParseTable = UpgradeModuleData.FieldParseTable
         .Concat(new IniParseTable<StealthUpgradeModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new StealthUpgrade(gameObject, context, this);
+        return new StealthUpgrade(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/StealthUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/StealthUpgrade.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class StealthUpgrade : UpgradeModule
 {
-    public StealthUpgrade(GameObject gameObject, GameContext context, StealthUpgradeModuleData moduleData)
+    public StealthUpgrade(GameObject gameObject, GameEngine context, StealthUpgradeModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
     }
@@ -31,7 +31,7 @@ public sealed class StealthUpgradeModuleData : UpgradeModuleData
     private static new readonly IniParseTable<StealthUpgradeModuleData> FieldParseTable = UpgradeModuleData.FieldParseTable
         .Concat(new IniParseTable<StealthUpgradeModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new StealthUpgrade(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/SubObjectsUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/SubObjectsUpgrade.cs
@@ -10,8 +10,8 @@ internal class SubObjectsUpgrade : UpgradeModule
 {
     private readonly SubObjectsUpgradeModuleData _moduleData;
 
-    internal SubObjectsUpgrade(GameObject gameObject, GameEngine context, SubObjectsUpgradeModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal SubObjectsUpgrade(GameObject gameObject, GameEngine gameEngine, SubObjectsUpgradeModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -83,8 +83,8 @@ public sealed class SubObjectsUpgradeModuleData : UpgradeModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool HideSubObjectsOnRemove { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new SubObjectsUpgrade(gameObject, context, this);
+        return new SubObjectsUpgrade(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/SubObjectsUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/SubObjectsUpgrade.cs
@@ -10,7 +10,7 @@ internal class SubObjectsUpgrade : UpgradeModule
 {
     private readonly SubObjectsUpgradeModuleData _moduleData;
 
-    internal SubObjectsUpgrade(GameObject gameObject, GameContext context, SubObjectsUpgradeModuleData moduleData)
+    internal SubObjectsUpgrade(GameObject gameObject, GameEngine context, SubObjectsUpgradeModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -83,7 +83,7 @@ public sealed class SubObjectsUpgradeModuleData : UpgradeModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool HideSubObjectsOnRemove { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new SubObjectsUpgrade(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/UnpauseSpecialPowerUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/UnpauseSpecialPowerUpgrade.cs
@@ -7,8 +7,8 @@ internal sealed class UnpauseSpecialPowerUpgrade : UpgradeModule
 {
     private readonly UnpauseSpecialPowerUpgradeModuleData _moduleData;
 
-    internal UnpauseSpecialPowerUpgrade(GameObject gameObject, GameEngine context, UnpauseSpecialPowerUpgradeModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal UnpauseSpecialPowerUpgrade(GameObject gameObject, GameEngine gameEngine, UnpauseSpecialPowerUpgradeModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -51,8 +51,8 @@ public sealed class UnpauseSpecialPowerUpgradeModuleData : UpgradeModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool ObeyRechageOnTrigger { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new UnpauseSpecialPowerUpgrade(gameObject, context, this);
+        return new UnpauseSpecialPowerUpgrade(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/UnpauseSpecialPowerUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/UnpauseSpecialPowerUpgrade.cs
@@ -7,7 +7,7 @@ internal sealed class UnpauseSpecialPowerUpgrade : UpgradeModule
 {
     private readonly UnpauseSpecialPowerUpgradeModuleData _moduleData;
 
-    internal UnpauseSpecialPowerUpgrade(GameObject gameObject, GameContext context, UnpauseSpecialPowerUpgradeModuleData moduleData)
+    internal UnpauseSpecialPowerUpgrade(GameObject gameObject, GameEngine context, UnpauseSpecialPowerUpgradeModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -51,7 +51,7 @@ public sealed class UnpauseSpecialPowerUpgradeModuleData : UpgradeModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool ObeyRechageOnTrigger { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new UnpauseSpecialPowerUpgrade(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
@@ -12,7 +12,7 @@ public abstract class UpgradeModule : BehaviorModule, IUpgradeableModule
 
     internal bool Triggered => _upgradeLogic.Triggered;
 
-    internal UpgradeModule(GameObject gameObject, GameContext context, UpgradeModuleData moduleData) : base(gameObject, context)
+    internal UpgradeModule(GameObject gameObject, GameEngine gameEngine, UpgradeModuleData moduleData) : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
         _upgradeLogic = new UpgradeLogic(moduleData.UpgradeData, OnUpgrade);

--- a/src/OpenSage.Game/Logic/Object/Upgrade/WeaponBonusUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/WeaponBonusUpgrade.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class WeaponBonusUpgrade : UpgradeModule
 {
-    internal WeaponBonusUpgrade(GameObject gameObject, GameContext context, WeaponBonusUpgradeModuleData moduleData)
+    internal WeaponBonusUpgrade(GameObject gameObject, GameEngine context, WeaponBonusUpgradeModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
     }
@@ -29,7 +29,7 @@ public sealed class WeaponBonusUpgradeModuleData : UpgradeModuleData
     private static new readonly IniParseTable<WeaponBonusUpgradeModuleData> FieldParseTable = UpgradeModuleData.FieldParseTable
         .Concat(new IniParseTable<WeaponBonusUpgradeModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new WeaponBonusUpgrade(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/WeaponBonusUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/WeaponBonusUpgrade.cs
@@ -4,8 +4,8 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class WeaponBonusUpgrade : UpgradeModule
 {
-    internal WeaponBonusUpgrade(GameObject gameObject, GameEngine context, WeaponBonusUpgradeModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal WeaponBonusUpgrade(GameObject gameObject, GameEngine gameEngine, WeaponBonusUpgradeModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -29,8 +29,8 @@ public sealed class WeaponBonusUpgradeModuleData : UpgradeModuleData
     private static new readonly IniParseTable<WeaponBonusUpgradeModuleData> FieldParseTable = UpgradeModuleData.FieldParseTable
         .Concat(new IniParseTable<WeaponBonusUpgradeModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new WeaponBonusUpgrade(gameObject, context, this);
+        return new WeaponBonusUpgrade(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/WeaponSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/WeaponSetUpgrade.cs
@@ -6,7 +6,7 @@ internal sealed class WeaponSetUpgrade : UpgradeModule
 {
     private readonly WeaponSetUpgradeModuleData _moduleData;
 
-    internal WeaponSetUpgrade(GameObject gameObject, GameContext context, WeaponSetUpgradeModuleData moduleData)
+    internal WeaponSetUpgrade(GameObject gameObject, GameEngine context, WeaponSetUpgradeModuleData moduleData)
         : base(gameObject, context, moduleData)
     {
         _moduleData = moduleData;
@@ -44,7 +44,7 @@ public sealed class WeaponSetUpgradeModuleData : UpgradeModuleData
 
     public WeaponSetConditions WeaponCondition { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameContext context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
     {
         return new WeaponSetUpgrade(gameObject, context, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/WeaponSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/WeaponSetUpgrade.cs
@@ -6,8 +6,8 @@ internal sealed class WeaponSetUpgrade : UpgradeModule
 {
     private readonly WeaponSetUpgradeModuleData _moduleData;
 
-    internal WeaponSetUpgrade(GameObject gameObject, GameEngine context, WeaponSetUpgradeModuleData moduleData)
-        : base(gameObject, context, moduleData)
+    internal WeaponSetUpgrade(GameObject gameObject, GameEngine gameEngine, WeaponSetUpgradeModuleData moduleData)
+        : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -44,8 +44,8 @@ public sealed class WeaponSetUpgradeModuleData : UpgradeModuleData
 
     public WeaponSetConditions WeaponCondition { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine context)
+    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
     {
-        return new WeaponSetUpgrade(gameObject, context, this);
+        return new WeaponSetUpgrade(gameObject, gameEngine, this);
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Weapon/Weapon.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/Weapon.cs
@@ -67,7 +67,7 @@ public sealed class Weapon : IPersistableObject
         GameObject gameObject,
         WeaponTemplate weaponTemplate,
         WeaponSlot slot,
-        GameContext gameContext)
+        GameEngine gameContext)
     {
         ParentGameObject = gameObject;
         Template = weaponTemplate;

--- a/src/OpenSage.Game/Logic/Object/Weapon/WeaponEffects/ProjectileNugget.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/WeaponEffects/ProjectileNugget.cs
@@ -57,7 +57,7 @@ public sealed class ProjectileNugget : WeaponEffectNugget
             warheadTemplate = WarheadTemplate.Value;
         }
 
-        var projectileObject = context.GameContext.GameLogic.CreateObject(
+        var projectileObject = context.GameEngine.GameLogic.CreateObject(
             projectileTemplate,
             context.Weapon.ParentGameObject.Owner);
 

--- a/src/OpenSage.Game/Logic/Object/Weapon/WeaponEffects/WeaponEffectExecutionContext.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/WeaponEffects/WeaponEffectExecutionContext.cs
@@ -3,11 +3,11 @@
 internal sealed class WeaponEffectExecutionContext
 {
     public readonly Weapon Weapon;
-    public readonly GameContext GameContext;
+    public readonly GameEngine GameEngine;
 
-    public WeaponEffectExecutionContext(Weapon weapon, GameContext gameContext)
+    public WeaponEffectExecutionContext(Weapon weapon, GameEngine gameEngine)
     {
         Weapon = weapon;
-        GameContext = gameContext;
+        GameEngine = gameEngine;
     }
 }

--- a/src/OpenSage.Game/Logic/Object/Weapon/WeaponSet.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/WeaponSet.cs
@@ -6,7 +6,7 @@ namespace OpenSage.Logic.Object;
 public sealed class WeaponSet : IPersistableObject
 {
     private readonly GameObject _gameObject;
-    private readonly GameContext _context;
+    private readonly GameEngine _gameEngine;
     private readonly Weapon[] _weapons;
     private WeaponTemplateSet _currentWeaponTemplateSet;
     private WeaponSlot _currentWeaponSlot;
@@ -21,10 +21,10 @@ public sealed class WeaponSet : IPersistableObject
     internal Weapon CurrentWeapon => _weapons[(int)_currentWeaponSlot];
     public IEnumerable<Weapon> Weapons => _weapons;
 
-    internal WeaponSet(GameObject gameObject, GameContext context)
+    internal WeaponSet(GameObject gameObject, GameEngine gameEngine)
     {
         _gameObject = gameObject;
-        _context = context;
+        _gameEngine = gameEngine;
 
         _weapons = new Weapon[WeaponTemplateSet.NumWeaponSlots];
     }
@@ -53,7 +53,7 @@ public sealed class WeaponSet : IPersistableObject
             var weaponTemplate = _currentWeaponTemplateSet.Slots[i]?.Weapon.Value;
             if (weaponTemplate != null)
             {
-                _weapons[i] = new Weapon(_gameObject, weaponTemplate, (WeaponSlot)i, _context);
+                _weapons[i] = new Weapon(_gameObject, weaponTemplate, (WeaponSlot)i, _gameEngine);
 
                 _filledWeaponSlots |= (uint)(1 << i);
                 _combinedAntiMask |= weaponTemplate.AntiMask;
@@ -92,7 +92,7 @@ public sealed class WeaponSet : IPersistableObject
                     _weapons[i] = new Weapon(
                         _gameObject,
                         _currentWeaponTemplateSet.Slots[i].Weapon.Value,
-                        (WeaponSlot)i, _context);
+                        (WeaponSlot)i, _gameEngine);
                 }
                 reader.PersistObject(_weapons[i], "Value");
             }

--- a/src/OpenSage.Game/Logic/Object/Weapon/WeaponStates/FiringWeaponState.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/WeaponStates/FiringWeaponState.cs
@@ -30,10 +30,10 @@ internal sealed class FiringWeaponState : FixedDurationWeaponState
             Context.Weapon.CurrentRounds--;
         }
 
-        Context.GameContext.AudioSystem.PlayAudioEvent(
+        Context.GameEngine.AudioSystem.PlayAudioEvent(
             Context.Weapon.Template.FireSound?.Value);
 
-        var weaponEffectExecutionContext = new WeaponEffectExecutionContext(Context.Weapon, Context.GameContext);
+        var weaponEffectExecutionContext = new WeaponEffectExecutionContext(Context.Weapon, Context.GameEngine);
         foreach (var nugget in Context.Weapon.Template.Nuggets)
         {
             nugget.Execute(weaponEffectExecutionContext);
@@ -68,7 +68,7 @@ internal sealed class FiringWeaponState : FixedDurationWeaponState
             new FXListExecutionContext(
                 rotation,
                 translation,
-                Context.GameContext));
+                Context.GameEngine));
     }
 
     public override WeaponState? GetNextState()

--- a/src/OpenSage.Game/Logic/Object/Weapon/WeaponStates/FixedDurationWeaponState.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/WeaponStates/FixedDurationWeaponState.cs
@@ -16,9 +16,9 @@ internal abstract class FixedDurationWeaponState : BaseWeaponState
     protected override void OnEnterStateImpl()
     {
         // TODO: Randomly pick value between Duration.Min and Duration.Max
-        _exitTime = Context.GameContext.GameLogic.CurrentFrame + Duration.Min;
+        _exitTime = Context.GameEngine.GameLogic.CurrentFrame + Duration.Min;
     }
 
     protected bool IsTimeToExitState() =>
-        Context.GameContext.GameLogic.CurrentFrame >= _exitTime;
+        Context.GameEngine.GameLogic.CurrentFrame >= _exitTime;
 }

--- a/src/OpenSage.Game/Logic/Object/Weapon/WeaponStates/WeaponStateMachine.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/WeaponStates/WeaponStateMachine.cs
@@ -132,16 +132,16 @@ internal sealed class WeaponStateContext
 {
     public readonly GameObject GameObject;
     public readonly Weapon Weapon;
-    public readonly GameContext GameContext;
+    public readonly GameEngine GameEngine;
 
     public WeaponStateContext(
         GameObject gameObject,
         Weapon weapon,
-        GameContext gameContext)
+        GameEngine gameContext)
     {
         GameObject = gameObject;
         Weapon = weapon;
-        GameContext = gameContext;
+        GameEngine = gameContext;
     }
 }
 

--- a/src/OpenSage.Game/Logic/OrderGeneratorSystem.cs
+++ b/src/OpenSage.Game/Logic/OrderGeneratorSystem.cs
@@ -142,7 +142,7 @@ public class OrderGeneratorSystem : GameSystem
         var gameData = Game.AssetStore.GameData.Current;
 
         ActiveGenerator = new SpecialPowerOrderGenerator(cursorInformation, gameData, Game.Scene3D.LocalPlayer,
-            Game.Scene3D.GameContext, targetType, Game.Scene3D, Game.MapTime);
+            Game.Scene3D.GameEngine, targetType, Game.Scene3D, Game.MapTime);
 
         if (cursorInformation.OrderFlags.HasFlag(SpecialPowerOrderFlags.CheckLike))
         {
@@ -172,7 +172,7 @@ public class OrderGeneratorSystem : GameSystem
         var gameData = Game.AssetStore.GameData.Current;
         var definitionIndex = buildingDefinition.InternalId;
 
-        ActiveGenerator = new ConstructBuildingOrderGenerator(buildingDefinition, definitionIndex, gameData, Game.Scene3D.LocalPlayer, Game.Scene3D.GameContext, Game.Scene3D);
+        ActiveGenerator = new ConstructBuildingOrderGenerator(buildingDefinition, definitionIndex, gameData, Game.Scene3D.LocalPlayer, Game.Scene3D.GameEngine, Game.Scene3D);
     }
 
     public void SetRallyPoint()

--- a/src/OpenSage.Game/Logic/OrderGenerators/ConstructBuildingOrderGenerator.cs
+++ b/src/OpenSage.Game/Logic/OrderGenerators/ConstructBuildingOrderGenerator.cs
@@ -32,7 +32,7 @@ public sealed class ConstructBuildingOrderGenerator : OrderGenerator, IDisposabl
         int definitionIndex,
         GameData config,
         Player player,
-        GameContext gameContext,
+        GameEngine gameContext,
         Scene3D scene) : base(gameContext.Game)
     {
         _buildingDefinition = buildingDefinition;

--- a/src/OpenSage.Game/Logic/OrderGenerators/SpecialPowerOrderGenerator.cs
+++ b/src/OpenSage.Game/Logic/OrderGenerators/SpecialPowerOrderGenerator.cs
@@ -39,7 +39,7 @@ public sealed class SpecialPowerOrderGenerator : OrderGenerator, IDisposable
     private readonly SpecialPowerCursorInformation _cursorInformation;
     private readonly GameData _config;
     private readonly Player _player;
-    private readonly GameContext _gameContext;
+    private readonly GameEngine _gameEngine;
     private readonly SpecialPowerTargetType _targetType;
     private readonly Scene3D _scene;
 
@@ -53,7 +53,7 @@ public sealed class SpecialPowerOrderGenerator : OrderGenerator, IDisposable
        SpecialPowerCursorInformation cursorInformation,
        GameData config,
        Player player,
-       GameContext gameContext,
+       GameEngine gameContext,
        SpecialPowerTargetType targetType,
        Scene3D scene,
        in TimeInterval time) : base(gameContext.Game)
@@ -64,10 +64,10 @@ public sealed class SpecialPowerOrderGenerator : OrderGenerator, IDisposable
         _scene = scene;
         _config = config;
         _player = player;
-        _gameContext = gameContext;
+        _gameEngine = gameContext;
 
         // TODO: Improve this check.
-        var radiusCursors = _scene.GameContext.AssetLoadContext.AssetStore.InGameUI.Current.RadiusCursors;
+        var radiusCursors = _scene.GameEngine.AssetLoadContext.AssetStore.InGameUI.Current.RadiusCursors;
         var radiusCursorName = _specialPower.Type.ToString();
         if (radiusCursors.TryGetValue(radiusCursorName, out var radiusCursor))
         {
@@ -87,7 +87,7 @@ public sealed class SpecialPowerOrderGenerator : OrderGenerator, IDisposable
         commandCenter = commandCenter?.IsKindOf(ObjectKinds.CommandCenter) == true ? commandCenter : null;
         if (commandCenter == null)
         {
-            foreach (var gameObject in _gameContext.GameLogic.Objects.Reverse())
+            foreach (var gameObject in _gameEngine.GameLogic.Objects.Reverse())
             {
                 // zero hour uses the _last_ built command center
                 if (gameObject.Owner == player && gameObject.IsKindOf(ObjectKinds.CommandCenter))

--- a/src/OpenSage.Game/Logic/TimeIntervalExtensions.cs
+++ b/src/OpenSage.Game/Logic/TimeIntervalExtensions.cs
@@ -4,6 +4,6 @@ public static class TimeIntervalExtensions
 {
     public static double GetLogicFrameRelativeDeltaTime(this TimeInterval timeInterval)
     {
-        return timeInterval.DeltaTime.TotalMilliseconds / Game.LogicUpdateInterval;
+        return timeInterval.DeltaTime.TotalMilliseconds / GameEngine.LogicUpdateInterval;
     }
 }

--- a/src/OpenSage.Game/Scene25D.cs
+++ b/src/OpenSage.Game/Scene25D.cs
@@ -102,13 +102,13 @@ public class Scene25D(Scene3D scene3D, AssetStore assetStore)
                 // AmmoFull, UNUSED?
                 // AmmoEmpty, UNUSED?
 
-                DrawAnimations(drawingContext, obj, scene3D.GameContext.GameLogic.CurrentFrame.Value);
+                DrawAnimations(drawingContext, obj, scene3D.GameEngine.GameLogic.CurrentFrame.Value);
                 // todo: transient animations need to be pulled from a game object, but processed separately
-                EnqueueTransientAnimations(obj, scene3D.GameContext.GameLogic.CurrentFrame.Value);
+                EnqueueTransientAnimations(obj, scene3D.GameEngine.GameLogic.CurrentFrame.Value);
             }
 
             // transient animations are not tied to a specific object
-            DrawTransientAnimations(drawingContext, scene3D.GameContext.GameLogic.CurrentFrame.Value);
+            DrawTransientAnimations(drawingContext, scene3D.GameEngine.GameLogic.CurrentFrame.Value);
         }
     }
 

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -38,7 +38,7 @@ public sealed class Scene3D : DisposableBase
     private EditorCameraInputState _editorCameraInputState;
     public readonly IEditorCameraController EditorCameraController;
 
-    internal readonly GameContext GameContext;
+    internal readonly GameEngine GameEngine;
 
     public SelectionGui SelectionGui { get; }
 
@@ -81,7 +81,7 @@ public sealed class Scene3D : DisposableBase
 
     public PlayerScriptsList PlayerScripts { get; private set; }
 
-    public IGameObjectCollection GameObjects => GameContext.GameLogic;
+    public IGameObjectCollection GameObjects => GameEngine.GameLogic;
     public bool ShowObjects { get; set; } = true;
     public readonly CameraCollection Cameras;
     public readonly WaypointCollection Waypoints;
@@ -194,7 +194,7 @@ public sealed class Scene3D : DisposableBase
                             break;
 
                         default:
-                            GameObject.FromMapObject(mapObject, GameContext, overwriteAngle: null);
+                            GameObject.FromMapObject(mapObject, GameEngine, overwriteAngle: null);
                             break;
                     }
                     break;
@@ -211,7 +211,7 @@ public sealed class Scene3D : DisposableBase
                     var bridgeEnd = mapObjects[++i];
 
                     bridgesList.Add(AddDisposable(new Bridge(
-                        GameContext,
+                        GameEngine,
                         mapObject,
                         mapObject.Position,
                         bridgeEnd.Position)));
@@ -322,7 +322,7 @@ public sealed class Scene3D : DisposableBase
             Quadtree = new Quadtree<GameObject>(new RectangleF(-borderWidth, -borderWidth, width, height));
         }
 
-        GameContext = new GameContext(
+        GameEngine = new GameEngine(
             game.AssetStore.LoadContext,
             game.Audio,
             ParticleSystemManager,

--- a/src/OpenSage.Game/Scripting/ScriptingSystem.cs
+++ b/src/OpenSage.Game/Scripting/ScriptingSystem.cs
@@ -87,7 +87,7 @@ public sealed class ScriptingSystem : GameSystem, IPersistableObject
         _breezeInfo.DirectionVector.Y = MathF.Cos(_breezeInfo.Direction);
         _breezeInfo.Intensity = 0.07f * MathF.PI / 4.0f;
         _breezeInfo.Lean = 0.07f * MathF.PI / 4.0f;
-        _breezeInfo.BreezePeriod = Game.LogicFramesPerSecondN * 5;
+        _breezeInfo.BreezePeriod = GameEngine.LogicFramesPerSecondN * 5;
         _breezeInfo.Randomness = 0.2f;
         _breezeInfo.BreezeVersion = 0;
     }

--- a/src/OpenSage.Game/Terrain/Bridge.cs
+++ b/src/OpenSage.Game/Terrain/Bridge.cs
@@ -19,7 +19,7 @@ public sealed class Bridge : DisposableBase
     private readonly List<Tuple<ModelSubObject, Matrix4x4>> _meshes;
 
     internal Bridge(
-        GameContext gameContext,
+        GameEngine gameContext,
         MapObject mapObject,
         in Vector3 startPosition,
         in Vector3 endPosition)
@@ -58,7 +58,7 @@ public sealed class Bridge : DisposableBase
     }
 
     private List<Tuple<ModelSubObject, Matrix4x4>> CreateMeshes(
-        GameContext gameContext,
+        GameEngine gameContext,
         BridgeTemplate template,
         in Vector3 startPosition,
         in Vector3 endPosition,

--- a/src/OpenSage.Game/Terrain/BridgeTowers.cs
+++ b/src/OpenSage.Game/Terrain/BridgeTowers.cs
@@ -7,7 +7,7 @@ namespace OpenSage.Terrain;
 public sealed class BridgeTowers
 {
     internal static BridgeTowers CreateForLandmarkBridge(
-        GameContext gameContext,
+        GameEngine gameContext,
         GameObject gameObject)
     {
         var worldMatrix =
@@ -36,7 +36,7 @@ public sealed class BridgeTowers
     internal BridgeTowers(
         BridgeTemplate template,
         Player owner,
-        GameContext gameContext,
+        GameEngine gameContext,
         Matrix4x4 worldMatrix,
         float startX,
         float startY,

--- a/src/OpenSage.Mods.Generals/GeneralsScene25D.cs
+++ b/src/OpenSage.Mods.Generals/GeneralsScene25D.cs
@@ -215,7 +215,7 @@ public class GeneralsScene25D(Scene3D scene3D, AssetStore assetStore) : Scene25D
 // shows text on-screen with the included offset, slowly moving up and fading out over 2.75 seconds
 internal class CashAnimation(Camera camera, uint currentFrame, Font font, in Vector3 baseLocation, int amount, in ColorRgbaF baseColor) : TransientAnimation(camera, currentFrame)
 {
-    protected override uint FrameLength => (uint)(Game.LogicFramesPerSecond * 2.75f);
+    protected override uint FrameLength => (uint)(GameEngine.LogicFramesPerSecond * 2.75f);
 
     private readonly Vector3 _baseLocation = baseLocation;
     private readonly string _text = $"{(amount < 0 ? "-" : string.Empty)}{MoneySymbol.Localize()}{amount}";
@@ -247,7 +247,7 @@ internal class CashAnimation(Camera camera, uint currentFrame, Font font, in Vec
 // Shows the rank-up animation rising above the character
 internal class RankUpAnimation(Camera camera, uint currentFrame, GameData gameData, Animation animation, in Vector3 baseLocation) : TransientAnimation(camera, currentFrame)
 {
-    protected override uint FrameLength { get; } = (uint)(Game.LogicFramesPerSecond * gameData.LevelGainAnimationTime);
+    protected override uint FrameLength { get; } = (uint)(GameEngine.LogicFramesPerSecond * gameData.LevelGainAnimationTime);
     private readonly float _zRise = gameData.LevelGainAnimationZRise;
 
     private readonly Vector3 _baseLocation = baseLocation;


### PR DESCRIPTION
This is part 1 of a series of refactoring PRs aimed at merging the `GameContext`, `Game`, and `Scene3D` classes, all three of which serve a similar purpose: to act as a root object that all other game systems hang off.

This PR:

* renames `GameContext` to `GameEngine`
* moves logic frame constants (e.g. 30fps) from `Game` to `GameEngine`