### PR TITLE
Port Money.cpp / BankAccount and (some of) AcademyStats.cpp

### DIFF
--- a/src/OpenSage.Game/Logic/AcademyStats.cs
+++ b/src/OpenSage.Game/Logic/AcademyStats.cs
@@ -1,0 +1,224 @@
+﻿using OpenSage.Logic.Object;
+
+namespace OpenSage.Logic;
+
+// TODO(Port): Add stats collection methods as needed.
+public sealed class AcademyStats(IGame game) : IPersistableObject
+{
+    private readonly IGame _game = game;
+
+    private uint _nextUpdateFrame;
+    private bool _firstUpdate;
+    private bool _unknownSide;
+
+    // Tier 1 (Basic advice)
+
+    // Did player run out of money before building a supply center?
+    private bool _spentCashBeforeBuildingSupplyCenter;
+    private uint _supplyCentersBuilt;
+    private ObjectDefinition _supplyCenterTemplate;
+    uint _supplyCenterCost;
+
+    // Did player build radar (if applicable)?
+    private bool _researchedRadar;
+
+    // Did player build any dozers/workers?
+    private uint _peonsBuilt;
+
+    // Did player ever capture a structure?
+    private uint _structuresCaptured;
+
+    // Did player spend any generals points?
+    private uint _generalsPointsSpent;
+
+    // Did player ever use a generals power or superweapon?
+    private uint _specialPowersUsed;
+
+    // Did player garrison any structures?
+    private uint _structuresGarrisoned;
+
+    // How idle was the player in building military units?
+    private uint _idleBuildingUnitsMaxFrames;
+    private uint _lastUnitBuiltFrame;
+
+    // Did player drag select units?
+    private uint _dragSelectUnits;
+
+    // Did player upgrade anything?
+    private uint _upgradesPurchased;
+
+    // Was player out of power for more than 10 minutes?
+    private uint _powerOutMaxFrames;
+    private uint _oldestPowerOutFrame;
+    private bool _hadPowerLastCheck;
+
+    // Extra gathers built?
+    private uint _gatherersBuilt;
+
+    // Heros built?
+    private uint _heroesBuilt;
+
+    // Tier 2 (Intermediate advice)
+
+    // Selected a strategy center battle plan?
+    private bool _hadAStrategyCenter;
+    private bool _choseAStrategyForCenter;
+
+    // Placed units inside tunnel network?
+    private uint _unitsEnteredTunnelNetwork;
+    private bool _hadATunnelNetwork;
+
+    // Player used control groups?
+    private uint _controlGroupsUsed;
+
+    // Built secondary income unit (hacker, dropzone, blackmarket)?
+    private uint _secondaryIncomeUnitsBuilt;
+
+    // Cleared out garrisoned buildings?
+    private uint _clearedGarrisonedBuildings;
+
+    // Did the Player pick up salvage (as GLA)?
+    private uint _salvageCollected;
+
+    // Did the player ever use the "Guard" ability?
+    private uint _guardAbilityUsedCount;
+
+    // Tier 3 (Advanced advice)
+
+    // Player did not use the new "double click location attack move/guard"
+    private uint _doubleClickAttackMoveOrdersGiven;
+
+    // Built barracks within 5 minutes?
+    private bool _builtBarracksWithinFiveMinutes;
+
+    // Built war factory within 10 minutes?
+    private bool _builtWarFactoryWithinTenMinutes;
+
+    // Built tech structure within 15 minutes?
+    private bool _builtTechStructureWithinFifteenMinutes;
+
+    // No income for 2 minutes?
+    private LogicFrame _lastIncomeFrame;
+    private LogicFrameSpan _maxFramesBetweenIncome;
+
+    // Did the Player ever use Dozers/Workers to clear out traps/mines/booby traps?
+    private uint _mines;
+    private uint _minesCleared;
+
+    // Captured any sniped vehicles?
+    private uint _vehiclesRecovered;
+    private uint _vehiclesSniped;
+
+    // Did the player ever build a "disguisable" unit and never used the disguise ability?
+    private uint _disguisableVehiclesBuilt;
+    private uint _vehiclesDisguised;
+
+    // Did the player ever create a "Firestorm" with his MiGs or Inferno Cannons?
+    private uint _firestormsCreated;
+
+    public void RecordIncome()
+    {
+        var now = _game.GameLogic.CurrentFrame;
+        // Port note: ZH has a bug here, which I've decided to fix.
+        // In ZH the subtraction is done in the wrong order, which is made worse by integer underflow.
+        var delta = new LogicFrameSpan(now.Value - _lastIncomeFrame.Value);
+        _maxFramesBetweenIncome = LogicFrameSpan.Max(_maxFramesBetweenIncome, delta);
+        _lastIncomeFrame = now;
+    }
+
+    public void RecordClearedGarrisonedBuilding()
+    {
+        _clearedGarrisonedBuildings++;
+    }
+    public void RecordVehicleSniped()
+    {
+        _vehiclesSniped++;
+    }
+
+    // TOOD: After porting this I realised that this doesn't seem to be used anywhere in ZH?
+    // Which means your stats will be reset every time you save & load a game.
+    // We could add this to the savefile, but we'd have to increment the version of the Player xfer format.
+    public void Persist(StatePersister persister)
+    {
+        persister.PersistVersion(1);
+
+        persister.PersistUInt32(ref _nextUpdateFrame);
+        persister.PersistBoolean(ref _firstUpdate);
+        persister.PersistBoolean(ref _unknownSide);
+
+        // Tier 1
+
+        persister.PersistBoolean(ref _spentCashBeforeBuildingSupplyCenter);
+        persister.PersistUInt32(ref _supplyCentersBuilt);
+        persister.PersistUInt32(ref _supplyCenterCost);
+
+        persister.PersistBoolean(ref _researchedRadar);
+
+        persister.PersistUInt32(ref _peonsBuilt);
+
+        persister.PersistUInt32(ref _structuresCaptured);
+
+        persister.PersistUInt32(ref _generalsPointsSpent);
+
+        persister.PersistUInt32(ref _specialPowersUsed);
+
+        persister.PersistUInt32(ref _structuresGarrisoned);
+
+        persister.PersistUInt32(ref _idleBuildingUnitsMaxFrames);
+        persister.PersistUInt32(ref _lastUnitBuiltFrame);
+
+        persister.PersistUInt32(ref _dragSelectUnits);
+
+        persister.PersistUInt32(ref _upgradesPurchased);
+
+        persister.PersistUInt32(ref _powerOutMaxFrames);
+        persister.PersistUInt32(ref _oldestPowerOutFrame);
+        persister.PersistBoolean(ref _hadPowerLastCheck);
+
+        persister.PersistUInt32(ref _gatherersBuilt);
+
+        persister.PersistUInt32(ref _heroesBuilt);
+
+        // Tier 2
+
+        persister.PersistBoolean(ref _hadAStrategyCenter);
+        persister.PersistBoolean(ref _choseAStrategyForCenter);
+
+        persister.PersistUInt32(ref _unitsEnteredTunnelNetwork);
+        persister.PersistBoolean(ref _hadATunnelNetwork);
+
+        persister.PersistUInt32(ref _controlGroupsUsed);
+
+        persister.PersistUInt32(ref _secondaryIncomeUnitsBuilt);
+
+        persister.PersistUInt32(ref _clearedGarrisonedBuildings);
+
+        persister.PersistUInt32(ref _salvageCollected);
+
+        persister.PersistUInt32(ref _guardAbilityUsedCount);
+
+        // Tier 3
+
+        persister.PersistUInt32(ref _doubleClickAttackMoveOrdersGiven);
+
+        persister.PersistBoolean(ref _builtBarracksWithinFiveMinutes);
+
+        persister.PersistBoolean(ref _builtWarFactoryWithinTenMinutes);
+
+        persister.PersistBoolean(ref _builtTechStructureWithinFifteenMinutes);
+
+        persister.PersistLogicFrame(ref _lastIncomeFrame);
+        persister.PersistLogicFrameSpan(ref _maxFramesBetweenIncome);
+
+        persister.PersistUInt32(ref _mines);
+        persister.PersistUInt32(ref _minesCleared);
+
+        persister.PersistUInt32(ref _vehiclesRecovered);
+        persister.PersistUInt32(ref _vehiclesSniped);
+
+        persister.PersistUInt32(ref _disguisableVehiclesBuilt);
+        persister.PersistUInt32(ref _vehiclesDisguised);
+
+        persister.PersistUInt32(ref _firestormsCreated);
+    }
+}

--- a/src/OpenSage.Game/Logic/AcademyStats.cs
+++ b/src/OpenSage.Game/Logic/AcademyStats.cs
@@ -7,7 +7,7 @@ public sealed class AcademyStats(IGame game) : IPersistableObject
 {
     private readonly IGame _game = game;
 
-    private uint _nextUpdateFrame;
+    private LogicFrame _nextUpdateFrame;
     private bool _firstUpdate;
     private bool _unknownSide;
 
@@ -17,7 +17,7 @@ public sealed class AcademyStats(IGame game) : IPersistableObject
     private bool _spentCashBeforeBuildingSupplyCenter;
     private uint _supplyCentersBuilt;
     private ObjectDefinition _supplyCenterTemplate;
-    uint _supplyCenterCost;
+    private uint _supplyCenterCost;
 
     // Did player build radar (if applicable)?
     private bool _researchedRadar;
@@ -142,7 +142,7 @@ public sealed class AcademyStats(IGame game) : IPersistableObject
     {
         persister.PersistVersion(1);
 
-        persister.PersistUInt32(ref _nextUpdateFrame);
+        persister.PersistLogicFrame(ref _nextUpdateFrame);
         persister.PersistBoolean(ref _firstUpdate);
         persister.PersistBoolean(ref _unknownSide);
 

--- a/src/OpenSage.Game/Logic/BankAccount.cs
+++ b/src/OpenSage.Game/Logic/BankAccount.cs
@@ -1,0 +1,68 @@
+﻿#nullable enable
+
+using System;
+
+namespace OpenSage.Logic;
+
+// Equivalent to the Money class in Generals
+// We can't name this class Money since it would conflict with the Money field
+public sealed class BankAccount(IGame game, uint playerIndex) : IPersistableObject
+{
+    public uint PlayerIndex { get; set; } = playerIndex;
+
+    public uint Money;
+
+    /// <summary>
+    /// Withdraws the specified amount of money from the bank account.
+    /// If the amount is greater than the current balance, it withdraws the entire balance.
+    /// </summary>
+    /// <param name="amountToWithdraw">Returns how much money was actually withdrawn.</param>
+    /// <param name="playSound">Should this play a sound?</param>
+    /// <returns></returns>
+    public uint Withdraw(uint amountToWithdraw, bool playSound = true)
+    {
+        amountToWithdraw = Math.Min(amountToWithdraw, Money);
+
+        if (amountToWithdraw == 0)
+        {
+            return 0;
+        }
+
+        if (playSound)
+        {
+            game.Audio.PlayAudioEvent(game.AssetStore.MiscAudio.Current.MoneyWithdrawSound.Value);
+            // TODO(Port): Attach player index to the sound event (so that only the owner or replay observer hears it)
+        }
+
+        Money -= amountToWithdraw;
+        return amountToWithdraw;
+    }
+
+    public void Deposit(uint amountToDeposit, bool playSound = true)
+    {
+        if (amountToDeposit == 0)
+        {
+            return;
+        }
+
+        if (playSound)
+        {
+            game.Audio.PlayAudioEvent(game.AssetStore.MiscAudio.Current.MoneyDepositSound.Value);
+            // TODO(Port): Attach player index to the sound event (so that only the owner or replay observer hears it)
+        }
+
+        Money += amountToDeposit;
+
+        if (amountToDeposit > 0)
+        {
+            game.PlayerManager.GetPlayerByIndex(PlayerIndex).AcademyStats.RecordIncome();
+        }
+    }
+
+    public void Persist(StatePersister reader)
+    {
+        reader.PersistVersion(1);
+
+        reader.PersistUInt32(ref Money);
+    }
+}

--- a/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
+++ b/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
@@ -228,6 +228,11 @@ public readonly struct LogicFrameSpan
         return left.Value <= right.Value;
     }
 
+    public static LogicFrameSpan Max(in LogicFrameSpan a, in LogicFrameSpan b)
+    {
+        return new LogicFrameSpan(Math.Max(a.Value, b.Value));
+    }
+
     public override bool Equals(object obj)
     {
         return obj is LogicFrameSpan logicFrameSpan && Equals(logicFrameSpan);

--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -1296,10 +1296,3 @@ public sealed class StrategyData : IPersistableObject
         persister.PersistBitArray(ref _invalidMemberKindOf);
     }
 }
-
-// TODO(Port): Port this.
-public sealed class AcademyStats
-{
-    public void RecordClearedGarrisonedBuilding() { }
-    public void RecordVehicleSniped() { }
-}

--- a/src/OpenSage.Game/Logic/Player.cs
+++ b/src/OpenSage.Game/Logic/Player.cs
@@ -83,7 +83,7 @@ public class Player : IPersistableObject
 
     public AIPlayer? AIPlayer { get; private set; }
 
-    public AcademyStats AcademyStats { get; } = new AcademyStats();
+    public AcademyStats AcademyStats { get; }
 
     // TODO(Port): Implement this.
     public bool IsLogicalRetaliationModeEnabled { get; set; }
@@ -182,7 +182,8 @@ public class Player : IPersistableObject
             }
         }
 
-        BankAccount = new BankAccount(_game, this);
+        BankAccount = new BankAccount(_game, Id);
+        AcademyStats = new AcademyStats(_game);
     }
 
     internal void SelectUnits(ICollection<GameObject> units, bool additive = false)
@@ -1087,51 +1088,6 @@ public enum UpgradeStatus
     Invalid = 0,
     Queued = 1,
     Completed = 2
-}
-
-public sealed class BankAccount(IGame game, Player owner) : IPersistableObject
-{
-    private static NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
-
-    public uint Money;
-
-    public void Withdraw(uint amount)
-    {
-        // TODO: Play MoneyWithdrawSound
-
-        if (game.PlayerManager.LocalPlayer == owner) // only play the deposit sound for the owner
-        {
-            game.Audio.PlayAudioEvent(game.AssetStore.MiscAudio.Current.MoneyWithdrawSound.Value);
-        }
-
-        if (Money >= amount)
-        {
-            Money -= amount;
-        }
-        else
-        {
-            // this should not happen since we should check first if we can spend that much
-            Logger.Warn($"Spent more money ({amount}) than player had ({Money})!");
-            Money = 0;
-        }
-    }
-
-    public void Deposit(uint amount)
-    {
-        if (game.PlayerManager.LocalPlayer == owner) // only play the deposit sound for the owner
-        {
-            game.Audio.PlayAudioEvent(game.AssetStore.MiscAudio.Current.MoneyDepositSound.Value);
-        }
-
-        Money += amount;
-    }
-
-    public void Persist(StatePersister reader)
-    {
-        reader.PersistVersion(1);
-
-        reader.PersistUInt32(ref Money);
-    }
 }
 
 public sealed class TunnelManager : IPersistableObject


### PR DESCRIPTION
- Update `BankAccount` with ported code from Money.cpp
  - `BankAccount` is the name of our original implementation. I tried renaming it `Money` to match Generals, but since it has a field named `Money` (both in our version and in Generals), the compiler didn't allow it. I think our current name is better anyway.
- Add partial port of `AcademyStats` (which is used to generate end-of-game strategy tips that are shown in ZH's score screen)
  - This is a pretty long class and IMHO not very important in the grand scheme of things. I added all of the fields as it was a pretty simple mechanical process, and the method used by `BankAccount`.
  - I also implemented `Persist`. After finishing the implementation I noticed that ZH doesn't seem to ever call the `xfer` method, so even though there's a serialisation format it's probably not actually used anywhere. I decided to leave it in anyway, in case I was mistaken and it is actually called somewhere, or if we want to introduce an OpenSAGE-specific version of the Player chunk which includes this missing data.
