### PR TITLE
Steam version fixes

### DIFF
--- a/src/OpenSage.Game/Content/ContentManager.cs
+++ b/src/OpenSage.Game/Content/ContentManager.cs
@@ -90,6 +90,15 @@ public sealed class ContentManager : DisposableBase
 
             switch (sageGame)
             {
+                // TOOD: We don't actually know how this file (which was added in the Steam Workshop update) gets loaded,
+                // as the publicly released source code is for a prior version.
+                // This file is required to show the correct label for the "Custom Mission" button in the singleplayer menu,
+                // which was added in the aforementioned update.
+                case SageGame.CncGenerals:
+                case SageGame.CncGeneralsZeroHour:
+                    Translation.TranslationManager.LoadStrFile(fileSystem, null, @"Data\Patch.str");
+                    break;
+
                 // Only load these INI files for a subset of games, because we can't parse them for others yet.
                 // TODO: Defer subsystem loading until necessary
                 case SageGame.Bfme:

--- a/src/OpenSage.Game/Content/Translation/ITranslationManager.cs
+++ b/src/OpenSage.Game/Content/Translation/ITranslationManager.cs
@@ -17,6 +17,8 @@ public interface ITranslationManager : ITranslationProvider
 
     void UnregisterProvider(ITranslationProvider provider, bool shouldNotifyLanguageChange = true);
 
+    void RegisterUniversalProvider(ITranslationProvider provider);
+
     IReadOnlyList<ITranslationProvider> GetParticularProviders(string context);
 
     string GetParticularString(string context, string str);

--- a/src/OpenSage.Game/Data/Wnd/Parser/WndParser.cs
+++ b/src/OpenSage.Game/Data/Wnd/Parser/WndParser.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using OpenSage.Content;
-using OpenSage.Gui;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Data.Wnd.Parser;
@@ -294,6 +293,12 @@ internal sealed class WndParser
 
                 case "CHILD":
                     NextToken();
+                    childWindows.Add(ParseWindow());
+                    break;
+
+                case "WINDOW":
+                    // Normally, WINDOW is only allowed after CHILD, but ZH's Steam update includes s new MainMenu.wnd
+                    // which has a WINDOW right after the previous window's END. ZH's original WND parser tolerates this.
                     childWindows.Add(ParseWindow());
                     break;
 

--- a/src/OpenSage.IO/BigFileSystem.cs
+++ b/src/OpenSage.IO/BigFileSystem.cs
@@ -29,7 +29,7 @@ public sealed class BigFileSystem : FileSystem
 
             var fileName = directoryParts[directoryParts.Length - 1];
 
-            bigDirectory.Files.TryAdd(fileName, bigArchiveEntry);
+            bigDirectory.Files[fileName] = bigArchiveEntry;
         }
     }
 

--- a/src/OpenSage.IO/SkudefReader.cs
+++ b/src/OpenSage.IO/SkudefReader.cs
@@ -21,7 +21,7 @@ internal static class SkudefReader
             else
             {
                 languageName = body;
-                versions = new[] { "0", "0" };
+                versions = ["0", "0"];
             }
 
             return new SkudefVersion
@@ -85,7 +85,7 @@ internal static class SkudefReader
                     break;
 
                 case "add-bigs-recurse":
-                    foreach (var bigPath in Directory.GetFiles(fullPath, "*.big", SearchOption.AllDirectories))
+                    foreach (var bigPath in GetBigFiles(fullPath))
                     {
                         addBigArchive(bigPath);
                     }
@@ -97,6 +97,71 @@ internal static class SkudefReader
                         Read(Path.GetDirectoryName(fullPath)!, reader, addBigArchive);
                     }
                     break;
+            }
+        }
+    }
+
+
+    /// <summary>
+    /// Enumerates all .big files in the specified directory and its subdirectories, in the order they should be loaded.
+    /// </summary>
+    private static IEnumerable<string> GetBigFiles(string directory)
+    {
+        // The OSS version of Generals / ZH loads .big files with FindFirstFile / FindNextFile, which means they are returned
+        // in whatever order the file system decides to return them. In practice on Windows & NTFS this is case-insensitive
+        // alphabetical order. For cross-platform compatibility, we need to sort the files ourselves.
+        // However, it seems that even that is not enough, as the Steam Workshop update made some changes which add other
+        // sorting criteria. We don't actually know what those criteria are as the source code for the update is not available.
+        // So this is a guess based on the behavior of the Steam version of the game.
+        var entries = Directory
+            .GetFileSystemEntries(directory)
+            // In the CD / Origin release of ZH, .big files from Generals were included in the same directory as the other .big files.
+            // In the current Steam version, they are in a subdirectory. We need to make sure that the Generals .big files are loaded first,
+            // so that Zero Hour can override them.
+            .OrderByDescending(entry => entry.Contains("ZH_Generals"))
+            .ThenBy(entry =>
+            {
+                var fileName = Path.GetFileNameWithoutExtension(entry);
+                if (fileName == null)
+                {
+                    return 0;
+                }
+                if (fileName.EndsWith("ZH", StringComparison.OrdinalIgnoreCase))
+                {
+                    // The Zero Hour .big files need to be loaded after the Generals .big files.
+                    // This can be a problem with pre-Steam versions.
+                    return 1;
+                }
+                if (fileName.StartsWith("Patch", StringComparison.OrdinalIgnoreCase))
+                {
+                    // The Steam Workshop update added a couple of new PatchX.big files, which need to be loaded after the main .big files.
+                    // Older versions of the game also had patch .big files, but it seems they either didn't override the main .big files
+                    // or they happened to accidentally be loaded in the right order thanks to their names (& NTFS).
+                    return 2;
+                }
+                return 0;
+            })
+            // And finally we sort alphabetically & case-insensitively to match the Windows behavior.
+            .ThenBy(entry => entry, StringComparer.OrdinalIgnoreCase);
+
+        // The final order for Zero Hour should be:
+        // 1. Generals .big files
+        // 2. Generals Patch .big files
+        // 3. Zero Hour .big files
+        // 4. Zero Hour Patch .big files
+        foreach (var entry in entries)
+        {
+            if (Directory.Exists(entry))
+            {
+                // Handle directories recursively to ensure the correct order in subdirectories
+                foreach (var bigFile in GetBigFiles(entry))
+                {
+                    yield return bigFile;
+                }
+            }
+            else if (Path.GetExtension(entry) == ".big")
+            {
+                yield return entry;
             }
         }
     }


### PR DESCRIPTION
- Fix `WndParser` crashing with ZH Steam version's `MainMenu.wnd`
  - The Steam version of base Generals doesn't have the same issue - looks like the Wnd file was modified by hand, and the ZH version has a small syntax issue which the game seems to handle without issues, but OpenSAGE didn't like it.
- Change .big file handling to override existing entries in case of duplicate filename
  - This is potentially a pretty big change, but it seems to match the original engine. I don't think `Patch` .big files could work any other way.
  - Without this change the actual load order was kind of inverted (vs how it is other games) - the files that were loaded first won, and there was no way to override their entries afterwards.
- Update .big file load order logic to match ZH Steam version
  - This is explained in comments in (hopefully) great detail 
- Support loading universal / language independent .str files
  - There is just one file like this (`Patch.str` from the current Steam version) from what I can tell.
- Load Generals / ZH Steam version's Patch.str if available
  - Required to display the `Custom Mission`  button properly in the single player menu

With these changes (with help from #1308), OpenSAGE can now boot into the shellmap in Zero Hour with the latest Steam build of the game.