### PR TITLE
Port ExperienceTracker & related code

### DIFF
--- a/src/OpenSage.Game/Logic/AI/AIStates/HackInternetAIUpdate/HackInternetState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/HackInternetAIUpdate/HackInternetState.cs
@@ -43,7 +43,7 @@ internal sealed class HackInternetState : State
 
             GameObject.ActiveCashEvent = new CashEvent(amount, new ColorRgb(0, 255, 0), new Vector3(0, 0, 20));
 
-            GameObject.GainExperience(_stateMachine.AIUpdate.ModuleData.XpPerCashUpdate);
+            GameObject.ExperienceTracker.AddExperiencePoints(_stateMachine.AIUpdate.ModuleData.XpPerCashUpdate);
         }
 
         return UpdateStateResult.Continue();
@@ -63,10 +63,10 @@ internal sealed class HackInternetState : State
 
     private int GetCashGrant(GameObject gameObject) => gameObject.Rank switch
     {
-        0 => _stateMachine.AIUpdate.ModuleData.RegularCashAmount,
-        1 => _stateMachine.AIUpdate.ModuleData.VeteranCashAmount,
-        2 => _stateMachine.AIUpdate.ModuleData.EliteCashAmount,
-        3 => _stateMachine.AIUpdate.ModuleData.HeroicCashAmount,
+        VeterancyLevel.Regular => _stateMachine.AIUpdate.ModuleData.RegularCashAmount,
+        VeterancyLevel.Veteran => _stateMachine.AIUpdate.ModuleData.VeteranCashAmount,
+        VeterancyLevel.Elite => _stateMachine.AIUpdate.ModuleData.EliteCashAmount,
+        VeterancyLevel.Heroic => _stateMachine.AIUpdate.ModuleData.HeroicCashAmount,
         _ => throw new ArgumentOutOfRangeException(nameof(GameObject.Rank)),
     };
 

--- a/src/OpenSage.Game/Logic/CrateData.cs
+++ b/src/OpenSage.Game/Logic/CrateData.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.Logic.Object;
-using OpenSage.Mathematics;
 
 namespace OpenSage.Logic;
 
@@ -56,21 +55,6 @@ public sealed class CrateData : BaseAsset
     /// Different crates which may be created if all conditions succeed.
     /// </summary>
     public List<CrateObject> CrateObjects { get; } = [];
-}
-
-public enum VeterancyLevel
-{
-    [IniEnum("REGULAR")]
-    Regular,
-
-    [IniEnum("VETERAN")]
-    Veteran,
-
-    [IniEnum("ELITE")]
-    Elite,
-
-    [IniEnum("HEROIC")]
-    Heroic,
 }
 
 public readonly record struct CrateObject(LazyAssetReference<ObjectDefinition>? Object, float Probability)

--- a/src/OpenSage.Game/Logic/Object/Create/ExperienceLevelCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/ExperienceLevelCreate.cs
@@ -15,7 +15,8 @@ internal sealed class ExperienceLevelCreateBehavior : CreateModule
 
     public override void OnCreate()
     {
-        GameObject.Rank = _moduleData.LevelToGrant;
+        // TODO: This is unlikely to be correct?
+        GameObject.Rank = (VeterancyLevel)_moduleData.LevelToGrant;
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Create/VeterancyGainCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/VeterancyGainCreate.cs
@@ -30,7 +30,7 @@ public sealed class VeterancyGainCreate : CreateModule
         }
 
         // units like the minigunner or tank battlemaster can start at vet 1 and be upgraded to vet 2, and so have two VeterancyGainCreate modules
-        var level = (int)_moduleData.StartingLevel;
+        var level = _moduleData.StartingLevel;
         if (level > GameObject.Rank)
         {
             GameObject.Rank = level;

--- a/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
@@ -55,7 +55,7 @@ public sealed class CreateCrateDie : DieModule
 
         return (!crateData.KilledByType.HasValue || killer.Definition.KindOf.Get(crateData.KilledByType.Value)) && // killer type ok
                killer.Team != GameObject.Team && // we can't generate our own salvage
-               (crateData.VeterancyLevel is not { } v || v != GameObject.VeterancyHelper.VeterancyLevel) && // killer meets veterancy requirements
+               (crateData.VeterancyLevel is not { } v || v != GameObject.ExperienceTracker.VeterancyLevel) && // killer meets veterancy requirements
                (crateData.KillerScience is null || killer.Owner.HasScience(crateData.KillerScience.Value)); // killer owner meets science requirements
     }
 

--- a/src/OpenSage.Game/Logic/Object/ExperienceTracker.cs
+++ b/src/OpenSage.Game/Logic/Object/ExperienceTracker.cs
@@ -1,0 +1,257 @@
+﻿#nullable enable
+
+namespace OpenSage.Logic.Object;
+
+public class ExperienceTracker(GameObject parent, GameEngine engine) : IPersistableObject
+{
+    private readonly GameEngine _engine = engine;
+
+    /// <summary>
+    /// Object I am owned by.
+    /// </summary>
+    private readonly GameObject _parent = parent;
+
+    /// <summary>
+    /// Level of experience.
+    /// </summary>
+    private VeterancyLevel _currentLevel = VeterancyLevel.Regular;
+
+    // TODO: Generals used two different names for the same thing (m_currentLevel and getVeterancyLevel).
+    // We could unify them.
+
+    /// <summary>
+    /// What level am I?
+    /// </summary>
+    public VeterancyLevel VeterancyLevel => _currentLevel;
+
+    private int _currentExperience;
+    /// <summary>
+    /// Number of experience points.
+    /// </summary>
+    public int CurrentExperience => _currentExperience;
+
+    private ObjectId _experienceSink;
+    /// <summary>
+    /// ID of object I have pledged my experience point gains to.
+    /// This is used by objects like missiles which grant the experience to the vehicle that fired them.
+    /// </summary>
+    public ObjectId ExperienceSink
+    {
+        get => _experienceSink;
+        set => _experienceSink = value;
+    }
+
+    private float _experienceScalar = 1.0f;
+    /// <summary>
+    /// Scales any experience gained by this multiplier.
+    /// </summary>
+    public float ExperienceScalar
+    {
+        get => _experienceScalar;
+        set => _experienceScalar = value;
+    }
+
+    /// <summary>
+    /// Can I gain experience?
+    /// </summary>
+    public bool IsTrainable => _parent.Definition.IsTrainable;
+
+    /// <summary>
+    /// Either I am trainable, or I have a sink set up.
+    /// </summary>
+    public bool IsAcceptingExperiencePoints => IsTrainable || ExperienceSink.IsValid;
+
+    public int? ExperienceRequiredForNextLevel
+    {
+        get
+        {
+            if (_currentLevel == VeterancyLevel.Last)
+            {
+                return null;
+            }
+
+            return _parent.Definition.ExperienceRequired[_currentLevel + 1];
+        }
+    }
+
+    public int GetExperienceValue(GameObject killer)
+    {
+        if (killer.GetRelationship(_parent) == RelationshipType.Allies)
+        {
+            // Friendly fire does not give experience.
+            return 0;
+        }
+
+        return _parent.Definition.ExperienceValue[_currentLevel];
+    }
+
+    // TODO: This is not how Generals actually does this.
+    // This is a temporary hack until we rewrite / refactor Scene25D.
+    public bool ShowRankUpAnimation { get; set; } = false;
+
+    private void OnVeterancyLevelChanged(VeterancyLevel oldLevel, VeterancyLevel newLevel, bool provideFeedback = true)
+    {
+        _parent.OnVeterancyLevelChanged(oldLevel, newLevel, provideFeedback);
+        ShowRankUpAnimation = true;
+    }
+
+    /// <summary>
+    /// Set the veterancy level to this level.
+    /// If we've already at this exact level, do nothing.
+    /// </summary>
+    public void SetVeterancyLevel(VeterancyLevel newLevel, bool provideFeedback = true)
+    {
+        if (newLevel == _currentLevel)
+        {
+            return;
+        }
+
+        var oldLevel = _currentLevel;
+        _currentLevel = newLevel;
+        _currentExperience = _parent.Definition.ExperienceRequired[_currentLevel];
+        // Original code checks if parent is null here, but I don't think it can ever be null
+        OnVeterancyLevelChanged(oldLevel, newLevel, provideFeedback);
+    }
+
+    /// <summary>
+    /// Set veterancy level to at least this level.
+    /// If we've already reached or exceeded this level, do nothing.
+    /// </summary>
+    public void SetMinVeterancyLevel(VeterancyLevel newLevel)
+    {
+        if (newLevel <= _currentLevel)
+        {
+            return;
+        }
+
+        var oldLevel = _currentLevel;
+        _currentExperience = _parent.Definition.ExperienceRequired[_currentLevel];
+        // Original code checks if parent is null here, but I don't think it can ever be null
+        OnVeterancyLevelChanged(oldLevel, newLevel);
+    }
+
+    public void AddExperiencePoints(int experienceGain, bool canScaleForBonus = true)
+    {
+        if (ExperienceSink.IsValid)
+        {
+            // I have been set up to give my experience to someone else
+            var sinkObject = _engine.Scene3D.GameObjects.GetObjectById(ExperienceSink);
+
+            if (sinkObject != null)
+            {
+                sinkObject.ExperienceTracker.AddExperiencePoints((int)(experienceGain * ExperienceScalar), canScaleForBonus);
+                return;
+            }
+        }
+
+        if (!IsTrainable)
+        {
+            // If we're not trainable, no points are given.
+            return;
+        }
+
+        var oldLevel = _currentLevel;
+        var amountToGain = experienceGain;
+        if (canScaleForBonus)
+        {
+            amountToGain = (int)(amountToGain * ExperienceScalar);
+        }
+
+        _currentExperience += amountToGain;
+
+        var levelIndex = 0;
+
+        // While we can gain more levels and we have enough experience to gain the next level...
+        while (((levelIndex + 1) < (int)VeterancyLevel.Count) && _currentExperience >= _parent.Definition.ExperienceRequired[(VeterancyLevel)(levelIndex + 1)])
+        {
+            levelIndex++;
+        }
+
+        _currentLevel = (VeterancyLevel)levelIndex;
+
+        // If this experience gain resulted in a level up, notify the parent object.
+        if (oldLevel != _currentLevel)
+        {
+            OnVeterancyLevelChanged(oldLevel, _currentLevel);
+        }
+    }
+
+    public bool GainExpForLevel(int levelsToGain, bool canScaleForBonus = true)
+    {
+        var newLevel = _currentLevel + levelsToGain;
+
+        if (newLevel > VeterancyLevel.Last)
+        {
+            newLevel = VeterancyLevel.Last;
+        }
+
+        if (newLevel > _currentLevel)
+        {
+            var experienceNeeded = _parent.Definition.ExperienceRequired[newLevel] - _currentExperience;
+            AddExperiencePoints(experienceNeeded, canScaleForBonus);
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool CanGainExpForLevel(int levelsToGain)
+    {
+        var newLevel = _currentLevel + levelsToGain;
+
+        if (newLevel > VeterancyLevel.Last)
+        {
+            newLevel = VeterancyLevel.Last;
+        }
+
+        return newLevel > _currentLevel;
+    }
+
+    // TODO: This is like 95% identical to AddExperiencePoints.
+    public void SetExperienceAndLevel(int experienceIn, bool provideFeedback = true)
+    {
+        if (ExperienceSink.IsValid)
+        {
+            var sinkObject = _engine.Scene3D.GameObjects.GetObjectById(ExperienceSink);
+
+            if (sinkObject != null)
+            {
+                sinkObject.ExperienceTracker.SetExperienceAndLevel(experienceIn, provideFeedback);
+                return;
+            }
+        }
+
+        if (!IsTrainable)
+        {
+            return;
+        }
+
+        var oldLevel = _currentLevel;
+        _currentExperience = experienceIn;
+
+        var levelIndex = 0;
+        while (((levelIndex + 1) < (int)VeterancyLevel.Count) && _currentExperience >= _parent.Definition.ExperienceRequired[(VeterancyLevel)(levelIndex + 1)])
+        {
+            levelIndex++;
+        }
+
+        _currentLevel = (VeterancyLevel)levelIndex;
+
+        if (oldLevel != _currentLevel)
+        {
+            OnVeterancyLevelChanged(oldLevel, _currentLevel, provideFeedback);
+            // Comment from original code: "paradox! this may be a level lost!"
+            // What does that mean?
+        }
+    }
+
+    public void Persist(StatePersister persister)
+    {
+        persister.PersistVersion(1);
+
+        persister.PersistEnum(ref _currentLevel);
+        persister.PersistInt32(ref _currentExperience);
+        persister.PersistObjectId(ref _experienceSink);
+        persister.PersistSingle(ref _experienceScalar);
+    }
+}

--- a/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
@@ -45,7 +45,7 @@ internal sealed class AutoDepositUpdate : UpdateModule
             GameObject.Owner.BankAccount.Deposit(amount);
             if (!_moduleData.GiveNoXP)
             {
-                GameObject.GainExperience((int)amount);
+                GameObject.ExperienceTracker.AddExperiencePoints((int)amount);
             }
         }
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
@@ -23,9 +23,9 @@ public class ExperienceUpdate : UpdateModule
     private void Initialize(BehaviorUpdateContext context)
     {
         // not sure why the required experience for rank 1 is 1 instead of 0
-        if (GameObject.ExperienceValue == 0)
+        if (GameObject.ExperienceTracker.CurrentExperience == 0)
         {
-            GameObject.ExperienceValue = 1;
+            GameObject.ExperienceTracker.SetExperienceAndLevel(1);
         }
 
         _experienceLevels = FindRelevantExperienceLevels(context);
@@ -35,7 +35,7 @@ public class ExperienceUpdate : UpdateModule
             GameObject.ExperienceRequiredForNextLevel = _nextLevel.RequiredExperience;
             ObjectGainsExperience = true;
 
-            while (GameObject.Rank >= _nextLevel.Rank)
+            while ((int)GameObject.Rank >= _nextLevel.Rank)
             {
                 levelUp();
             }
@@ -53,7 +53,7 @@ public class ExperienceUpdate : UpdateModule
         }
 
         if (_experienceLevels == null || _experienceLevels.Count == 0
-            || GameObject.ExperienceValue < _nextLevel.RequiredExperience)
+            || GameObject.ExperienceTracker.CurrentExperience < _nextLevel.RequiredExperience)
         {
             return;
         }
@@ -66,8 +66,7 @@ public class ExperienceUpdate : UpdateModule
                 context.GameEngine));
         }
 
-        GameObject.ExperienceValue -= _nextLevel.RequiredExperience;
-        GameObject.Rank = _nextLevel.Rank; GameObject.Rank = _nextLevel.Rank;
+        GameObject.ExperienceTracker.SetVeterancyLevel((VeterancyLevel)_nextLevel.Rank, false);
 
         levelUp();
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -356,7 +356,7 @@ public sealed class ProductionUpdate : UpdateModule
 
         if (!_moduleData.GiveNoXP)
         {
-            GameObject.GainExperience((int)producedUnit.Definition.BuildCost);
+            GameObject.ExperienceTracker.AddExperiencePoints((int)producedUnit.Definition.BuildCost);
         }
 
         var isHorde = producedUnit.Definition.KindOf.Get(ObjectKinds.Horde);

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ExperienceScalarUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ExperienceScalarUpgrade.cs
@@ -14,7 +14,7 @@ internal sealed class ExperienceScalarUpgrade : UpgradeModule
 
     protected override void OnUpgrade()
     {
-        GameObject.VeterancyHelper.ExperienceScalar += _moduleData.AddXPScalar;
+        GameObject.ExperienceTracker.ExperienceScalar += _moduleData.AddXPScalar;
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/VeterancyLevel.cs
+++ b/src/OpenSage.Game/Logic/Object/VeterancyLevel.cs
@@ -1,0 +1,24 @@
+﻿
+using OpenSage.Data.Ini;
+
+namespace OpenSage.Logic.Object;
+
+public enum VeterancyLevel
+{
+    [IniEnum("REGULAR")]
+    Regular,
+
+    [IniEnum("VETERAN")]
+    Veteran,
+
+    [IniEnum("ELITE")]
+    Elite,
+
+    [IniEnum("HEROIC")]
+    Heroic,
+
+    Count,
+
+    First = Regular,
+    Last = Heroic
+}

--- a/src/OpenSage.Game/Logic/Object/VeterancyValues.cs
+++ b/src/OpenSage.Game/Logic/Object/VeterancyValues.cs
@@ -22,4 +22,6 @@ public sealed class VeterancyValues
     }
 
     public int[] Values { get; private set; }
+
+    public int this[VeterancyLevel level] => Values[(int)level];
 }

--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -801,6 +801,29 @@ public class Player : IPersistableObject
         _searchAndDestroyActive = false;
         _strategyData?.ClearBattlePlan();
     }
+
+    public RelationshipType GetRelationship(Team? that)
+    {
+        if (that == null)
+        {
+            return RelationshipType.Neutral;
+        }
+
+        // Check team override
+        if (_playerToTeamRelationships.TryGetValue(that.Id, out var relationship))
+        {
+            return relationship;
+        }
+
+        // Check player override
+        if (_playerToPlayerRelationships.TryGetValue(that.ControllingPlayer.Id, out relationship))
+        {
+            return relationship;
+        }
+
+        // Default to neutral
+        return RelationshipType.Neutral;
+    }
 }
 
 public sealed class SupplyManager : IPersistableObject
@@ -938,6 +961,11 @@ public enum RelationshipType : uint
 public sealed class PlayerRelationships : IPersistableObject
 {
     private readonly Dictionary<uint, RelationshipType> _store = new();
+
+    public bool TryGetValue(uint playerOrTeamid, out RelationshipType relationship)
+    {
+        return _store.TryGetValue(playerOrTeamid, out relationship);
+    }
 
     public void Persist(StatePersister reader)
     {

--- a/src/OpenSage.Game/Logic/Team.cs
+++ b/src/OpenSage.Game/Logic/Team.cs
@@ -27,6 +27,26 @@ public sealed class Team : IPersistableObject
         Id = id;
     }
 
+    public Player ControllingPlayer => Template.Owner;
+
+    public RelationshipType GetRelationship(Team that)
+    {
+        // Check team override
+        if (TeamToTeamRelationships.TryGetValue(that.Id, out var relationship))
+        {
+            return relationship;
+        }
+
+        // Check player override
+        if (TeamToPlayerRelationships.TryGetValue(ControllingPlayer.Id, out relationship))
+        {
+            return relationship;
+        }
+
+        // Otherwise use player's personal relationship
+        return ControllingPlayer.GetRelationship(that);
+    }
+
     public void Persist(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Scene25D.cs
+++ b/src/OpenSage.Game/Scene25D.cs
@@ -211,7 +211,7 @@ public class Scene25D(Scene3D scene3D, AssetStore assetStore)
             DrawBar(
                 experienceBoxRect,
                 new ColorRgba(255, 255, 0, 255).ToColorRgbaF(),
-                gameObject.ExperienceValue / (float)gameObject.ExperienceRequiredForNextLevel);
+                gameObject.ExperienceTracker.CurrentExperience / (float)gameObject.ExperienceTracker.ExperienceRequiredForNextLevel);
         }
     }
 

--- a/src/OpenSage.Mods.Generals/GeneralsScene25D.cs
+++ b/src/OpenSage.Mods.Generals/GeneralsScene25D.cs
@@ -75,11 +75,10 @@ public class GeneralsScene25D(Scene3D scene3D, AssetStore assetStore) : Scene25D
             gameObject.ActiveCashEvent = null;
         }
 
-        if (gameObject.VeterancyHelper.ShowRankUpAnimation)
+        if (gameObject.ExperienceTracker.ShowRankUpAnimation)
         {
             TransientAnimations.Enqueue(new RankUpAnimation(Camera, GameEngine.LogicFramesPerSecond, currentFrame, GameData, new Animation(LevelUpAnimation, GameEngine.LogicFramesPerSecond), gameObject.Translation with { Z = gameObject.Translation.Z + 20 }));
-
-            gameObject.VeterancyHelper.ShowRankUpAnimation = false;
+            gameObject.ExperienceTracker.ShowRankUpAnimation = false;
         }
     }
 
@@ -87,9 +86,9 @@ public class GeneralsScene25D(Scene3D scene3D, AssetStore assetStore) : Scene25D
     {
         var mappedImage = gameObject.Rank switch
         {
-            1 => _veteranPip,
-            2 => _elitePip,
-            3 => _heroicPip,
+            VeterancyLevel.Veteran => _veteranPip,
+            VeterancyLevel.Elite => _elitePip,
+            VeterancyLevel.Heroic => _heroicPip,
             _ => throw new ArgumentOutOfRangeException(nameof(gameObject.Rank), gameObject.Rank, "Rank not supported"),
         };
 

--- a/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
+++ b/src/OpenSage.Mods.Generals/Gui/GeneralsControlBar.cs
@@ -299,24 +299,24 @@ public sealed class GeneralsControlBar : IControlBar
 
         private static NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
-        protected Image? RankOverlayLarge(GeneralsControlBar controlBar, int rank)
+        protected Image? RankOverlayLarge(GeneralsControlBar controlBar, VeterancyLevel rank)
         {
             return rank switch
             {
-                1 => controlBar.Rank1OverlayLarge,
-                2 => controlBar.Rank2OverlayLarge,
-                3 => controlBar.Rank3OverlayLarge,
+                VeterancyLevel.Veteran => controlBar.Rank1OverlayLarge,
+                VeterancyLevel.Elite => controlBar.Rank2OverlayLarge,
+                VeterancyLevel.Heroic => controlBar.Rank3OverlayLarge,
                 _ => null,
             };
         }
 
-        protected Image? RankOverlaySmall(GeneralsControlBar controlBar, int rank)
+        protected Image? RankOverlaySmall(GeneralsControlBar controlBar, VeterancyLevel rank)
         {
             return rank switch
             {
-                1 => controlBar.Rank1OverlaySmall,
-                2 => controlBar.Rank2OverlaySmall,
-                3 => controlBar.Rank3OverlaySmall,
+                VeterancyLevel.Veteran => controlBar.Rank1OverlaySmall,
+                VeterancyLevel.Elite => controlBar.Rank2OverlaySmall,
+                VeterancyLevel.Heroic => controlBar.Rank3OverlaySmall,
                 _ => null,
             };
         }
@@ -401,7 +401,7 @@ public sealed class GeneralsControlBar : IControlBar
                 .FirstOrDefault(d => d.ScienceRequired == null || player.HasScience(d.ScienceRequired.Value)) // take the first one that actively applies
                 ?.StartingLevel ?? VeterancyLevel.Regular; // or default to regular if there isn't one
 
-            return RankOverlaySmall(controlBar, (int)startingVeterancy);
+            return RankOverlaySmall(controlBar, startingVeterancy);
         }
 
         protected void ApplyCommandSet(Player player, GameObject selectedUnit, GeneralsControlBar controlBar, CommandSet commandSet)


### PR DESCRIPTION
Resolves #1268.

Replaces `VeterancyHelper` with `ExperienceTracker`, ported from the [original C++ class](https://github.com/electronicarts/CnC_Generals_Zero_Hour/blob/main/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ExperienceTracker.cpp). Also includes some other related code I had to port, such as player / team relationship logic.