### PR TITLE
Ignore changes from reformat PR in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# The big reformat (PR #1298)
+a64af4c95254bf2d2e5224f5558a8d5a67426cb4
+72ec78b946a7e0f4f492c99a1c8a8bd95e92f4f4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "gitlens.advanced.blame.customArguments": [
+    "--ignore-revs-file .git-blame-ignore-revs"
+  ]
+}


### PR DESCRIPTION
Based on instructions from https://www.stefanjudis.com/today-i-learned/how-to-exclude-commits-from-git-blame/

- Add `.git-blame-ignore-revs` file to make `git blame` more usable after #1298
  - After we switched to file-scoped namespaces, almost every line in every file was pointing to that commit.
  - [GitHub recognizes this file and automatically uses it for blame](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view)
  - However, git doesn't use this file automatically and from what I've gathered there's no way to configure it to be enabled by default. You might need to explicitly enable the file with `git config blame.ignoreRevsFile .git-blame-ignore-revs`
- Add workspace VS Code config to use `.git-blame-ignore-revs` with [GitLens extension](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens).
  - While GitLens isn't an official part of VS Code, it's in the top 20 most popular extensions of all time.
