### PR TITLE
Split client and logic random values

### DIFF
--- a/src/OpenSage.Game.Tests/Graphics/Animation/AnimationInstanceTests.cs
+++ b/src/OpenSage.Game.Tests/Graphics/Animation/AnimationInstanceTests.cs
@@ -5,6 +5,7 @@ using System.Numerics;
 using OpenSage.Graphics;
 using OpenSage.Graphics.Animation;
 using OpenSage.Logic.Object;
+using OpenSage.Mathematics;
 using Xunit;
 
 namespace OpenSage.Tests.Graphics.Animation;
@@ -318,7 +319,7 @@ public class AnimationInstanceTests
 /// <summary>
 /// Guaranteed random!
 /// </summary>
-internal class QuoteUnquoteRandom : Random
+internal class QuoteUnquoteRandom : RandomValue
 {
     private readonly int _random;
 
@@ -338,19 +339,14 @@ internal class QuoteUnquoteRandom : Random
         _random = random;
     }
 
-    public override int Next()
+    public override int Next(int lo, int hi)
     {
         return _random;
     }
 
-    public override int Next(int maxValue)
+    public override float NextSingle(float lo, float hi)
     {
-        return Next();
-    }
-
-    public override int Next(int minValue, int maxValue)
-    {
-        return Next(minValue);
+        return _random;
     }
 }
 

--- a/src/OpenSage.Game.Tests/Graphics/Animation/AnimationInstanceTests.cs
+++ b/src/OpenSage.Game.Tests/Graphics/Animation/AnimationInstanceTests.cs
@@ -319,9 +319,11 @@ public class AnimationInstanceTests
 /// <summary>
 /// Guaranteed random!
 /// </summary>
-internal class QuoteUnquoteRandom : RandomValue
+internal class QuoteUnquoteRandom : IRandom
 {
     private readonly int _random;
+
+    public uint Seed => 0;
 
     /// <summary>
     /// Constructs a new "random" number generator which will always return 0.
@@ -329,6 +331,8 @@ internal class QuoteUnquoteRandom : RandomValue
     public QuoteUnquoteRandom() : this(0)
     {
     }
+
+    public void Initialize(uint seed) { }
 
     /// <summary>
     /// Constructs a new "random" number generator.
@@ -339,12 +343,12 @@ internal class QuoteUnquoteRandom : RandomValue
         _random = random;
     }
 
-    public override int Next(int lo, int hi)
+    public int Next(int lo, int hi)
     {
         return _random;
     }
 
-    public override float NextSingle(float lo, float hi)
+    public float NextSingle(float lo, float hi)
     {
         return _random;
     }

--- a/src/OpenSage.Game/Client/Drawable.cs
+++ b/src/OpenSage.Game/Client/Drawable.cs
@@ -49,7 +49,7 @@ public sealed class Drawable : Entity, IPersistableObject
             {
                 foreach (var drawModule in _drawModules)
                 {
-                    drawModule.UpdateConditionState(ModelConditionFlags, _gameEngine.Random);
+                    drawModule.UpdateConditionState(ModelConditionFlags, _gameEngine.GameClient.Random);
                 }
                 ModelConditionFlags.BitsChanged = false;
             }

--- a/src/OpenSage.Game/Client/GameClient.cs
+++ b/src/OpenSage.Game/Client/GameClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using OpenSage.Logic;
 using OpenSage.Logic.Object;
+using OpenSage.Mathematics;
 
 namespace OpenSage.Client;
 
@@ -14,6 +15,8 @@ internal sealed class GameClient : DisposableBase, IPersistableObject
     private uint _currentFrame;
 
     internal uint NextDrawableId = 1;
+
+    public readonly RandomValue Random = new();
 
     public GameClient(Game game)
     {

--- a/src/OpenSage.Game/Client/GameClient.cs
+++ b/src/OpenSage.Game/Client/GameClient.cs
@@ -7,7 +7,7 @@ namespace OpenSage.Client;
 
 internal sealed class GameClient : DisposableBase, IPersistableObject
 {
-    private readonly Game _game;
+    private readonly IGame _game;
     private readonly ObjectDefinitionLookupTable _objectDefinitionLookupTable;
     private readonly List<Drawable> _drawables = new();
     private readonly List<string> _briefingTexts = new();
@@ -16,12 +16,14 @@ internal sealed class GameClient : DisposableBase, IPersistableObject
 
     internal uint NextDrawableId = 1;
 
-    public readonly RandomValue Random = new();
+    public readonly IRandom Random;
 
-    public GameClient(Game game)
+    public GameClient(IGame game)
     {
         _game = game;
         _objectDefinitionLookupTable = new ObjectDefinitionLookupTable(game.AssetStore.ObjectDefinitions);
+
+        Random = game.CreateRandom();
     }
 
     public Drawable CreateDrawable(ObjectDefinition objectDefinition, GameObject gameObject)

--- a/src/OpenSage.Game/Diagnostics/RenderedView.cs
+++ b/src/OpenSage.Game/Diagnostics/RenderedView.cs
@@ -42,7 +42,6 @@ internal sealed class RenderedView : DisposableBase
             () => new Viewport(0, 0, ImGui.GetContentRegionAvail().X, ImGui.GetContentRegionAvail().Y, 0, 1),
             new ArcballCameraController(cameraTarget, cameraDistance),
             WorldLighting.CreateDefault(),
-            Environment.TickCount,
             isDiagnosticScene: true));
 
         createGameObjects?.Invoke(_scene3D.GameObjects);

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -612,7 +612,6 @@ public sealed class Game : DisposableBase, IGame
             this,
             mapFile,
             entry.FilePath,
-            Environment.TickCount,
             mapPlayers,
             mapTeams,
             mapScriptLists,

--- a/src/OpenSage.Game/GameEngine.cs
+++ b/src/OpenSage.Game/GameEngine.cs
@@ -46,17 +46,7 @@ public sealed class GameEngine
 
     public AssetStore AssetStore => AssetLoadContext.AssetStore;
 
-    public readonly Random Random = new Random();
-
     public readonly AI AI = new();
-
-    public LogicFrameSpan GetRandomLogicFrameSpan(LogicFrameSpan min, LogicFrameSpan max)
-    {
-        var value = Random.Next(
-            (int)min.Value,
-            (int)max.Value);
-        return new LogicFrameSpan((uint)value);
-    }
 
     public readonly IQuadtree<GameObject> Quadtree;
 

--- a/src/OpenSage.Game/Graphics/Animation/AnimationInstance.cs
+++ b/src/OpenSage.Game/Graphics/Animation/AnimationInstance.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using ImGuiNET;
 using OpenSage.Logic.Object;
 using OpenSage.Mathematics;
+using OpenSage.Utilities;
 
 namespace OpenSage.Graphics.Animation;
 
@@ -19,7 +20,7 @@ public sealed class AnimationInstance
     private bool _playing;
     private readonly AnimationMode _mode;
     private readonly AnimationFlags _flags;
-    private readonly Random _random;
+    private readonly RandomValue _random;
 
     private float _speedFactor;
 
@@ -39,7 +40,7 @@ public sealed class AnimationInstance
     /// <param name="gameObject"></param>
     /// <param name="random">Random number generator used when combined with <see cref="AnimationFlags.RandomStart"/></param>
     public AnimationInstance(ModelBoneInstance[] modelBoneInstances, W3DAnimation animation,
-        AnimationMode mode, AnimationFlags flags, GameObject gameObject, Random random)
+        AnimationMode mode, AnimationFlags flags, GameObject gameObject, RandomValue random)
     {
         _animation = animation;
         _mode = mode;
@@ -100,7 +101,7 @@ public sealed class AnimationInstance
         }
         else if (_flags.HasFlag(AnimationFlags.RandomStart))
         {
-            _currentTimeValue = TimeSpan.FromMilliseconds(_random.Next((int)_animation.Duration.TotalMilliseconds));
+            _currentTimeValue = TimeSpan.FromMilliseconds(_random.Next(0, (int)_animation.Duration.TotalMilliseconds));
         }
         else
         {

--- a/src/OpenSage.Game/Graphics/Animation/AnimationInstance.cs
+++ b/src/OpenSage.Game/Graphics/Animation/AnimationInstance.cs
@@ -20,7 +20,7 @@ public sealed class AnimationInstance
     private bool _playing;
     private readonly AnimationMode _mode;
     private readonly AnimationFlags _flags;
-    private readonly RandomValue _random;
+    private readonly IRandom _random;
 
     private float _speedFactor;
 
@@ -40,7 +40,7 @@ public sealed class AnimationInstance
     /// <param name="gameObject"></param>
     /// <param name="random">Random number generator used when combined with <see cref="AnimationFlags.RandomStart"/></param>
     public AnimationInstance(ModelBoneInstance[] modelBoneInstances, W3DAnimation animation,
-        AnimationMode mode, AnimationFlags flags, GameObject gameObject, RandomValue random)
+        AnimationMode mode, AnimationFlags flags, GameObject gameObject, IRandom random)
     {
         _animation = animation;
         _mode = mode;

--- a/src/OpenSage.Game/IGame.cs
+++ b/src/OpenSage.Game/IGame.cs
@@ -4,6 +4,7 @@ using OpenSage.Client;
 using OpenSage.Content;
 using OpenSage.Data.Sav;
 using OpenSage.Logic;
+using OpenSage.Mathematics;
 using OpenSage.Network;
 using OpenSage.Scripting;
 
@@ -39,4 +40,8 @@ public interface IGame
     void StartSkirmishOrMultiPlayerGame(string mapFileName, IConnection connection, PlayerSetting[] playerSettings, int seed, bool isMultiPlayer);
     void StartSinglePlayerGame(string mapFileName);
     IEnumerable<PlayerTemplate> GetPlayableSides();
+
+    // TODO: Move this somewhere where it could be configured for specific games;
+    // e.g. for a replay we might want to use SageRandom.
+    IRandom CreateRandom() => new SystemRandom();
 }

--- a/src/OpenSage.Game/Logic/GameLogic.cs
+++ b/src/OpenSage.Game/Logic/GameLogic.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using OpenSage.Content;
 using OpenSage.Logic.Map;
 using OpenSage.Logic.Object;
+using OpenSage.Mathematics;
 
 namespace OpenSage.Logic;
 
@@ -51,6 +52,8 @@ internal sealed class GameLogic : DisposableBase, IGameObjectCollection, IPersis
             return _objectsToIterate;
         }
     }
+
+    public readonly RandomValue Random = new();
 
     public GameLogic(IGame game)
     {

--- a/src/OpenSage.Game/Logic/GameLogic.cs
+++ b/src/OpenSage.Game/Logic/GameLogic.cs
@@ -53,12 +53,14 @@ internal sealed class GameLogic : DisposableBase, IGameObjectCollection, IPersis
         }
     }
 
-    public readonly RandomValue Random = new();
+    public readonly IRandom Random;
 
     public GameLogic(IGame game)
     {
         _game = game;
         _objectDefinitionLookupTable = new ObjectDefinitionLookupTable(game.AssetStore.ObjectDefinitions);
+
+        Random = game.CreateRandom();
     }
 
     public GameObject CreateObject(ObjectDefinition objectDefinition, Player player)

--- a/src/OpenSage.Game/Logic/Object/Behaviors/GenerateMinefieldBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/GenerateMinefieldBehavior.cs
@@ -149,7 +149,7 @@ public sealed class GenerateMinefieldBehavior : BehaviorModule, IUpgradeableModu
     {
         // todo: should the normal matching be handled by KindOf STICK_TO_TERRAIN_SLOPE?
         var normal = GameEngine.Terrain.HeightMap.GetNormal(location.X, location.Y);
-        var rotation = (float)(GameEngine.Random.NextDouble() * 2 * Math.PI);
+        var rotation = GameEngine.GameLogic.Random.NextSingle(0, MathUtility.TwoPi);
         return new Transform(location, Quaternion.CreateFromAxisAngle(normal, rotation));
     }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
@@ -599,13 +599,13 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
         // Set bounce to true for a while until the unit is complete bouncing.
         SetAllowBouncing(true);
 
-        var randomModifier = GameEngine.Random.NextSingle(-1.0f, 1.0f);
+        var randomModifier = GameEngine.GameLogic.Random.NextSingle(-1.0f, 1.0f);
         _yawRate += _moduleData.ShockMaxYaw * randomModifier;
 
-        randomModifier = GameEngine.Random.NextSingle(-1.0f, 1.0f);
+        randomModifier = GameEngine.GameLogic.Random.NextSingle(-1.0f, 1.0f);
         _pitchRate += _moduleData.ShockMaxPitch * randomModifier;
 
-        randomModifier = GameEngine.Random.NextSingle(-1.0f, 1.0f);
+        randomModifier = GameEngine.GameLogic.Random.NextSingle(-1.0f, 1.0f);
         _rollRate += _moduleData.ShockMaxRoll * randomModifier;
 
         MaybeWakeUp();

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
@@ -66,7 +66,7 @@ public class SlowDeathBehavior : UpdateModule
 
     private static LogicFrameSpan GetDelayWithVariance(BehaviorUpdateContext context, LogicFrameSpan delay, LogicFrameSpan variance)
     {
-        var randomMultiplier = (context.GameEngine.Random.NextDouble() * 2.0) - 1.0;
+        var randomMultiplier = context.GameEngine.GameLogic.Random.NextSingle(-1.0f, 1.0f);
         return delay + (variance * (float)randomMultiplier);
     }
 

--- a/src/OpenSage.Game/Logic/Object/ClientUpdate/SwayClientUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/ClientUpdate/SwayClientUpdate.cs
@@ -103,9 +103,9 @@ public sealed class SwayClientUpdate : ClientUpdateModule
 
         var delta = breezeInfo.Randomness * 0.5f;
 
-        _currentAngleLimit = breezeInfo.Intensity * _gameEngine.Random.NextSingle(1.0f - delta, 1.0f + delta);
-        _currentDelta = 2.0f * MathF.PI / breezeInfo.BreezePeriod * _gameEngine.Random.NextSingle(1.0f - delta, 1.0f + delta);
-        _leanAngle = breezeInfo.Lean * _gameEngine.Random.NextSingle(1.0f - delta, 1.0f + delta);
+        _currentAngleLimit = breezeInfo.Intensity * _gameEngine.GameClient.Random.NextSingle(1.0f - delta, 1.0f + delta);
+        _currentDelta = 2.0f * MathF.PI / breezeInfo.BreezePeriod * _gameEngine.GameClient.Random.NextSingle(1.0f - delta, 1.0f + delta);
+        _leanAngle = breezeInfo.Lean * _gameEngine.GameClient.Random.NextSingle(1.0f - delta, 1.0f + delta);
         _currentVersion = breezeInfo.BreezeVersion;
     }
 

--- a/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
@@ -59,7 +59,7 @@ public class TransportContain : OpenContainModule
                 // testing with a humvee, evacuating individually, the units never use the same exit path
                 // using the evac command, two pairs of rangers will share an exit path, and the 5th ranger will use a 3rd exit path
                 // todo: this doesn't seem to be strictly random, but it's unclear how this works at the moment
-                var pathToChoose = GameEngine.GameLogic.Random.Next(1, _moduleData.NumberOfExitPaths + 1);
+                var pathToChoose = GameEngine.GameLogic.Random.Next(1, _moduleData.NumberOfExitPaths);
                 startBoneName = $"{startBoneName}{pathToChoose:00}";
                 endBoneName = $"{endBoneName}{pathToChoose:00}";
             }

--- a/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
@@ -59,7 +59,7 @@ public class TransportContain : OpenContainModule
                 // testing with a humvee, evacuating individually, the units never use the same exit path
                 // using the evac command, two pairs of rangers will share an exit path, and the 5th ranger will use a 3rd exit path
                 // todo: this doesn't seem to be strictly random, but it's unclear how this works at the moment
-                var pathToChoose = GameEngine.Random.Next(1, _moduleData.NumberOfExitPaths + 1);
+                var pathToChoose = GameEngine.GameLogic.Random.Next(1, _moduleData.NumberOfExitPaths + 1);
                 startBoneName = $"{startBoneName}{pathToChoose:00}";
                 endBoneName = $"{endBoneName}{pathToChoose:00}";
             }

--- a/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
@@ -25,11 +25,11 @@ public sealed class CreateCrateDie : DieModule
 
             if (KillerCanSpawnCrate(killer, crateData))
             {
-                if (GameEngine.Random.NextSingle() < crateData.CreationChance)
+                if (GameEngine.GameLogic.Random.NextSingle(0, 1) < crateData.CreationChance)
                 {
                     // actually create the crate
                     float totalProbability = 0;
-                    var selection = GameEngine.Random.NextSingle();
+                    var selection = GameEngine.GameLogic.Random.NextSingle(0, 1);
                     foreach (var crate in crateData.CrateObjects)
                     {
                         totalProbability += crate.Probability;

--- a/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
@@ -30,7 +30,7 @@ public abstract class DrawModule : ModuleBase
     internal abstract string GetWeaponFireFXBone(WeaponSlot slot);
     internal abstract string GetWeaponLaunchBone(WeaponSlot slot);
 
-    public virtual void UpdateConditionState(BitArray<ModelConditionFlag> flags, Random random)
+    public virtual void UpdateConditionState(BitArray<ModelConditionFlag> flags, RandomValue random)
     {
 
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
@@ -30,7 +30,7 @@ public abstract class DrawModule : ModuleBase
     internal abstract string GetWeaponFireFXBone(WeaponSlot slot);
     internal abstract string GetWeaponLaunchBone(WeaponSlot slot);
 
-    public virtual void UpdateConditionState(BitArray<ModelConditionFlag> flags, RandomValue random)
+    public virtual void UpdateConditionState(BitArray<ModelConditionFlag> flags, IRandom random)
     {
 
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dHordeModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dHordeModelDraw.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using OpenSage.Client;
 using OpenSage.Data.Ini;
+using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object;
 
@@ -16,7 +17,7 @@ public class W3dHordeModelDraw : W3dScriptedModelDraw
     {
     }
 
-    protected override bool SetActiveAnimationState(AnimationState animationState, Random random)
+    protected override bool SetActiveAnimationState(AnimationState animationState, RandomValue random)
     {
         return base.SetActiveAnimationState(animationState, random);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dHordeModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dHordeModelDraw.cs
@@ -17,7 +17,7 @@ public class W3dHordeModelDraw : W3dScriptedModelDraw
     {
     }
 
-    protected override bool SetActiveAnimationState(AnimationState animationState, RandomValue random)
+    protected override bool SetActiveAnimationState(AnimationState animationState, IRandom random)
     {
         return base.SetActiveAnimationState(animationState, random);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -96,7 +96,7 @@ public class W3dModelDraw : DrawModule
         Drawable = drawable;
         _gameEngine = gameEngine;
 
-        UpdateConditionState(new BitArray<ModelConditionFlag>(), gameEngine.Random);
+        UpdateConditionState(new BitArray<ModelConditionFlag>(), gameEngine.GameClient.Random);
 
         _unknownSomething = new List<W3dModelDrawSomething>[3];
         for (var i = 0; i < _unknownSomething.Length; i++)
@@ -105,7 +105,7 @@ public class W3dModelDraw : DrawModule
         }
     }
 
-    private void SetActiveConditionState(ModelConditionState conditionState, Random random)
+    private void SetActiveConditionState(ModelConditionState conditionState, RandomValue random)
     {
         if (_activeConditionState == conditionState || ShouldWaitForRunningAnimationsToFinish())
         {
@@ -139,7 +139,7 @@ public class W3dModelDraw : DrawModule
         //&& (_activeModelDrawConditionState?.StillActive() ?? false);
     }
 
-    protected virtual bool SetActiveAnimationState(AnimationState animationState, Random random)
+    protected virtual bool SetActiveAnimationState(AnimationState animationState, RandomValue random)
     {
         if (animationState == _activeAnimationState && (_activeModelDrawConditionState?.StillActive() ?? false))
         {
@@ -179,7 +179,7 @@ public class W3dModelDraw : DrawModule
         {
             var flags = animationState.Flags;
             var mode = animationBlock.AnimationMode;
-            var animationInstance = new AnimationInstance(modelInstance.ModelBoneInstances, anim, mode, flags, GameObject, _gameEngine.Random);
+            var animationInstance = new AnimationInstance(modelInstance.ModelBoneInstances, anim, mode, flags, GameObject, _gameEngine.GameClient.Random);
             modelInstance.AnimationInstances.Add(animationInstance);
             animationInstance.Play(animationBlock.AnimationSpeedFactorRange.GetValue(random));
         }
@@ -192,7 +192,7 @@ public class W3dModelDraw : DrawModule
     public void SetTransitionState(string state)
     {
         var transitionState = _data.TransitionStates.FirstOrDefault(x => x.StateName == state);
-        SetActiveAnimationState(transitionState, _gameEngine.Random);
+        SetActiveAnimationState(transitionState, _gameEngine.GameClient.Random);
     }
 
     internal static T FindBestFittingConditionState<T, TFlag>(List<T> conditionStates, BitArray<TFlag> flags)
@@ -204,7 +204,7 @@ public class W3dModelDraw : DrawModule
             flags);
     }
 
-    public override void UpdateConditionState(BitArray<ModelConditionFlag> flags, Random random)
+    public override void UpdateConditionState(BitArray<ModelConditionFlag> flags, RandomValue random)
     {
         if (!flags.BitsChanged)
         {
@@ -261,7 +261,7 @@ public class W3dModelDraw : DrawModule
         }
     }
 
-    private W3dModelDrawConditionState CreateModelDrawConditionStateInstance(ModelConditionState conditionState, Random random)
+    private W3dModelDrawConditionState CreateModelDrawConditionStateInstance(ModelConditionState conditionState, RandomValue random)
     {
         // Load model, fallback to default model.
         var model = conditionState.Model?.Value;

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -105,7 +105,7 @@ public class W3dModelDraw : DrawModule
         }
     }
 
-    private void SetActiveConditionState(ModelConditionState conditionState, RandomValue random)
+    private void SetActiveConditionState(ModelConditionState conditionState, IRandom random)
     {
         if (_activeConditionState == conditionState || ShouldWaitForRunningAnimationsToFinish())
         {
@@ -139,7 +139,7 @@ public class W3dModelDraw : DrawModule
         //&& (_activeModelDrawConditionState?.StillActive() ?? false);
     }
 
-    protected virtual bool SetActiveAnimationState(AnimationState animationState, RandomValue random)
+    protected virtual bool SetActiveAnimationState(AnimationState animationState, IRandom random)
     {
         if (animationState == _activeAnimationState && (_activeModelDrawConditionState?.StillActive() ?? false))
         {
@@ -204,7 +204,7 @@ public class W3dModelDraw : DrawModule
             flags);
     }
 
-    public override void UpdateConditionState(BitArray<ModelConditionFlag> flags, RandomValue random)
+    public override void UpdateConditionState(BitArray<ModelConditionFlag> flags, IRandom random)
     {
         if (!flags.BitsChanged)
         {
@@ -261,7 +261,7 @@ public class W3dModelDraw : DrawModule
         }
     }
 
-    private W3dModelDrawConditionState CreateModelDrawConditionStateInstance(ModelConditionState conditionState, RandomValue random)
+    private W3dModelDrawConditionState CreateModelDrawConditionStateInstance(ModelConditionState conditionState, IRandom random)
     {
         // Load model, fallback to default model.
         var model = conditionState.Model?.Value;

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
@@ -65,7 +65,7 @@ public sealed class W3dTruckDraw : W3dModelDraw
         }
     }
 
-    public override void UpdateConditionState(BitArray<ModelConditionFlag> flags, Random random)
+    public override void UpdateConditionState(BitArray<ModelConditionFlag> flags, RandomValue random)
     {
         base.UpdateConditionState(flags, random);
 

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
@@ -65,7 +65,7 @@ public sealed class W3dTruckDraw : W3dModelDraw
         }
     }
 
-    public override void UpdateConditionState(BitArray<ModelConditionFlag> flags, RandomValue random)
+    public override void UpdateConditionState(BitArray<ModelConditionFlag> flags, IRandom random)
     {
         base.UpdateConditionState(flags, random);
 

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -1476,7 +1476,7 @@ public sealed class GameObject : Entity, IInspectable, ICollidable, IPersistable
             .ToList();
 
         var sumProbabilityModifiers = slowDeathBehaviors.Sum(x => x.ProbabilityModifier);
-        var random = _gameEngine.GameLogic.Random.Next(0, sumProbabilityModifiers);
+        var random = _gameEngine.GameLogic.Random.Next(0, sumProbabilityModifiers - 1);
         var cumulative = 0;
         foreach (var deathBehavior in slowDeathBehaviors)
         {

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -527,7 +527,7 @@ public sealed class GameObject : Entity, IInspectable, ICollidable, IPersistable
     {
         if (objectDefinition.BuildVariations != null && objectDefinition.BuildVariations.Count() > 0)
         {
-            objectDefinition = objectDefinition.BuildVariations[gameContext.Random.Next(0, objectDefinition.BuildVariations.Count())].Value;
+            objectDefinition = objectDefinition.BuildVariations[gameContext.GameLogic.Random.Next(0, objectDefinition.BuildVariations.Length - 1)].Value;
         }
 
         _objectMoved = true;
@@ -1476,7 +1476,7 @@ public sealed class GameObject : Entity, IInspectable, ICollidable, IPersistable
             .ToList();
 
         var sumProbabilityModifiers = slowDeathBehaviors.Sum(x => x.ProbabilityModifier);
-        var random = _gameEngine.Random.Next(sumProbabilityModifiers);
+        var random = _gameEngine.GameLogic.Random.Next(0, sumProbabilityModifiers);
         var cumulative = 0;
         foreach (var deathBehavior in slowDeathBehaviors)
         {

--- a/src/OpenSage.Game/Logic/Object/Locomotor.cs
+++ b/src/OpenSage.Game/Logic/Object/Locomotor.cs
@@ -81,9 +81,9 @@ public sealed class Locomotor : IPersistableObject
         _preferredHeight = template.PreferredHeight;
         _preferredHeightDamping = template.PreferredHeightDamping;
 
-        _angleOffset = gameEngine.Random.NextSingle(-MathF.PI / 6.0f, MathF.PI / 6.0f);
-        _offsetIncrement = (MathF.PI / 40.0f) * (gameEngine.Random.NextSingle(0.8f, 1.2f) / template.WanderLengthFactor);
-        SetFlag(LocomotorFlags.OffsetIncreasing, gameEngine.Random.NextBoolean());
+        _angleOffset = gameEngine.GameLogic.Random.NextSingle(-MathF.PI / 6.0f, MathF.PI / 6.0f);
+        _offsetIncrement = (MathF.PI / 40.0f) * (gameEngine.GameLogic.Random.NextSingle(0.8f, 1.2f) / template.WanderLengthFactor);
+        SetFlag(LocomotorFlags.OffsetIncreasing, gameEngine.GameLogic.Random.NextBoolean());
 
         ResetDonutTimer();
     }

--- a/src/OpenSage.Game/Logic/Object/ObjectCreationList.cs
+++ b/src/OpenSage.Game/Logic/Object/ObjectCreationList.cs
@@ -5,6 +5,7 @@ using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.Gui.InGame;
 using OpenSage.Mathematics;
+using OpenSage.Utilities;
 
 namespace OpenSage.Logic.Object;
 
@@ -133,7 +134,7 @@ public sealed class CreateDebrisOCNugget : OCNugget
 
         var debrisObject = context.GameEngine.GameLogic.CreateObject(debrisObjectDefinition, context.GameObject.Owner);
 
-        var lifeTime = context.GameEngine.GetRandomLogicFrameSpan(MinLifetime, MaxLifetime);
+        var lifeTime = context.GameEngine.GameLogic.Random.NextLogicFrameSpan(MinLifetime, MaxLifetime);
         debrisObject.LifeTime = context.LogicFrame + lifeTime;
 
         debrisObject.UpdateTransform(context.GameObject.Translation + Offset, context.GameObject.Rotation);
@@ -155,8 +156,8 @@ public sealed class CreateDebrisOCNugget : OCNugget
             var forceMultiplier = 200 / 30.0f * Mass; // TODO: Is this right?
             physicsBehavior.ApplyForce(
                 new Vector3(
-                    ((float)context.GameEngine.Random.NextDouble() - 0.5f) * DispositionIntensity * forceMultiplier,
-                    ((float)context.GameEngine.Random.NextDouble() - 0.5f) * DispositionIntensity * forceMultiplier,
+                    context.GameEngine.GameLogic.Random.NextSingle(-0.5f, 0.5f) * DispositionIntensity * forceMultiplier,
+                    context.GameEngine.GameLogic.Random.NextSingle(-0.5f, 0.5f) * DispositionIntensity * forceMultiplier,
                     DispositionIntensity * forceMultiplier));
         }
 
@@ -357,7 +358,7 @@ public sealed class CreateObjectOCNugget : OCNugget
                 var lifetimeUpdate = newGameObject.FindBehavior<LifetimeUpdate>();
                 if (lifetimeUpdate != null)
                 {
-                    var lifetime = context.GameEngine.GetRandomLogicFrameSpan(MinLifetime, MaxLifetime);
+                    var lifetime = context.GameEngine.GameLogic.Random.NextLogicFrameSpan(MinLifetime, MaxLifetime);
                     lifetimeUpdate.FrameToDie = context.LogicFrame + lifetime;
                 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/HackInternetAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/HackInternetAIUpdate.cs
@@ -105,7 +105,6 @@ internal sealed class HackInternetAIUpdateStateMachine : AIUpdateStateMachine
 
     internal LogicFrameSpan GetVariableFrames(LogicFrameSpan time, GameEngine gameEngine)
     {
-        // take a random float, *2 for 0 - 2, -1 for -1 - 1, *variance for our actual variance factor
         var variationFactor = AIUpdate.ModuleData.PackUnpackVariationFactor;
         var variation = gameEngine.GameLogic.Random.NextSingle(
             1.0f - variationFactor,

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/HackInternetAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/HackInternetAIUpdate.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 
 using System.Numerics;
-using OpenSage.Audio;
 using OpenSage.Data.Ini;
 using OpenSage.Logic.AI;
 using OpenSage.Logic.AI.AIStates;
@@ -107,7 +106,11 @@ internal sealed class HackInternetAIUpdateStateMachine : AIUpdateStateMachine
     internal LogicFrameSpan GetVariableFrames(LogicFrameSpan time, GameEngine gameEngine)
     {
         // take a random float, *2 for 0 - 2, -1 for -1 - 1, *variance for our actual variance factor
-        return new LogicFrameSpan((uint)(time.Value + time.Value * ((gameEngine.Random.NextSingle() * 2 - 1) * AIUpdate.ModuleData.PackUnpackVariationFactor)));
+        var variationFactor = AIUpdate.ModuleData.PackUnpackVariationFactor;
+        var variation = gameEngine.GameLogic.Random.NextSingle(
+            1.0f - variationFactor,
+            1.0f + variationFactor);
+        return new LogicFrameSpan((uint)(time.Value * variation));
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TurretAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TurretAIUpdate.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using OpenSage.Data.Ini;
 using OpenSage.Mathematics;
+using OpenSage.Utilities;
 
 namespace OpenSage.Logic.Object;
 
@@ -75,7 +76,7 @@ public class TurretAIUpdate : UpdateModule
                 {
                     if (!FoundTargetWhileScanning(context, autoAcquireEnemiesWhenIdle))
                     {
-                        var scanInterval = context.GameEngine.GetRandomLogicFrameSpan(
+                        var scanInterval = context.GameEngine.GameLogic.Random.NextLogicFrameSpan(
                             _moduleData.MinIdleScanInterval,
                             _moduleData.MaxIdleScanInterval);
                         _waitUntil = context.LogicFrame + scanInterval;

--- a/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using ImGuiNET;
+﻿using ImGuiNET;
 using OpenSage.Data.Ini;
+using OpenSage.Utilities;
 
 namespace OpenSage.Logic.Object;
 
@@ -15,7 +15,7 @@ internal class DeletionUpdate : UpdateModule
     {
         _moduleData = moduleData;
 
-        _frameToDelete = gameEngine.GameLogic.CurrentFrame + gameEngine.GetRandomLogicFrameSpan(_moduleData.MinLifetime, _moduleData.MaxLifetime);
+        _frameToDelete = gameEngine.GameLogic.CurrentFrame + gameEngine.GameLogic.Random.NextLogicFrameSpan(_moduleData.MinLifetime, _moduleData.MaxLifetime);
         SetNextUpdateFrame(_frameToDelete);
     }
 

--- a/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
@@ -20,7 +20,7 @@ internal sealed class LifetimeUpdate : UpdateModule
     {
         _moduleData = moduleData;
 
-        var lifetimeFrames = gameEngine.Random.Next(
+        var lifetimeFrames = gameEngine.GameLogic.Random.Next(
             (int)moduleData.MinLifetime.Value,
             (int)moduleData.MaxLifetime.Value);
 

--- a/src/OpenSage.Game/Logic/Object/Update/SlavedUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SlavedUpdate.cs
@@ -5,6 +5,7 @@ using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.Graphics.ParticleSystems;
 using OpenSage.Mathematics;
+using OpenSage.Utilities;
 
 namespace OpenSage.Logic.Object;
 
@@ -77,16 +78,16 @@ public class SlavedUpdateModule : UpdateModule
                     if (!isMoving)
                     {
                         _repairStatus = RepairStatus.READY;
-                        var readyDuration = context.GameEngine.GetRandomLogicFrameSpan(_moduleData.RepairMinReadyTime, _moduleData.RepairMaxReadyTime);
+                        var readyDuration = context.GameEngine.GameLogic.Random.NextLogicFrameSpan(_moduleData.RepairMinReadyTime, _moduleData.RepairMaxReadyTime);
                         _waitUntil = context.LogicFrame + readyDuration;
                     }
                     break;
                 case RepairStatus.READY:
                     if (context.LogicFrame >= _waitUntil)
                     {
-                        var range = (float)(context.GameEngine.Random.NextDouble() * _moduleData.RepairRange);
-                        var height = (float)(context.GameEngine.Random.NextDouble() * (_moduleData.RepairMaxAltitude - _moduleData.RepairMinAltitude) + _moduleData.RepairMinAltitude);
-                        var angle = (float)(context.GameEngine.Random.NextDouble() * (Math.PI * 2));
+                        var range = context.GameEngine.GameLogic.Random.NextSingle(0, _moduleData.RepairRange);
+                        var height = context.GameEngine.GameLogic.Random.NextSingle(_moduleData.RepairMinAltitude, _moduleData.RepairMaxAltitude);
+                        var angle = context.GameEngine.GameLogic.Random.NextSingle(0, MathUtility.TwoPi);
 
                         var offset = Vector3.Transform(new Vector3(range, 0.0f, height), Quaternion.CreateFromAxisAngle(Vector3.UnitZ, angle));
                         GameObject.AIUpdate.SetTargetPoint(_master.Translation + offset);
@@ -106,7 +107,7 @@ public class SlavedUpdateModule : UpdateModule
 
                         particleSystem.Activate();
 
-                        var weldDuration = context.GameEngine.GetRandomLogicFrameSpan(_moduleData.RepairMinWeldTime, _moduleData.RepairMaxWeldTime);
+                        var weldDuration = context.GameEngine.GameLogic.Random.NextLogicFrameSpan(_moduleData.RepairMinWeldTime, _moduleData.RepairMaxWeldTime);
                         _waitUntil = context.LogicFrame + weldDuration;
                         _repairStatus = RepairStatus.WELDING;
                     }

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -99,8 +99,6 @@ public sealed class Scene3D : DisposableBase
     internal AudioSystem Audio => Game.Audio;
     internal AssetLoadContext AssetLoadContext => Game.AssetStore.LoadContext;
 
-    public readonly Random Random;
-
     private readonly OrderGeneratorInputHandler _orderGeneratorInputHandler;
 
     public readonly Radar Radar;
@@ -119,12 +117,11 @@ public sealed class Scene3D : DisposableBase
         Game game,
         MapFile mapFile,
         string mapPath,
-        int randomSeed,
         Data.Map.Player[] mapPlayers,
         Data.Map.Team[] mapTeams,
         ScriptList[] mapScriptLists,
         GameType gameType)
-        : this(game, () => game.Viewport, game.InputMessageBuffer, randomSeed, false, mapFile, mapPath)
+        : this(game, () => game.Viewport, game.InputMessageBuffer, false, mapFile, mapPath)
     {
         game.Scene3D = this;
 
@@ -266,9 +263,8 @@ public sealed class Scene3D : DisposableBase
         Func<Viewport> getViewport,
         IEditorCameraController cameraController,
         WorldLighting lighting,
-        int randomSeed,
         bool isDiagnosticScene = false)
-        : this(game, getViewport, inputMessageBuffer, randomSeed, isDiagnosticScene, null, null)
+        : this(game, getViewport, inputMessageBuffer, isDiagnosticScene, null, null)
     {
         WaterAreas = AddDisposable(new WaterAreaCollection());
         Lighting = lighting;
@@ -281,7 +277,7 @@ public sealed class Scene3D : DisposableBase
         EditorCameraController = cameraController;
     }
 
-    private Scene3D(Game game, Func<Viewport> getViewport, InputMessageBuffer inputMessageBuffer, int randomSeed, bool isDiagnosticScene, MapFile mapFile, string mapPath)
+    private Scene3D(Game game, Func<Viewport> getViewport, InputMessageBuffer inputMessageBuffer, bool isDiagnosticScene, MapFile mapFile, string mapPath)
     {
         Game = game;
 
@@ -290,8 +286,6 @@ public sealed class Scene3D : DisposableBase
         SelectionGui = new SelectionGui();
 
         DebugOverlay = new DebugOverlay(this, game.ContentManager);
-
-        Random = new Random(randomSeed);
 
         RenderScene = new RenderScene();
 

--- a/src/OpenSage.Game/Scripting/Actions/ScriptActions.Unit.cs
+++ b/src/OpenSage.Game/Scripting/Actions/ScriptActions.Unit.cs
@@ -50,7 +50,7 @@ partial class ScriptActions
         var nearestWaypoint = waypoints.MinByOrDefault(w => Vector3.DistanceSquared(unit.Translation, w.Position));
         if (nearestWaypoint != null)
         {
-            var positions = nearestWaypoint.FollowPath(context.Scene.Random);
+            var positions = nearestWaypoint.FollowPath(context.Game.GameLogic.Random);
             unit.AIUpdate.FollowWaypoints(positions);
         }
     }

--- a/src/OpenSage.Game/Scripting/Waypoints.cs
+++ b/src/OpenSage.Game/Scripting/Waypoints.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 using OpenSage.Data.Map;
+using OpenSage.Mathematics;
 using OpenSage.Utilities.Extensions;
 
 namespace OpenSage.Scripting;
@@ -128,7 +129,7 @@ public sealed class Waypoint
     /// b) the returned enumerable is potentially infinite, so avoid materializing it by
     /// calling <see cref="Enumerable.ToList"/> and co.
     /// </summary>
-    public IEnumerable<Vector3> FollowPath(Random random)
+    public IEnumerable<Vector3> FollowPath(RandomValue random)
     {
         var currentWaypoint = this;
         while (currentWaypoint != null)
@@ -139,7 +140,7 @@ public sealed class Waypoint
             {
                 0 => null,
                 1 => connectedWaypoints[0],
-                int n => connectedWaypoints[random.Next(n)]
+                int n => connectedWaypoints[random.Next(0, n - 1)]
             };
         }
     }

--- a/src/OpenSage.Game/Scripting/Waypoints.cs
+++ b/src/OpenSage.Game/Scripting/Waypoints.cs
@@ -129,7 +129,7 @@ public sealed class Waypoint
     /// b) the returned enumerable is potentially infinite, so avoid materializing it by
     /// calling <see cref="Enumerable.ToList"/> and co.
     /// </summary>
-    public IEnumerable<Vector3> FollowPath(RandomValue random)
+    public IEnumerable<Vector3> FollowPath(IRandom random)
     {
         var currentWaypoint = this;
         while (currentWaypoint != null)

--- a/src/OpenSage.Game/Utilities/IRandomExtensions.cs
+++ b/src/OpenSage.Game/Utilities/IRandomExtensions.cs
@@ -3,10 +3,10 @@ using OpenSage.Mathematics;
 
 namespace OpenSage.Utilities;
 
-public static class RandomExtensions
+public static class IRandomExtensions
 {
     public static LogicFrameSpan NextLogicFrameSpan(
-        this RandomValue random,
+        this IRandom random,
         LogicFrameSpan min,
         LogicFrameSpan max)
     {
@@ -14,7 +14,7 @@ public static class RandomExtensions
         return new LogicFrameSpan((uint)value);
     }
 
-    public static bool NextBoolean(this RandomValue random)
+    public static bool NextBoolean(this IRandom random)
     {
         return random.Next(0, 1) == 1;
     }

--- a/src/OpenSage.Game/Utilities/RandomExtensions.cs
+++ b/src/OpenSage.Game/Utilities/RandomExtensions.cs
@@ -1,23 +1,21 @@
-﻿using System;
+﻿using OpenSage.Logic.Object;
+using OpenSage.Mathematics;
 
 namespace OpenSage.Utilities;
 
-internal static class RandomExtensions
+public static class RandomExtensions
 {
-    public static float NextSingle(this Random random, float lo, float hi)
+    public static LogicFrameSpan NextLogicFrameSpan(
+        this RandomValue random,
+        LogicFrameSpan min,
+        LogicFrameSpan max)
     {
-        var delta = hi - lo;
-
-        if (delta <= 0.0f)
-        {
-            return hi;
-        }
-
-        return random.NextSingle() * delta + lo;
+        var value = random.Next((int)min.Value, (int)max.Value);
+        return new LogicFrameSpan((uint)value);
     }
 
-    public static bool NextBoolean(this Random random)
+    public static bool NextBoolean(this RandomValue random)
     {
-        return random.Next(0, 2) == 1;
+        return random.Next(0, 1) == 1;
     }
 }

--- a/src/OpenSage.Mathematics.Tests/RandomValueTests.cs
+++ b/src/OpenSage.Mathematics.Tests/RandomValueTests.cs
@@ -1,0 +1,67 @@
+﻿using Xunit;
+
+namespace OpenSage.Mathematics.Tests;
+
+public class RandomValueTests
+{
+    [Fact]
+    public void CanGenerateRandomIntegers()
+    {
+        var random = new RandomValue();
+
+        Assert.Equal(5, random.Next(0, 5));
+        Assert.Equal(1, random.Next(0, 5));
+        Assert.Equal(4, random.Next(0, 5));
+        Assert.Equal(4, random.Next(0, 5));
+        Assert.Equal(5, random.Next(0, 5));
+        Assert.Equal(2, random.Next(0, 5));
+        Assert.Equal(1, random.Next(0, 5));
+        Assert.Equal(0, random.Next(0, 5));
+        Assert.Equal(2, random.Next(0, 5));
+        Assert.Equal(5, random.Next(0, 5));
+        Assert.Equal(2, random.Next(0, 5));
+        Assert.Equal(0, random.Next(0, 5));
+        Assert.Equal(5, random.Next(0, 5));
+        Assert.Equal(3, random.Next(0, 5));
+    }
+
+    [Theory]
+    [InlineData(0, 5)]
+    [InlineData(-10, 5)]
+    public void GeneratesIntegerValuesInRequestedRange(int lo, int hi)
+    {
+        var random = new RandomValue();
+        for (var i = 0; i < 1000; i++)
+        {
+            var value = random.Next(lo, hi);
+            Assert.True(value >= lo && value <= hi);
+        }
+    }
+
+    [Fact]
+    public void CanGenerateRandomFloats()
+    {
+        var random = new RandomValue();
+
+        Assert.Equal(1.67192996f, random.NextSingle(0, 5));
+        Assert.Equal(0.767719746f, random.NextSingle(0, 5));
+        Assert.Equal(4.53429937f, random.NextSingle(0, 5));
+        Assert.Equal(2.31859875f, random.NextSingle(0, 5));
+        Assert.Equal(2.48254776f, random.NextSingle(0, 5));
+        Assert.Equal(4.58807659f, random.NextSingle(0, 5));
+    }
+
+    [Theory]
+    [InlineData(0, 5)]
+    [InlineData(-10, 5)]
+    [InlineData(-1.5f, 3.5f)]
+    public void GeneratesFloatValuesInRequestedRange(int lo, int hi)
+    {
+        var random = new RandomValue();
+        for (var i = 0; i < 1000; i++)
+        {
+            var value = random.NextSingle(lo, hi);
+            Assert.True(value >= lo && value <= hi);
+        }
+    }
+}

--- a/src/OpenSage.Mathematics.Tests/SageRandomTests.cs
+++ b/src/OpenSage.Mathematics.Tests/SageRandomTests.cs
@@ -2,12 +2,12 @@
 
 namespace OpenSage.Mathematics.Tests;
 
-public class RandomValueTests
+public class SageRandomTests
 {
     [Fact]
     public void CanGenerateRandomIntegers()
     {
-        var random = new RandomValue();
+        var random = new SageRandom();
 
         Assert.Equal(5, random.Next(0, 5));
         Assert.Equal(1, random.Next(0, 5));
@@ -30,7 +30,7 @@ public class RandomValueTests
     [InlineData(-10, 5)]
     public void GeneratesIntegerValuesInRequestedRange(int lo, int hi)
     {
-        var random = new RandomValue();
+        var random = new SageRandom();
         for (var i = 0; i < 1000; i++)
         {
             var value = random.Next(lo, hi);
@@ -41,7 +41,7 @@ public class RandomValueTests
     [Fact]
     public void CanGenerateRandomFloats()
     {
-        var random = new RandomValue();
+        var random = new SageRandom();
 
         Assert.Equal(1.67192996f, random.NextSingle(0, 5));
         Assert.Equal(0.767719746f, random.NextSingle(0, 5));
@@ -57,7 +57,7 @@ public class RandomValueTests
     [InlineData(-1.5f, 3.5f)]
     public void GeneratesFloatValuesInRequestedRange(int lo, int hi)
     {
-        var random = new RandomValue();
+        var random = new SageRandom();
         for (var i = 0; i < 1000; i++)
         {
             var value = random.NextSingle(lo, hi);

--- a/src/OpenSage.Mathematics/FloatRange.cs
+++ b/src/OpenSage.Mathematics/FloatRange.cs
@@ -13,5 +13,5 @@ public readonly struct FloatRange
         High = high;
     }
 
-    public float GetValue(Random random) => (float)(random.NextDouble() * (High - Low) + Low);
+    public float GetValue(RandomValue random) => random.NextSingle(Low, High);
 }

--- a/src/OpenSage.Mathematics/FloatRange.cs
+++ b/src/OpenSage.Mathematics/FloatRange.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace OpenSage.Mathematics;
+﻿namespace OpenSage.Mathematics;
 
 public readonly struct FloatRange
 {
@@ -13,5 +11,5 @@ public readonly struct FloatRange
         High = high;
     }
 
-    public float GetValue(RandomValue random) => random.NextSingle(Low, High);
+    public float GetValue(IRandom random) => random.NextSingle(Low, High);
 }

--- a/src/OpenSage.Mathematics/IRandom.cs
+++ b/src/OpenSage.Mathematics/IRandom.cs
@@ -3,16 +3,55 @@ using System.Runtime.CompilerServices;
 
 namespace OpenSage.Mathematics;
 
-public class RandomValue
+public interface IRandom
+{
+    uint Seed { get; }
+
+    void Initialize(uint seed);
+
+    int Next(int lo, int hi);
+    float NextSingle(float lo, float hi);
+}
+
+public sealed class SystemRandom : IRandom
+{
+    private Random _random;
+
+    public uint Seed => throw new NotImplementedException();
+
+    public SystemRandom()
+    {
+        _random = CreateRandom(0);
+    }
+
+    public void Initialize(uint seed)
+    {
+        _random = CreateRandom((int)seed);
+    }
+
+    private static Random CreateRandom(int seed) => new(seed);
+
+    public int Next(int lo, int hi)
+    {
+        return _random.Next(lo, hi + 1);
+    }
+
+    public float NextSingle(float lo, float hi)
+    {
+        return lo + (hi - lo) * _random.NextSingle();
+    }
+}
+
+public sealed class SageRandom : IRandom
 {
     private static readonly float MultiplicationFactor = 1.0f / (MathF.Pow(2, 8 * sizeof(uint)) - 1.0f);
 
     private readonly uint[] _seed;
     private uint _baseSeed;
 
-    internal uint BaseSeed => _baseSeed;
+    public uint Seed => _baseSeed;
 
-    public RandomValue()
+    public SageRandom()
     {
         _seed = new uint[6];
 
@@ -38,7 +77,7 @@ public class RandomValue
         _seed[5] = ax;
     }
 
-    public virtual int Next(int lo, int hi)
+    public int Next(int lo, int hi)
     {
         var delta = (uint)(hi - lo + 1);
 
@@ -50,7 +89,7 @@ public class RandomValue
         return (int)((GetRandomValue() % delta) + lo);
     }
 
-    public virtual float NextSingle(float lo, float hi)
+    public float NextSingle(float lo, float hi)
     {
         var delta = hi - lo;
 

--- a/src/OpenSage.Mathematics/IRandom.cs
+++ b/src/OpenSage.Mathematics/IRandom.cs
@@ -9,7 +9,36 @@ public interface IRandom
 
     void Initialize(uint seed);
 
+    /// <summary>
+    /// Returns a random integer that is within a specified range.
+    /// </summary>
+    /// <param name="lo">The inclusive lower bound of the random number returned.</param>
+    /// <param name="hi">The inclusive upper bound of the random number returned.
+    /// <paramref name="hi"/> must be greater than or equal to
+    /// <paramref name="lo"/>.</param>
+    /// <returns>
+    /// A 32-bit signed integer greater than or equal to <paramref name="lo"/>
+    /// and less than or equal to <paramref name="hi"/>; that is, the range of
+    /// return values includes both <paramref name="lo"/> and <paramref name="hi"/>.
+    /// If <paramref name="lo"/> equals <paramref name="hi"/>, <paramref name="lo"/>
+    /// is returned.
+    /// </returns>
     int Next(int lo, int hi);
+
+    /// <summary>
+    /// Returns a random floating-point number that is within a specified range.
+    /// </summary>
+    /// <param name="lo">The inclusive lower bound of the random number returned.</param>
+    /// <param name="hi">The inclusive upper bound of the random number returned.
+    /// <paramref name="hi"/> must be greater than or equal to
+    /// <paramref name="lo"/>.</param>
+    /// <returns>
+    /// A 32-bit floating-point number greater than or equal to <paramref name="lo"/>
+    /// and less than or equal to <paramref name="hi"/>; that is, the range of
+    /// return values includes both <paramref name="lo"/> and <paramref name="hi"/>.
+    /// If <paramref name="lo"/> equals <paramref name="hi"/>, <paramref name="lo"/>
+    /// is returned.
+    /// </returns>
     float NextSingle(float lo, float hi);
 }
 

--- a/src/OpenSage.Mathematics/RandomValue.cs
+++ b/src/OpenSage.Mathematics/RandomValue.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace OpenSage.Mathematics;
+
+public class RandomValue
+{
+    private static readonly float MultiplicationFactor = 1.0f / (MathF.Pow(2, 8 * sizeof(uint)) - 1.0f);
+
+    private readonly uint[] _seed;
+    private uint _baseSeed;
+
+    internal uint BaseSeed => _baseSeed;
+
+    public RandomValue()
+    {
+        _seed = new uint[6];
+
+        Initialize(0);
+    }
+
+    public void Initialize(uint seed)
+    {
+        _baseSeed = seed;
+
+        var ax = seed;
+        ax += 0xf22d0e56;
+        _seed[0] = ax;
+        ax += unchecked(0x883126e9 - 0xf22d0e56);
+        _seed[1] = ax;
+        ax += 0xc624dd2f - 0x883126e9;
+        _seed[2] = ax;
+        ax += unchecked(0x0702c49c - 0xc624dd2f);
+        _seed[3] = ax;
+        ax += 0x9e353f7d - 0x0702c49c;
+        _seed[4] = ax;
+        ax += unchecked(0x6fdf3b64 - 0x9e353f7d);
+        _seed[5] = ax;
+    }
+
+    public virtual int Next(int lo, int hi)
+    {
+        var delta = (uint)(hi - lo + 1);
+
+        if (delta == 0)
+        {
+            return hi;
+        }
+
+        return (int)((GetRandomValue() % delta) + lo);
+    }
+
+    public virtual float NextSingle(float lo, float hi)
+    {
+        var delta = hi - lo;
+
+        if (delta <= 0)
+        {
+            return hi;
+        }
+
+        return ((GetRandomValue() * MultiplicationFactor) * delta) + lo;
+    }
+
+    private uint GetRandomValue()
+    {
+        uint ax;
+        uint c = 0;
+
+        Adc(out ax, _seed[5], _seed[4], ref c);
+        _seed[4] = ax;
+
+        Adc(out ax, ax, _seed[3], ref c);
+        _seed[3] = ax;
+
+        Adc(out ax, ax, _seed[2], ref c);
+        _seed[2] = ax;
+
+        Adc(out ax, ax, _seed[1], ref c);
+        _seed[1] = ax;
+
+        Adc(out ax, ax, _seed[0], ref c);
+        _seed[0] = ax;
+
+        // Increment seed array, bubbling up the carries.
+        if (++_seed[5] == 0
+            && ++_seed[4] == 0
+            && ++_seed[3] == 0
+            && ++_seed[2] == 0
+            && ++_seed[1] == 0)
+        {
+            ++_seed[0];
+            ++ax;
+        }
+
+        return ax;
+    }
+
+    /// <summary>
+    /// Add with carry. <paramref name="sum"/> is replaced with <paramref name="a"/> +
+    /// <paramref name="b"/> + <paramref name="c"/>. <paramref name="c"/> is replaced with
+    /// 1 if there was a carry, 0 if there wasn't. A carry occurred if the sum is less
+    /// than one of the inputs. This is addition, so carry can never be more than 1.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Adc(out uint sum, uint a, uint b, ref uint c)
+    {
+        sum = a + b + c;
+        c = (sum < a || sum < b)
+            ? 1u
+            : 0u;
+    }
+}


### PR DESCRIPTION
I've ported `RandomValue.cpp` from the original game, but I'm not tied to it. We may want to switch back to `System.Random` as the underlying generator, if we're not aiming for bit-level compatibility with the original game.

The main change here is to have a clean split between client and logic random values.