### PR TITLE
Replace all usages of GameEngine with IGameEngine

### DIFF
--- a/src/OpenSage.Game.Tests/MockedGameTest.cs
+++ b/src/OpenSage.Game.Tests/MockedGameTest.cs
@@ -79,7 +79,7 @@ public abstract class MockedGameTest : IDisposable
         public OrderGeneratorSystem OrderGenerator { get; }
         public AudioSystem Audio { get; }
         public SelectionSystem Selection { get; }
-        public GameEngine GameEngine { get; }
+        public IGameEngine GameEngine { get; }
         public event EventHandler<GameUpdatingEventArgs> Updating;
         public event EventHandler RenderCompleted;
         public void LoadSaveFile(FileSystemEntry entry)

--- a/src/OpenSage.Game/Client/Drawable.cs
+++ b/src/OpenSage.Game/Client/Drawable.cs
@@ -24,7 +24,7 @@ public sealed class Drawable : Entity, IPersistableObject
         return _tagToModuleLookup[tag];
     }
 
-    private readonly GameEngine _gameEngine;
+    private readonly IGameEngine _gameEngine;
 
     private readonly List<string> _hiddenDrawModules;
     private readonly Dictionary<string, bool> _hiddenSubObjects;
@@ -150,7 +150,7 @@ public sealed class Drawable : Entity, IPersistableObject
                 Math.Clamp(_gameEngine.AssetLoadContext.AssetStore.GameData.Current.SelectionFlashSaturationFactor / 2f, 0, 1),
                 Math.Clamp(_gameEngine.AssetLoadContext.AssetStore.GameData.Current.SelectionFlashSaturationFactor / 2f, 0, 1));
 
-    internal Drawable(ObjectDefinition objectDefinition, GameEngine gameEngine, GameObject gameObject)
+    internal Drawable(ObjectDefinition objectDefinition, IGameEngine gameEngine, GameObject gameObject)
     {
         Definition = objectDefinition;
         _gameEngine = gameEngine;

--- a/src/OpenSage.Game/FX/FXListExecutionContext.cs
+++ b/src/OpenSage.Game/FX/FXListExecutionContext.cs
@@ -6,12 +6,12 @@ internal sealed class FXListExecutionContext
 {
     public readonly Quaternion Rotation;
     public readonly Vector3 Position;
-    public readonly GameEngine GameEngine;
+    public readonly IGameEngine GameEngine;
 
     public FXListExecutionContext(
         in Quaternion rotation,
         in Vector3 position,
-        GameEngine gameEngine)
+        IGameEngine gameEngine)
     {
         Rotation = rotation;
         Position = position;

--- a/src/OpenSage.Game/Game.cs
+++ b/src/OpenSage.Game/Game.cs
@@ -386,7 +386,7 @@ public sealed class Game : DisposableBase, IGame
 
     public PartitionCellManager PartitionCellManager { get; }
 
-    public GameEngine GameEngine => Scene3D.GameEngine;
+    public IGameEngine GameEngine => Scene3D.GameEngine;
 
     public Game(GameInstallation installation)
         : this(installation, null, new Configuration(), null)

--- a/src/OpenSage.Game/GameEngine.cs
+++ b/src/OpenSage.Game/GameEngine.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Text;
+﻿using System.Text;
 using OpenSage.Audio;
 using OpenSage.Client;
 using OpenSage.Content;
@@ -12,7 +11,7 @@ using OpenSage.Logic.Object;
 
 namespace OpenSage;
 
-public sealed class GameEngine
+public sealed class GameEngine : IGameEngine
 {
     static GameEngine()
     {
@@ -29,30 +28,35 @@ public sealed class GameEngine
     /// </summary>
     public float MsPerLogicFrame { get; }
 
-    internal readonly AssetLoadContext AssetLoadContext;
-    public readonly AudioSystem AudioSystem;
-    internal readonly ParticleSystemManager ParticleSystems;
-    internal readonly ObjectCreationListManager ObjectCreationLists;
-    public readonly Terrain.Terrain Terrain;
-    public readonly Navigation.Navigation Navigation;
-    public readonly Radar Radar;
+    AssetLoadContext IGameEngine.AssetLoadContext => AssetLoadContext;
+    internal AssetLoadContext AssetLoadContext { get; }
+    public AudioSystem AudioSystem { get; }
+    ParticleSystemManager IGameEngine.ParticleSystems => ParticleSystems;
+    internal ParticleSystemManager ParticleSystems { get; }
+    ObjectCreationListManager IGameEngine.ObjectCreationLists => ObjectCreationLists;
+    internal ObjectCreationListManager ObjectCreationLists { get; }
+    public Terrain.Terrain Terrain { get; }
+    public Navigation.Navigation Navigation { get; }
+    public Radar Radar { get; }
 
-    public readonly IGame Game;
+    public IGame Game { get; }
 
     public SageGame SageGame => Game.SageGame;
 
+    GameLogic IGameEngine.GameLogic => GameLogic;
     internal GameLogic GameLogic => Game.GameLogic;
 
+    GameClient IGameEngine.GameClient => GameClient;
     internal GameClient GameClient => Game.GameClient;
 
     public AssetStore AssetStore => AssetLoadContext.AssetStore;
 
-    public readonly AI AI = new();
+    public AI AI { get; } = new();
 
-    public readonly IQuadtree<GameObject> Quadtree;
+    public IQuadtree<GameObject> Quadtree { get; }
 
     // TODO: This is temporary until Scene3D and GameEngine are merged.
-    public readonly IScene3D Scene3D;
+    public IScene3D Scene3D { get; }
 
     internal GameEngine(
         AssetLoadContext assetLoadContext,

--- a/src/OpenSage.Game/IGame.cs
+++ b/src/OpenSage.Game/IGame.cs
@@ -122,7 +122,7 @@ public interface IGame
     PlayerManager PlayerManager { get; }
     TeamFactory TeamFactory { get; }
     PartitionCellManager PartitionCellManager { get; }
-    GameEngine GameEngine { get; }
+    IGameEngine GameEngine { get; }
 
     event EventHandler<GameUpdatingEventArgs> Updating;
 

--- a/src/OpenSage.Game/IGameEngine.cs
+++ b/src/OpenSage.Game/IGameEngine.cs
@@ -1,0 +1,40 @@
+﻿using OpenSage.Audio;
+using OpenSage.Client;
+using OpenSage.Content;
+using OpenSage.Content.Loaders;
+using OpenSage.DataStructures;
+using OpenSage.Graphics.ParticleSystems;
+using OpenSage.Logic;
+using OpenSage.Logic.AI;
+using OpenSage.Logic.Object;
+
+namespace OpenSage;
+
+public interface IGameEngine
+{
+    /// <summary>
+    /// "Ideal" logic frames per second, used for converting module data and animations.
+    /// </summary>
+    float LogicFramesPerSecond { get; }
+
+    /// <summary>
+    /// Milliseconds per "ideal" logic frame, computed based on <see cref="LogicFramesPerSecond"/>.
+    /// </summary>
+    float MsPerLogicFrame { get; }
+
+    internal AssetLoadContext AssetLoadContext { get; }
+    AudioSystem AudioSystem { get; }
+    internal ParticleSystemManager ParticleSystems { get; }
+    internal ObjectCreationListManager ObjectCreationLists { get; }
+    Terrain.Terrain Terrain { get; }
+    Navigation.Navigation Navigation { get; }
+    Radar Radar { get; }
+    IGame Game { get; }
+    SageGame SageGame { get; }
+    internal GameLogic GameLogic { get; }
+    internal GameClient GameClient { get; }
+    AssetStore AssetStore { get; }
+    AI AI { get; }
+    IQuadtree<GameObject> Quadtree { get; }
+    IScene3D Scene3D { get; }
+}

--- a/src/OpenSage.Game/IScene3D.cs
+++ b/src/OpenSage.Game/IScene3D.cs
@@ -25,7 +25,7 @@ namespace OpenSage;
 public interface IScene3D : IDisposable
 {
     IEditorCameraController EditorCameraController { get; }
-    GameEngine GameEngine { get; }
+    IGameEngine GameEngine { get; }
     SelectionGui SelectionGui { get; }
     DebugOverlay DebugOverlay { get; }
     internal ParticleSystemManager ParticleSystemManager { get; }

--- a/src/OpenSage.Game/Logic/AI/AIUpdateStateMachine.cs
+++ b/src/OpenSage.Game/Logic/AI/AIUpdateStateMachine.cs
@@ -14,7 +14,7 @@ internal class AIUpdateStateMachine : StateMachineBase
     private State _overrideState;
     private LogicFrame _overrideStateUntilFrame;
 
-    public AIUpdateStateMachine(GameObject gameObject, GameEngine gameEngine, AIUpdate aiUpdate) : base(gameObject, gameEngine, aiUpdate)
+    public AIUpdateStateMachine(GameObject gameObject, IGameEngine gameEngine, AIUpdate aiUpdate) : base(gameObject, gameEngine, aiUpdate)
     {
         AddState(IdleState.StateId, new IdleState(this));
         AddState(1, new MoveTowardsState(this));

--- a/src/OpenSage.Game/Logic/AI/State.cs
+++ b/src/OpenSage.Game/Logic/AI/State.cs
@@ -9,7 +9,7 @@ internal abstract class State : IPersistableObject
     public uint Id { get; internal set; }
 
     private protected GameObject GameObject => _stateMachine.GameObject;
-    private protected GameEngine GameEngine => _stateMachine.GameEngine;
+    private protected IGameEngine GameEngine => _stateMachine.GameEngine;
 
     private readonly StateMachineBase _stateMachine;
 

--- a/src/OpenSage.Game/Logic/AI/StateMachineBase.cs
+++ b/src/OpenSage.Game/Logic/AI/StateMachineBase.cs
@@ -10,7 +10,7 @@ namespace OpenSage.Logic.AI;
 internal abstract class StateMachineBase : IPersistableObject
 {
     public GameObject GameObject { get; }
-    public GameEngine GameEngine { get; }
+    public IGameEngine GameEngine { get; }
     public virtual AIUpdate AIUpdate { get; }
 
     private readonly Dictionary<uint, State> _states;
@@ -26,7 +26,7 @@ internal abstract class StateMachineBase : IPersistableObject
     private bool _unknownBool1;
     private bool _unknownBool2;
 
-    protected StateMachineBase(GameObject gameObject, GameEngine gameEngine, AIUpdate aiUpdate)
+    protected StateMachineBase(GameObject gameObject, IGameEngine gameEngine, AIUpdate aiUpdate)
     {
         GameObject = gameObject;
         GameEngine = gameEngine;

--- a/src/OpenSage.Game/Logic/AI/SupplyAIUpdateStateMachine.cs
+++ b/src/OpenSage.Game/Logic/AI/SupplyAIUpdateStateMachine.cs
@@ -9,7 +9,7 @@ internal sealed class SupplyAIUpdateStateMachine : StateMachineBase
 {
     public override SupplyAIUpdate AIUpdate { get; }
 
-    public SupplyAIUpdateStateMachine(GameObject gameObject, GameEngine gameEngine, SupplyAIUpdate aiUpdate) : base(gameObject, gameEngine, aiUpdate)
+    public SupplyAIUpdateStateMachine(GameObject gameObject, IGameEngine gameEngine, SupplyAIUpdate aiUpdate) : base(gameObject, gameEngine, aiUpdate)
     {
         AIUpdate = aiUpdate;
 

--- a/src/OpenSage.Game/Logic/ModifierList.cs
+++ b/src/OpenSage.Game/Logic/ModifierList.cs
@@ -30,7 +30,7 @@ public class AttributeModifier
         _delayedUpgrades = new List<(UpgradeTemplate, TimeSpan)>();
     }
 
-    public void Apply(GameObject gameObject, GameEngine gameEngine, in TimeInterval time)
+    public void Apply(GameObject gameObject, IGameEngine gameEngine, in TimeInterval time)
     {
         if (_selfExpiring)
         {
@@ -98,7 +98,7 @@ public class AttributeModifier
         }
     }
 
-    public void Remove(GameObject gameObject, GameEngine gameEngine)
+    public void Remove(GameObject gameObject, IGameEngine gameEngine)
     {
         foreach (var modifier in _modifierList.Modifiers)
         {
@@ -127,7 +127,7 @@ public class AttributeModifier
         TriggerFX(_modifierList.EndFX3, gameObject, gameEngine);
     }
 
-    private void TriggerFX(LazyAssetReference<FXList> fx, GameObject gameObject, GameEngine gameEngine)
+    private void TriggerFX(LazyAssetReference<FXList> fx, GameObject gameObject, IGameEngine gameEngine)
     {
         fx?.Value?.Execute(new FXListExecutionContext(
                 gameObject.Rotation,

--- a/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
+++ b/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
@@ -9,9 +9,9 @@ public abstract class ObjectModule : ModuleBase
 {
     protected GameObject GameObject { get; }
 
-    protected GameEngine GameEngine { get; }
+    protected IGameEngine GameEngine { get; }
 
-    protected ObjectModule(GameObject gameObject, GameEngine gameEngine)
+    protected ObjectModule(GameObject gameObject, IGameEngine gameEngine)
     {
         GameObject = gameObject;
         GameEngine = gameEngine;
@@ -29,7 +29,7 @@ public abstract class ObjectModule : ModuleBase
 
 public abstract class BehaviorModule : ObjectModule
 {
-    protected BehaviorModule(GameObject gameObject, GameEngine gameEngine)
+    protected BehaviorModule(GameObject gameObject, IGameEngine gameEngine)
         : base(gameObject, gameEngine)
     {
     }
@@ -48,13 +48,13 @@ public abstract class BehaviorModule : ObjectModule
 
 internal sealed class BehaviorUpdateContext
 {
-    public readonly GameEngine GameEngine;
+    public readonly IGameEngine GameEngine;
     public readonly GameObject GameObject;
 
     public LogicFrame LogicFrame => GameEngine.GameLogic.CurrentFrame;
 
     public BehaviorUpdateContext(
-        GameEngine gameEngine,
+        IGameEngine gameEngine,
         GameObject gameObject)
     {
         GameEngine = gameEngine;
@@ -616,5 +616,5 @@ public abstract class BehaviorModuleData : ModuleData
         { "WeaponSetUpgrade", WeaponSetUpgradeModuleData.Parse },
     };
 
-    internal virtual BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine) => null; // TODO: Make this abstract.
+    internal virtual BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine) => null; // TODO: Make this abstract.
 }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/AutoHealBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/AutoHealBehavior.cs
@@ -17,7 +17,7 @@ public sealed class AutoHealBehavior : UpdateModule, IUpgradeableModule, IDamage
     /// </summary>
     private LogicFrame _endOfStartHealingDelay;
 
-    public AutoHealBehavior(GameObject gameObject, GameEngine gameEngine, AutoHealBehaviorModuleData moduleData)
+    public AutoHealBehavior(GameObject gameObject, IGameEngine gameEngine, AutoHealBehaviorModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -254,7 +254,7 @@ public sealed class AutoHealBehaviorModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2Rotwk)]
     public bool HealOnlyIfNotUnderAttack { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new AutoHealBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BezierProjectileBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BezierProjectileBehavior.cs
@@ -19,7 +19,7 @@ public class BezierProjectileBehavior : UpdateModule
 
     internal FXList DetonationFX { get; set; }
 
-    internal BezierProjectileBehavior(GameObject gameObject, GameEngine gameEngine, BezierProjectileBehaviorData moduleData)
+    internal BezierProjectileBehavior(GameObject gameObject, IGameEngine gameEngine, BezierProjectileBehaviorData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -208,7 +208,7 @@ public class BezierProjectileBehaviorData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool PreLandingEmotionAffectsAllies { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new BezierProjectileBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BridgeBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BridgeBehavior.cs
@@ -8,7 +8,7 @@ public sealed class BridgeBehavior : UpdateModule
 {
     private readonly ObjectId[] _towerIds = new ObjectId[4];
 
-    public BridgeBehavior(GameObject gameObject, GameEngine gameEngine)
+    public BridgeBehavior(GameObject gameObject, IGameEngine gameEngine)
         : base(gameObject, gameEngine)
     {
     }
@@ -60,7 +60,7 @@ public sealed class BridgeBehaviorModuleData : BehaviorModuleData
     public List<BridgeDieObjectCreationList> BridgeDieOCLs { get; } = new List<BridgeDieObjectCreationList>();
     public List<BridgeDieFX> BridgeDieFXs { get; } = new List<BridgeDieFX>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new BridgeBehavior(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BridgeTowerBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BridgeTowerBehavior.cs
@@ -7,7 +7,7 @@ public sealed class BridgeTowerBehavior : BehaviorModule
     private int _unknown1;
     private int _unknown2;
 
-    public BridgeTowerBehavior(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public BridgeTowerBehavior(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -33,7 +33,7 @@ public sealed class BridgeTowerBehaviorModuleData : BehaviorModuleData
 
     private static readonly IniParseTable<BridgeTowerBehaviorModuleData> FieldParseTable = new IniParseTable<BridgeTowerBehaviorModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new BridgeTowerBehavior(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BuildingBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BuildingBehavior.cs
@@ -12,7 +12,7 @@ public class BuildingBehavior : UpdateModule
     private bool _fire;
     private bool _isGlowing;
 
-    internal BuildingBehavior(GameObject gameObject, GameEngine gameEngine, BuildingBehaviorModuleData moduleData)
+    internal BuildingBehavior(GameObject gameObject, IGameEngine gameEngine, BuildingBehaviorModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -109,7 +109,7 @@ public sealed class BuildingBehaviorModuleData : BehaviorModuleData
     public string GlowWindowName { get; private set; }
     public List<string> FireNames { get; private set; } = new List<string>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new BuildingBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
@@ -18,7 +18,7 @@ internal sealed class CastleBehavior : FoundationAIUpdate
 
     public bool IsUnpacked { get; set; }
 
-    internal CastleBehavior(GameObject gameObject, GameEngine gameEngine, CastleBehaviorModuleData moduleData)
+    internal CastleBehavior(GameObject gameObject, IGameEngine gameEngine, CastleBehaviorModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         IsUnpacked = false;
@@ -211,7 +211,7 @@ public class CastleBehaviorModuleData : FoundationAIUpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool Summoned { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new CastleBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDamagedBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDamagedBehavior.cs
@@ -25,7 +25,7 @@ public sealed class FireWeaponWhenDamagedBehavior : UpdateModule, IUpgradeableMo
 
     internal UpgradeLogic UpgradeLogic { get; }
 
-    public FireWeaponWhenDamagedBehavior(GameObject gameObject, GameEngine gameEngine, FireWeaponWhenDamagedBehaviorModuleData moduleData)
+    public FireWeaponWhenDamagedBehavior(GameObject gameObject, IGameEngine gameEngine, FireWeaponWhenDamagedBehaviorModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -177,7 +177,7 @@ public sealed class FireWeaponWhenDamagedBehaviorModuleData : UpgradeModuleData
     /// </summary>
     public float DamageAmount { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new FireWeaponWhenDamagedBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDeadBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDeadBehavior.cs
@@ -13,7 +13,7 @@ public sealed class FireWeaponWhenDeadBehavior : BehaviorModule, IUpgradeableMod
 
     internal UpgradeLogic UpgradeLogic { get; }
 
-    internal FireWeaponWhenDeadBehavior(GameObject gameObject, GameEngine gameEngine, FireWeaponWhenDeadBehaviorModuleData moduleData)
+    internal FireWeaponWhenDeadBehavior(GameObject gameObject, IGameEngine gameEngine, FireWeaponWhenDeadBehaviorModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -90,7 +90,7 @@ public sealed class FireWeaponWhenDeadBehaviorModuleData : UpgradeModuleData
     [AddedIn(SageGame.Bfme)]
     public Vector3 WeaponOffset { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new FireWeaponWhenDeadBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/GateOpenAndCloseBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/GateOpenAndCloseBehavior.cs
@@ -26,7 +26,7 @@ public class GateOpenAndCloseBehavior : UpdateModule
     private AudioSource _openingSoundLoop;
     private AudioSource _closingSoundLoop;
 
-    internal GateOpenAndCloseBehavior(GameObject gameObject, GameEngine gameEngine, GateOpenAndCloseBehaviorModuleData moduleData)
+    internal GateOpenAndCloseBehavior(GameObject gameObject, IGameEngine gameEngine, GateOpenAndCloseBehaviorModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -183,7 +183,7 @@ public sealed class GateOpenAndCloseBehaviorModuleData : BehaviorModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool RepelCollidingUnits { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new GateOpenAndCloseBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/GenerateMinefieldBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/GenerateMinefieldBehavior.cs
@@ -33,7 +33,7 @@ public sealed class GenerateMinefieldBehavior : BehaviorModule, IUpgradeableModu
 
     private readonly List<ObjectId> _generatedMineIds = [];
 
-    internal GenerateMinefieldBehavior(GameObject gameObject, GameEngine gameEngine, GenerateMinefieldBehaviorModuleData moduleData)
+    internal GenerateMinefieldBehavior(GameObject gameObject, IGameEngine gameEngine, GenerateMinefieldBehaviorModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -292,7 +292,7 @@ public sealed class GenerateMinefieldBehaviorModuleData : UpdateModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public LazyAssetReference<ObjectDefinition>? UpgradedMineName { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new GenerateMinefieldBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/HelicopterSlowDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/HelicopterSlowDeathBehavior.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class HelicopterSlowDeathBehavior : SlowDeathBehavior
 {
-    internal HelicopterSlowDeathBehavior(GameObject gameObject, GameEngine gameEngine, HelicopterSlowDeathBehaviorModuleData moduleData)
+    internal HelicopterSlowDeathBehavior(GameObject gameObject, IGameEngine gameEngine, HelicopterSlowDeathBehaviorModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
     }
@@ -89,7 +89,7 @@ public sealed class HelicopterSlowDeathBehaviorModuleData : SlowDeathBehaviorMod
     public int DelayFromGroundToFinalDeath { get; private set; }
     public string FinalRubbleObject { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new HelicopterSlowDeathBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/InstantDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/InstantDeathBehavior.cs
@@ -9,7 +9,7 @@ public sealed class InstantDeathBehavior : DieModule
 {
     private readonly InstantDeathBehaviorModuleData _moduleData;
 
-    internal InstantDeathBehavior(GameObject gameObject, GameEngine gameEngine, InstantDeathBehaviorModuleData moduleData)
+    internal InstantDeathBehavior(GameObject gameObject, IGameEngine gameEngine, InstantDeathBehaviorModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -51,7 +51,7 @@ public sealed class InstantDeathBehaviorModuleData : DieModuleData
     public LazyAssetReference<FXList> FX { get; private set; }
     public string OCL { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new InstantDeathBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/MinefieldBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/MinefieldBehavior.cs
@@ -8,7 +8,7 @@ public sealed class MinefieldBehavior : UpdateModule
     private uint _numVirtualMachines;
     private uint _unknownFrame;
 
-    public MinefieldBehavior(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public MinefieldBehavior(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -72,7 +72,7 @@ public sealed class MinefieldBehaviorModuleData : BehaviorModuleData
     public bool StopsRegenAfterCreatorDies { get; private set; }
     public Percentage DegenPercentPerSecondAfterCreatorDies { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new MinefieldBehavior(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
@@ -11,7 +11,7 @@ public sealed class OverchargeBehavior : UpdateModule
     private bool _enabled;
     public bool Enabled => _enabled;
 
-    public OverchargeBehavior(GameObject gameObject, GameEngine gameEngine, OverchargeBehaviorModuleData moduleData)
+    public OverchargeBehavior(GameObject gameObject, IGameEngine gameEngine, OverchargeBehaviorModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -103,7 +103,7 @@ public sealed class OverchargeBehaviorModuleData : UpdateModuleData
     /// </summary>
     public Percentage NotAllowedWhenHealthBelowPercent { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new OverchargeBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/ParkingPlaceBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/ParkingPlaceBehavior.cs
@@ -28,7 +28,7 @@ public sealed class ParkingPlaceBehaviour : UpdateModule, IHasRallyPoint, IProdu
     private const int HealsPerSecond = 5; // not sure if this is configured anywhere
     private readonly LogicFrameSpan _healUpdateRate;
 
-    internal ParkingPlaceBehaviour(GameObject gameObject, GameEngine gameEngine, ParkingPlaceBehaviorModuleData moduleData)
+    internal ParkingPlaceBehaviour(GameObject gameObject, IGameEngine gameEngine, ParkingPlaceBehaviorModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -715,7 +715,7 @@ public sealed class ParkingPlaceBehaviorModuleData : UpdateModuleData
     public int ApproachHeight { get; private set; }
     public bool ParkInHangars { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new ParkingPlaceBehaviour(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PassiveAreaEffectBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PassiveAreaEffectBehavior.cs
@@ -12,7 +12,7 @@ public class PassiveAreaEffectBehavior : UpdateModule
     private readonly PassiveAreaEffectBehaviorModuleData _moduleData;
     private LogicFrame _nextPing;
 
-    public PassiveAreaEffectBehavior(GameObject gameObject, GameEngine gameEngine, PassiveAreaEffectBehaviorModuleData moduleData)
+    public PassiveAreaEffectBehavior(GameObject gameObject, IGameEngine gameEngine, PassiveAreaEffectBehaviorModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -80,7 +80,7 @@ public sealed class PassiveAreaEffectBehaviorModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public BitArray<ModifierCategory> AntiCategories { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new PassiveAreaEffectBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PhysicsBehavior.cs
@@ -155,7 +155,7 @@ public class PhysicsBehavior : UpdateModule, ICollideModule
         set => SetFlag(PhysicsFlagType.ApplyFriction2DWhenAirborne, value);
     }
 
-    internal PhysicsBehavior(GameObject gameObject, GameEngine gameEngine, PhysicsBehaviorModuleData moduleData)
+    internal PhysicsBehavior(GameObject gameObject, IGameEngine gameEngine, PhysicsBehaviorModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -1640,7 +1640,7 @@ public class PhysicsBehaviorModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme)]
     public int SecondHeight { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new PhysicsBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PoisonedBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PoisonedBehavior.cs
@@ -6,7 +6,7 @@ public sealed class PoisonedBehavior : UpdateModule
 {
     private uint _unknown;
 
-    public PoisonedBehavior(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public PoisonedBehavior(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -44,7 +44,7 @@ public sealed class PoisonedBehaviorModuleData : UpdateModuleData
     /// </summary>
     public int PoisonDuration { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new PoisonedBehavior(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PropagandaTowerBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PropagandaTowerBehavior.cs
@@ -18,7 +18,7 @@ public sealed class PropagandaTowerBehavior : UpdateModule
 
     private readonly BitArray<ObjectKinds> _allowedKinds = new();
 
-    public PropagandaTowerBehavior(GameObject gameObject, GameEngine gameEngine, PropagandaTowerBehaviorModuleData moduleData)
+    public PropagandaTowerBehavior(GameObject gameObject, IGameEngine gameEngine, PropagandaTowerBehaviorModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -167,7 +167,7 @@ public sealed class PropagandaTowerBehaviorModuleData : BehaviorModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public bool AffectsSelf { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new PropagandaTowerBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/RailroadBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/RailroadBehavior.cs
@@ -21,7 +21,7 @@ public sealed class RailroadBehavior : PhysicsBehavior
     private readonly RailroadBehaviorSomething _something1 = new();
     private readonly RailroadBehaviorSomething _something2 = new();
 
-    internal RailroadBehavior(GameObject gameObject, GameEngine gameEngine, PhysicsBehaviorModuleData moduleData)
+    internal RailroadBehavior(GameObject gameObject, IGameEngine gameEngine, PhysicsBehaviorModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
     }
@@ -163,7 +163,7 @@ public sealed class RailroadBehaviorModuleData : PhysicsBehaviorModuleData
 
     public List<string> CarriageTemplateNames { get; } = new List<string>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new RailroadBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
@@ -30,7 +30,7 @@ public class SlowDeathBehavior : UpdateModule, IDieModule
 
     public int ProbabilityModifier => _moduleData.ProbabilityModifier;
 
-    internal SlowDeathBehavior(GameObject gameObject, GameEngine gameEngine, SlowDeathBehaviorModuleData moduleData)
+    internal SlowDeathBehavior(GameObject gameObject, IGameEngine gameEngine, SlowDeathBehaviorModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -253,7 +253,7 @@ public class SlowDeathBehaviorModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2Rotwk)]
     public bool DoNotRandomizeMidpoint { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SlowDeathBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
@@ -27,7 +27,7 @@ internal sealed class SpawnBehavior : BehaviorModule, IUpdateModule
 
     public UpdateOrder UpdatePhase => UpdateOrder.Order2;
 
-    internal SpawnBehavior(GameObject gameObject, GameEngine gameEngine, SpawnBehaviorModuleData moduleData) : base(gameObject, gameEngine)
+    internal SpawnBehavior(GameObject gameObject, IGameEngine gameEngine, SpawnBehaviorModuleData moduleData) : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
 
@@ -243,7 +243,7 @@ public sealed class SpawnBehaviorModuleData : UpgradeModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool SpawnInsideBuilding { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SpawnBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/TechBuildingBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/TechBuildingBehavior.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class TechBuildingBehavior : UpdateModule
 {
-    public TechBuildingBehavior(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public TechBuildingBehavior(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -27,7 +27,7 @@ public sealed class TechBuildingBehaviorModuleData : BehaviorModuleData
 
     private static readonly IniParseTable<TechBuildingBehaviorModuleData> FieldParseTable = new IniParseTable<TechBuildingBehaviorModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new TechBuildingBehavior(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Body/ActiveBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/ActiveBody.cs
@@ -38,7 +38,7 @@ public class ActiveBody : BodyModule
     private Armor _currentArmor = Armor.NoArmor;
     private DamageFX? _currentDamageFX;
 
-    internal ActiveBody(GameObject gameObject, GameEngine gameEngine, ActiveBodyModuleData moduleData)
+    internal ActiveBody(GameObject gameObject, IGameEngine gameEngine, ActiveBodyModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -152,7 +152,7 @@ public class ActiveBody : BodyModule
                 {
                     // Original comment (which suggests that this code and the code
                     // mentioned in DumbProjectileBehavior) could be refactored:
-                    // 
+                    //
                     // This code is very misleading (but in a good way). One would think this is
                     // an excellent place to add the hook to kill garrisoned troops. And that is
                     // a correct assumption. Unfortunately, the vast majority of garrison slayings
@@ -1138,7 +1138,7 @@ public class ActiveBodyModuleData : BodyModuleData
     [AddedIn(SageGame.Bfme2Rotwk)]
     public string? ReallyDamagedAttributeModifier { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new ActiveBody(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Body/BodyModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/BodyModule.cs
@@ -13,7 +13,7 @@ public abstract class BodyModule : BehaviorModule
 {
     private float _damageScalar = 1.0f;
 
-    protected BodyModule(GameObject gameObject, GameEngine gameEngine)
+    protected BodyModule(GameObject gameObject, IGameEngine gameEngine)
         : base(gameObject, gameEngine)
     {
     }

--- a/src/OpenSage.Game/Logic/Object/Body/HighlanderBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/HighlanderBody.cs
@@ -11,7 +11,7 @@ namespace OpenSage.Logic.Object;
 /// </summary>
 public sealed class HighlanderBody : ActiveBody
 {
-    internal HighlanderBody(GameObject gameObject, GameEngine gameEngine, HighlanderBodyModuleData moduleData)
+    internal HighlanderBody(GameObject gameObject, IGameEngine gameEngine, HighlanderBodyModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
     }
@@ -49,7 +49,7 @@ public sealed class HighlanderBodyModuleData : ActiveBodyModuleData
     private static new readonly IniParseTable<HighlanderBodyModuleData> FieldParseTable = ActiveBodyModuleData.FieldParseTable
         .Concat(new IniParseTable<HighlanderBodyModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new HighlanderBody(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Body/ImmortalBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/ImmortalBody.cs
@@ -11,7 +11,7 @@ namespace OpenSage.Logic.Object;
 /// </summary>
 public sealed class ImmortalBody : ActiveBody
 {
-    internal ImmortalBody(GameObject gameObject, GameEngine gameEngine, ImmortalBodyModuleData moduleData)
+    internal ImmortalBody(GameObject gameObject, IGameEngine gameEngine, ImmortalBodyModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
     }
@@ -50,7 +50,7 @@ public sealed class ImmortalBodyModuleData : ActiveBodyModuleData
     private static new readonly IniParseTable<ImmortalBodyModuleData> FieldParseTable = ActiveBodyModuleData.FieldParseTable
         .Concat(new IniParseTable<ImmortalBodyModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new ImmortalBody(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Body/InactiveBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/InactiveBody.cs
@@ -23,7 +23,7 @@ public sealed class InactiveBody : BodyModule
         set { }
     }
 
-    internal InactiveBody(GameObject gameObject, GameEngine gameEngine)
+    internal InactiveBody(GameObject gameObject, IGameEngine gameEngine)
         : base(gameObject, gameEngine)
     {
         gameObject.IsEffectivelyDead = true;
@@ -129,7 +129,7 @@ public sealed class InactiveBodyModuleData : BodyModuleData
 
     private static readonly IniParseTable<InactiveBodyModuleData> FieldParseTable = [];
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new InactiveBody(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Body/StructureBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/StructureBody.cs
@@ -15,7 +15,7 @@ public sealed class StructureBody : ActiveBody
     /// </summary>
     private ObjectId _constructorObjectID;
 
-    internal StructureBody(GameObject gameObject, GameEngine gameEngine, StructureBodyModuleData moduleData)
+    internal StructureBody(GameObject gameObject, IGameEngine gameEngine, StructureBodyModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
     }
@@ -48,7 +48,7 @@ public sealed class StructureBodyModuleData : ActiveBodyModuleData
     private static new readonly IniParseTable<StructureBodyModuleData> FieldParseTable = ActiveBodyModuleData.FieldParseTable
         .Concat(new IniParseTable<StructureBodyModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new StructureBody(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Body/UndeadBody.cs
+++ b/src/OpenSage.Game/Logic/Object/Body/UndeadBody.cs
@@ -21,7 +21,7 @@ public sealed class UndeadBody : ActiveBody
     /// </summary>
     private bool _isSecondLife;
 
-    internal UndeadBody(GameObject gameObject, GameEngine gameEngine, UndeadBodyModuleData moduleData)
+    internal UndeadBody(GameObject gameObject, IGameEngine gameEngine, UndeadBodyModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -99,7 +99,7 @@ public sealed class UndeadBody : ActiveBody
 }
 
 /// <summary>
-/// Treats the first death as a state change. Triggers the Use of SECOND_LIFE 
+/// Treats the first death as a state change. Triggers the Use of SECOND_LIFE
 /// ModelConditionState/ArmorSet and allows the use of the BattleBusSlowDeathBehavior module.
 /// </summary>
 [AddedIn(SageGame.CncGeneralsZeroHour)]

--- a/src/OpenSage.Game/Logic/Object/ClientUpdate/AnimatedParticleSysBoneClientUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/ClientUpdate/AnimatedParticleSysBoneClientUpdate.cs
@@ -16,7 +16,7 @@ public sealed class AnimatedParticleSysBoneClientUpdate : ClientUpdateModule
 }
 
 /// <summary>
-/// Allows the object to have particle system effects dynamically attached to animated 
+/// Allows the object to have particle system effects dynamically attached to animated
 /// sub objects or bones.
 /// </summary>
 public sealed class AnimatedParticleSysBoneClientUpdateModuleData : ClientUpdateModuleData
@@ -25,7 +25,7 @@ public sealed class AnimatedParticleSysBoneClientUpdateModuleData : ClientUpdate
 
     internal static readonly IniParseTable<AnimatedParticleSysBoneClientUpdateModuleData> FieldParseTable = new IniParseTable<AnimatedParticleSysBoneClientUpdateModuleData>();
 
-    internal override ClientUpdateModule CreateModule(Drawable drawable, GameEngine gameEngine)
+    internal override ClientUpdateModule CreateModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new AnimatedParticleSysBoneClientUpdate();
     }

--- a/src/OpenSage.Game/Logic/Object/ClientUpdate/BeaconClientUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/ClientUpdate/BeaconClientUpdate.cs
@@ -9,7 +9,7 @@ public sealed class BeaconClientUpdate : ClientUpdateModule
 }
 
 /// <summary>
-/// Hardcoded to produce the BeaconSmokeFFFFFF particle system definition by default but will 
+/// Hardcoded to produce the BeaconSmokeFFFFFF particle system definition by default but will
 /// call the BeaconSmoke###### particle system definition relative to the player's color.
 /// </summary>
 public sealed class BeaconClientUpdateModuleData : ClientUpdateModuleData
@@ -25,7 +25,7 @@ public sealed class BeaconClientUpdateModuleData : ClientUpdateModuleData
     public int RadarPulseFrequency { get; private set; }
     public int RadarPulseDuration { get; private set; }
 
-    internal override ClientUpdateModule CreateModule(Drawable drawable, GameEngine gameEngine)
+    internal override ClientUpdateModule CreateModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new BeaconClientUpdate();
     }

--- a/src/OpenSage.Game/Logic/Object/ClientUpdate/ClientUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/ClientUpdate/ClientUpdate.cs
@@ -36,5 +36,5 @@ public abstract class ClientUpdateModuleData : ModuleData
         { "SwayClientUpdate", SwayClientUpdateModuleData.Parse },
     };
 
-    internal virtual ClientUpdateModule CreateModule(Drawable drawable, GameEngine gameEngine) => null; // TODO: Make this abstract.
+    internal virtual ClientUpdateModule CreateModule(Drawable drawable, IGameEngine gameEngine) => null; // TODO: Make this abstract.
 }

--- a/src/OpenSage.Game/Logic/Object/ClientUpdate/LaserUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/ClientUpdate/LaserUpdate.cs
@@ -74,7 +74,7 @@ public sealed class LaserUpdateModuleData : ClientUpdateModuleData
     [AddedIn(SageGame.Bfme)]
     public LogicFrameSpan LaserLifetime { get; private set; }
 
-    internal override LaserUpdate CreateModule(Drawable drawable, GameEngine gameEngine)
+    internal override LaserUpdate CreateModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new LaserUpdate();
     }

--- a/src/OpenSage.Game/Logic/Object/ClientUpdate/SwayClientUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/ClientUpdate/SwayClientUpdate.cs
@@ -14,7 +14,7 @@ namespace OpenSage.Logic.Object;
 public sealed class SwayClientUpdate : ClientUpdateModule
 {
     private readonly Drawable _drawable;
-    private readonly GameEngine _gameEngine;
+    private readonly IGameEngine _gameEngine;
 
     private float _currentValue;
     private float _currentAngle;
@@ -24,7 +24,7 @@ public sealed class SwayClientUpdate : ClientUpdateModule
     private short _currentVersion = -1; // So we don't match the first time
     private bool _swaying = true;
 
-    internal SwayClientUpdate(Drawable drawable, GameEngine gameEngine)
+    internal SwayClientUpdate(Drawable drawable, IGameEngine gameEngine)
     {
         _drawable = drawable;
         _gameEngine = gameEngine;
@@ -149,7 +149,7 @@ public sealed class SwayClientUpdateModuleData : ClientUpdateModuleData
 
     private static readonly IniParseTable<SwayClientUpdateModuleData> FieldParseTable = new IniParseTable<SwayClientUpdateModuleData>();
 
-    internal override ClientUpdateModule CreateModule(Drawable drawable, GameEngine gameEngine)
+    internal override ClientUpdateModule CreateModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new SwayClientUpdate(drawable, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Collide/CollideModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/CollideModule.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public abstract class CollideModule : BehaviorModule, ICollideModule
 {
-    protected CollideModule(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    protected CollideModule(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Collide/ConvertToCarBombCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/ConvertToCarBombCrateCollide.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class ConvertToCarBombCrateCollide : CrateCollide
 {
-    public ConvertToCarBombCrateCollide(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public ConvertToCarBombCrateCollide(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -27,7 +27,7 @@ public sealed class ConvertToCarBombCrateCollideModuleData : CrateCollideModuleD
     private static new readonly IniParseTable<ConvertToCarBombCrateCollideModuleData> FieldParseTable = CrateCollideModuleData.FieldParseTable
         .Concat(new IniParseTable<ConvertToCarBombCrateCollideModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new ConvertToCarBombCrateCollide(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Collide/ConvertToHijackedVehicleCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/ConvertToHijackedVehicleCrateCollide.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class ConvertToHijackedVehicleCrateCollide : CrateCollide
 {
-    public ConvertToHijackedVehicleCrateCollide(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public ConvertToHijackedVehicleCrateCollide(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -29,7 +29,7 @@ public sealed class ConvertToHijackedVehicleCrateCollideModuleData : CrateCollid
     private static new readonly IniParseTable<ConvertToHijackedVehicleCrateCollideModuleData> FieldParseTable = CrateCollideModuleData.FieldParseTable
         .Concat(new IniParseTable<ConvertToHijackedVehicleCrateCollideModuleData>());
 
-    internal override ConvertToHijackedVehicleCrateCollide CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override ConvertToHijackedVehicleCrateCollide CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new ConvertToHijackedVehicleCrateCollide(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Collide/CrateCollideModuleData.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/CrateCollideModuleData.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 
 public abstract class CrateCollide : CollideModule
 {
-    protected CrateCollide(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    protected CrateCollide(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Collide/FireWeaponCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/FireWeaponCollide.cs
@@ -11,7 +11,7 @@ public sealed class FireWeaponCollide : CollideModule
     private readonly Weapon _collideWeapon;
     private bool _unknown2;
 
-    internal FireWeaponCollide(GameObject gameObject, GameEngine gameEngine, FireWeaponCollideModuleData moduleData) : base(gameObject, gameEngine)
+    internal FireWeaponCollide(GameObject gameObject, IGameEngine gameEngine, FireWeaponCollideModuleData moduleData) : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
 
@@ -49,7 +49,7 @@ public sealed class FireWeaponCollideModuleData : CollideModuleData
     public LazyAssetReference<WeaponTemplate> CollideWeapon { get; private set; }
     public ModelConditionFlag RequiredStatus { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new FireWeaponCollide(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Collide/MoneyCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/MoneyCrateCollide.cs
@@ -7,7 +7,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class MoneyCrateCollide : CrateCollide
 {
-    public MoneyCrateCollide(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public MoneyCrateCollide(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -35,7 +35,7 @@ public sealed class MoneyCrateCollideModuleData : CrateCollideModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public BoostUpgrade UpgradedBoost { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new MoneyCrateCollide(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Collide/SalvageCrateCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/SalvageCrateCollide.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class SalvageCrateCollide : CrateCollide
 {
-    public SalvageCrateCollide(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public SalvageCrateCollide(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -76,7 +76,7 @@ public sealed class SalvageCrateCollideModuleData : CrateCollideModuleData
     [AddedIn(SageGame.Bfme)]
     public bool AllowAIPickup { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SalvageCrateCollide(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Collide/SquishCollide.cs
+++ b/src/OpenSage.Game/Logic/Object/Collide/SquishCollide.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 public sealed class SquishCollide : CollideModule
 {
     // TODO
-    public SquishCollide(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public SquishCollide(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -25,7 +25,7 @@ public sealed class SquishCollideModuleData : CollideModuleData
 
     private static readonly IniParseTable<SquishCollideModuleData> FieldParseTable = new IniParseTable<SquishCollideModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SquishCollide(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Contain/GarrisonContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/GarrisonContain.cs
@@ -13,7 +13,7 @@ public sealed class GarrisonContain : OpenContainModule
     private readonly Vector3[] _positions = new Vector3[120];
     private bool _originalTeamSet;
 
-    internal GarrisonContain(GameObject gameObject, GameEngine gameEngine, OpenContainModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal GarrisonContain(GameObject gameObject, IGameEngine gameEngine, OpenContainModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -138,7 +138,7 @@ public class GarrisonContainModuleData : OpenContainModuleData
     [AddedIn(SageGame.Bfme)]
     public ObjectFilter PassengerFilter { get; private set; } = new();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new GarrisonContain(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Contain/HealContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/HealContain.cs
@@ -10,7 +10,7 @@ public sealed class HealContain : OpenContainModule
 {
     private readonly HealContainModuleData _moduleData;
 
-    internal HealContain(GameObject gameObject, GameEngine gameEngine, HealContainModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal HealContain(GameObject gameObject, IGameEngine gameEngine, HealContainModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
     }
@@ -63,7 +63,7 @@ public sealed class HealContainModuleData : GarrisonContainModuleData
 
     public int TimeForFullHeal { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new HealContain(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Contain/HordeContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/HordeContain.cs
@@ -17,7 +17,7 @@ public sealed class HordeContainBehavior : UpdateModule
     private ProductionUpdate _productionUpdate;
     private int _pendingRegistrations;
 
-    public HordeContainBehavior(GameObject gameObject, GameEngine gameEngine, HordeContainModuleData moduleData)
+    public HordeContainBehavior(GameObject gameObject, IGameEngine gameEngine, HordeContainModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -295,7 +295,7 @@ public class HordeContainModuleData : BehaviorModuleData
     [AddedIn(SageGame.Bfme2Rotwk)]
     public string LivingWorldOverloadTemplate { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new HordeContainBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
@@ -39,7 +39,7 @@ public abstract class OpenContainModule : UpdateModule, IHasRallyPoint
     protected const string ExitBoneStartName = "ExitStart";
     protected const string ExitBoneEndName = "ExitEnd";
 
-    private protected OpenContainModule(GameObject gameObject, GameEngine gameEngine, OpenContainModuleData moduleData)
+    private protected OpenContainModule(GameObject gameObject, IGameEngine gameEngine, OpenContainModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;

--- a/src/OpenSage.Game/Logic/Object/Contain/OverlordContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OverlordContain.cs
@@ -6,7 +6,7 @@ public sealed class OverlordContain : TransportContain
 {
     private readonly OverlordContainModuleData _moduleData;
 
-    internal OverlordContain(GameObject gameObject, GameEngine gameEngine, OverlordContainModuleData moduleData)
+    internal OverlordContain(GameObject gameObject, IGameEngine gameEngine, OverlordContainModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -48,7 +48,7 @@ public sealed class OverlordContainModuleData : TransportContainModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public bool ExperienceSinkForRider { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new OverlordContain(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
@@ -14,7 +14,7 @@ public class TransportContain : OpenContainModule
 
     private LogicFrame _nextEvacAllowedAfter; // unsure if this is correct, but seems plausible from testing?
 
-    internal TransportContain(GameObject gameObject, GameEngine gameEngine, TransportContainModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal TransportContain(GameObject gameObject, IGameEngine gameEngine, TransportContainModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
 
@@ -310,7 +310,7 @@ public class TransportContainModuleData : OpenContainModuleData
     [AddedIn(SageGame.Bfme2Rotwk)]
     public ModelConditionFlag ConditionForEntry { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new TransportContain(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Contain/TunnelContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TunnelContain.cs
@@ -14,7 +14,7 @@ public sealed class TunnelContain : OpenContainModule, IDieModule
     private bool _unknown1;
     private bool _unknown2;
 
-    internal TunnelContain(GameObject gameObject, GameEngine gameEngine, TunnelContainModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal TunnelContain(GameObject gameObject, IGameEngine gameEngine, TunnelContainModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
         gameObject.Owner.TunnelManager?.TunnelIds.Add(gameObject.Id);
@@ -125,7 +125,7 @@ public sealed class TunnelContainModuleData : GarrisonContainModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool AllowOwnPlayerInsideOverride { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new TunnelContain(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Create/CreateModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/CreateModule.cs
@@ -4,7 +4,7 @@ public abstract class CreateModule : BehaviorModule, ICreateModule
 {
     private bool _shouldCallOnBuildComplete = true;
 
-    protected CreateModule(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    protected CreateModule(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Create/ExperienceLevelCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/ExperienceLevelCreate.cs
@@ -7,7 +7,7 @@ internal sealed class ExperienceLevelCreateBehavior : CreateModule
 {
     ExperienceLevelCreateModuleData _moduleData;
 
-    internal ExperienceLevelCreateBehavior(GameObject gameObject, GameEngine gameEngine, ExperienceLevelCreateModuleData moduleData)
+    internal ExperienceLevelCreateBehavior(GameObject gameObject, IGameEngine gameEngine, ExperienceLevelCreateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -33,7 +33,7 @@ public sealed class ExperienceLevelCreateModuleData : CreateModuleData
     public int LevelToGrant { get; private set; }
     public bool MPOnly { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new ExperienceLevelCreateBehavior(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Create/GrantUpgradeCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/GrantUpgradeCreate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class GrantUpgradeCreate : CreateModule
 {
-    public GrantUpgradeCreate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public GrantUpgradeCreate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -35,7 +35,7 @@ public sealed class GrantUpgradeCreateModuleData : CreateModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool GiveOnBuildComplete { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new GrantUpgradeCreate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Create/LockWeaponCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/LockWeaponCreate.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 [AddedIn(SageGame.CncGeneralsZeroHour)]
 public sealed class LockWeaponCreate : CreateModule
 {
-    public LockWeaponCreate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public LockWeaponCreate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -34,7 +34,7 @@ public sealed class LockWeaponCreateModuleData : CreateModuleData
 
     public WeaponSlot SlotToLock { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new LockWeaponCreate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Create/PreorderCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/PreorderCreate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class PreorderCreate : CreateModule
 {
-    public PreorderCreate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public PreorderCreate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -29,7 +29,7 @@ public sealed class PreorderCreateModuleData : CreateModuleData
 
     private static readonly IniParseTable<PreorderCreateModuleData> FieldParseTable = new IniParseTable<PreorderCreateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new PreorderCreate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Create/SpecialPowerCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/SpecialPowerCreate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public class SpecialPowerCreate : CreateModule
 {
-    public SpecialPowerCreate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public SpecialPowerCreate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -36,7 +36,7 @@ public sealed class SpecialPowerCreateModuleData : CreateModuleData
 
     private static readonly IniParseTable<SpecialPowerCreateModuleData> FieldParseTable = new IniParseTable<SpecialPowerCreateModuleData>();
 
-    internal override SpecialPowerCreate CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override SpecialPowerCreate CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SpecialPowerCreate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Create/SupplyCenterCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/SupplyCenterCreate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class SupplyCenterCreate : CreateModule
 {
-    public SupplyCenterCreate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public SupplyCenterCreate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -44,7 +44,7 @@ public sealed class SupplyCenterCreateModuleData : CreateModuleData
 
     private static readonly IniParseTable<SupplyCenterCreateModuleData> FieldParseTable = new IniParseTable<SupplyCenterCreateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SupplyCenterCreate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Create/SupplyWarehouseCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/SupplyWarehouseCreate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class SupplyWarehouseCreate : CreateModule
 {
-    public SupplyWarehouseCreate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public SupplyWarehouseCreate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -43,7 +43,7 @@ public sealed class SupplyWarehouseCreateModuleData : CreateModuleData
 
     private static readonly IniParseTable<SupplyWarehouseCreateModuleData> FieldParseTable = new IniParseTable<SupplyWarehouseCreateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SupplyWarehouseCreate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Create/VeterancyGainCreate.cs
+++ b/src/OpenSage.Game/Logic/Object/Create/VeterancyGainCreate.cs
@@ -7,7 +7,7 @@ public sealed class VeterancyGainCreate : CreateModule
 {
     private readonly VeterancyGainCreateModuleData _moduleData;
 
-    public VeterancyGainCreate(GameObject gameObject, GameEngine gameEngine, VeterancyGainCreateModuleData moduleData)
+    public VeterancyGainCreate(GameObject gameObject, IGameEngine gameEngine, VeterancyGainCreateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -51,7 +51,7 @@ public sealed class VeterancyGainCreateModuleData : CreateModuleData
     public VeterancyLevel StartingLevel { get; private set; }
     public LazyAssetReference<Science> ScienceRequired { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new VeterancyGainCreate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Damage/BoneFXDamage.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/BoneFXDamage.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class BoneFXDamage : DamageModule
 {
-    public BoneFXDamage(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public BoneFXDamage(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -28,7 +28,7 @@ public sealed class BoneFXDamageModuleData : DamageModuleData
 
     private static readonly IniParseTable<BoneFXDamageModuleData> FieldParseTable = new IniParseTable<BoneFXDamageModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new BoneFXDamage(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Damage/DamageFX.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/DamageFX.cs
@@ -96,7 +96,7 @@ public sealed class DamageFX : BaseAsset
         return GetGroup(damageType, source).ThrottleTime;
     }
 
-    public void DoDamageFX(DamageType damageType, float damageAmount, GameObject source, GameObject victim, GameEngine gameEngine)
+    public void DoDamageFX(DamageType damageType, float damageAmount, GameObject source, GameObject victim, IGameEngine gameEngine)
     {
         var fxList = GetDamageFXList(damageType, damageAmount, source);
 

--- a/src/OpenSage.Game/Logic/Object/Damage/DamageModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/DamageModule.cs
@@ -2,7 +2,7 @@
 
 public abstract class DamageModule : BehaviorModule
 {
-    protected DamageModule(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    protected DamageModule(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Damage/TransitionDamageFX.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/TransitionDamageFX.cs
@@ -16,7 +16,7 @@ public sealed class TransitionDamageFX : DamageModule
     private const int NumParticleSystemsPerDamageType = 12;
     private readonly uint[] _particleSystemIds = new uint[EnumUtility.GetEnumValueLength<BodyDamageType>() * NumParticleSystemsPerDamageType];
 
-    public TransitionDamageFX(GameObject gameObject, GameEngine gameEngine, TransitionDamageFXModuleData moduleData)
+    public TransitionDamageFX(GameObject gameObject, IGameEngine gameEngine, TransitionDamageFXModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -158,7 +158,7 @@ public sealed class TransitionDamageFXModuleData : DamageModuleData
     [AddedIn(SageGame.Bfme)]
     public string[] ReallyDamagedHideSubObject { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new TransitionDamageFX(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateCrateDie.cs
@@ -9,7 +9,7 @@ public sealed class CreateCrateDie : DieModule
 {
     private readonly CreateCrateDieModuleData _moduleData;
 
-    internal CreateCrateDie(GameObject gameObject, GameEngine gameEngine, CreateCrateDieModuleData moduleData)
+    internal CreateCrateDie(GameObject gameObject, IGameEngine gameEngine, CreateCrateDieModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -90,7 +90,7 @@ public sealed class CreateCrateDieModuleData : DieModuleData
 
     public LazyAssetReference<CrateData> CrateData { get; private set; }
 
-    internal override CreateCrateDie CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override CreateCrateDie CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new CreateCrateDie(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
@@ -7,7 +7,7 @@ public sealed class CreateObjectDie : DieModule
 {
     private readonly CreateObjectDieModuleData _moduleData;
 
-    internal CreateObjectDie(GameObject gameObject, GameEngine gameEngine, CreateObjectDieModuleData moduleData)
+    internal CreateObjectDie(GameObject gameObject, IGameEngine gameEngine, CreateObjectDieModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -54,7 +54,7 @@ public sealed class CreateObjectDieModuleData : DieModuleData
     [AddedIn(SageGame.Bfme2)]
     public string[] UpgradeRequired { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new CreateObjectDie(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/CrushDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CrushDie.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class CrushDie : DieModule
 {
-    public CrushDie(GameObject gameObject, GameEngine gameEngine, CrushDieModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    public CrushDie(GameObject gameObject, IGameEngine gameEngine, CrushDieModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -43,7 +43,7 @@ public sealed class CrushDieModuleData : DieModuleData
     public int BackEndCrushSoundPercent { get; private set; }
     public int FrontEndCrushSoundPercent { get; private set; }
 
-    internal override CrushDie CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override CrushDie CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new CrushDie(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/DamDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DamDie.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 public sealed class DamDie : DieModule
 {
     // TODO
-    public DamDie(GameObject gameObject, GameEngine gameEngine, DamDieModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    public DamDie(GameObject gameObject, IGameEngine gameEngine, DamDieModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -30,7 +30,7 @@ public sealed class DamDieModuleData : DieModuleData
     private static new readonly IniParseTable<DamDieModuleData> FieldParseTable = DieModuleData.FieldParseTable
         .Concat(new IniParseTable<DamDieModuleData>());
 
-    internal override DamDie CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override DamDie CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new DamDie(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/DestroyDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DestroyDie.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class DestroyDie : DieModule
 {
-    internal DestroyDie(GameObject gameObject, GameEngine gameEngine, DestroyDieModuleData moduleData)
+    internal DestroyDie(GameObject gameObject, IGameEngine gameEngine, DestroyDieModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
     }
@@ -31,7 +31,7 @@ public sealed class DestroyDieModuleData : DieModuleData
     private static new readonly IniParseTable<DestroyDieModuleData> FieldParseTable = DieModuleData.FieldParseTable
         .Concat(new IniParseTable<DestroyDieModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new DestroyDie(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/DieModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/DieModule.cs
@@ -9,7 +9,7 @@ public abstract class DieModule : BehaviorModule, IDieModule
 {
     private readonly DieModuleData _moduleData;
 
-    protected DieModule(GameObject gameObject, GameEngine gameEngine, DieModuleData moduleData)
+    protected DieModule(GameObject gameObject, IGameEngine gameEngine, DieModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;

--- a/src/OpenSage.Game/Logic/Object/Die/EjectPilotDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/EjectPilotDie.cs
@@ -8,7 +8,7 @@ public sealed class EjectPilotDie : DieModule
 {
     private readonly EjectPilotDieModuleData _moduleData;
 
-    internal EjectPilotDie(GameObject gameObject, GameEngine gameEngine, EjectPilotDieModuleData moduleData)
+    internal EjectPilotDie(GameObject gameObject, IGameEngine gameEngine, EjectPilotDieModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -61,7 +61,7 @@ public sealed class EjectPilotDieModuleData : DieModuleData
     public LazyAssetReference<ObjectCreationList> AirCreationList { get; private set; }
     public BitArray<VeterancyLevel> VeterancyLevels { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new EjectPilotDie(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/FXListDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/FXListDie.cs
@@ -8,7 +8,7 @@ public sealed class FXListDie : DieModule
 {
     private readonly FXListDieModuleData _moduleData;
 
-    internal FXListDie(GameObject gameObject, GameEngine gameEngine, FXListDieModuleData moduleData)
+    internal FXListDie(GameObject gameObject, IGameEngine gameEngine, FXListDieModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -58,7 +58,7 @@ public sealed class FXListDieModuleData : DieModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public string[] TriggeredBy { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new FXListDie(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/KeepObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/KeepObjectDie.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class KeepObjectDie : DieModule
 {
-    public KeepObjectDie(GameObject gameObject, GameEngine gameEngine, KeepObjectDieModuleData moduleData)
+    public KeepObjectDie(GameObject gameObject, IGameEngine gameEngine, KeepObjectDieModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
     }
@@ -36,7 +36,7 @@ public sealed class KeepObjectDieModuleData : DieModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool StayOnRadar { get; private set; }
 
-    internal override KeepObjectDie CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override KeepObjectDie CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new KeepObjectDie(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/RebuildHoleExposeDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/RebuildHoleExposeDie.cs
@@ -7,7 +7,7 @@ public sealed class RebuildHoleExposeDie : DieModule
 {
     private readonly RebuildHoleExposeDieModuleData _moduleData;
 
-    internal RebuildHoleExposeDie(GameObject gameObject, GameEngine gameEngine, RebuildHoleExposeDieModuleData moduleData)
+    internal RebuildHoleExposeDie(GameObject gameObject, IGameEngine gameEngine, RebuildHoleExposeDieModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -63,7 +63,7 @@ public sealed class RebuildHoleExposeDieModuleData : DieModuleData
         DieData.ExemptStatus = ObjectStatus.UnderConstruction;
     }
 
-    internal override RebuildHoleExposeDie CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override RebuildHoleExposeDie CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new RebuildHoleExposeDie(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Die/UpgradeDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/UpgradeDie.cs
@@ -7,7 +7,7 @@ public class UpgradeDieModule : DieModule
 {
     private readonly UpgradeDieModuleData _moduleData;
 
-    internal UpgradeDieModule(GameObject gameObject, GameEngine gameEngine, UpgradeDieModuleData moduleData)
+    internal UpgradeDieModule(GameObject gameObject, IGameEngine gameEngine, UpgradeDieModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -45,7 +45,7 @@ public sealed class UpgradeDieModuleData : DieModuleData
 
     public UpgradeToRemove UpgradeToRemove { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new UpgradeDieModule(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/DrawModule.cs
@@ -114,5 +114,5 @@ public abstract class DrawModuleData : ModuleData
         { "W3DTruckDraw", W3dTruckDrawModuleData.Parse },
     };
 
-    internal virtual DrawModule? CreateDrawModule(Drawable drawable, GameEngine gameEngine) => null; // TODO: Make this abstract.
+    internal virtual DrawModule? CreateDrawModule(Drawable drawable, IGameEngine gameEngine) => null; // TODO: Make this abstract.
 }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dDebrisDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dDebrisDraw.cs
@@ -14,7 +14,7 @@ namespace OpenSage.Logic.Object;
 public sealed class W3dDebrisDraw : DrawModule
 {
     private readonly W3dDebrisDrawModuleData _data;
-    private readonly GameEngine _gameEngine;
+    private readonly IGameEngine _gameEngine;
     private ModelInstance _modelInstance;
 
     private string _modelName;
@@ -22,7 +22,7 @@ public sealed class W3dDebrisDraw : DrawModule
     private uint _unknownInt2;
     private bool _unknownBool;
 
-    internal W3dDebrisDraw(W3dDebrisDrawModuleData data, GameEngine gameEngine)
+    internal W3dDebrisDraw(W3dDebrisDrawModuleData data, IGameEngine gameEngine)
     {
         _data = data;
         _gameEngine = gameEngine;
@@ -98,8 +98,8 @@ public sealed class W3dDebrisDraw : DrawModule
 }
 
 /// <summary>
-/// Special-case draw module used by ObjectCreationList.INI when using the CreateDebris code 
-/// which defaults to calling the GenericDebris object definition as a template for each debris 
+/// Special-case draw module used by ObjectCreationList.INI when using the CreateDebris code
+/// which defaults to calling the GenericDebris object definition as a template for each debris
 /// object generated.
 /// </summary>
 public sealed class W3dDebrisDrawModuleData : DrawModuleData
@@ -108,7 +108,7 @@ public sealed class W3dDebrisDrawModuleData : DrawModuleData
 
     internal static readonly IniParseTable<W3dDebrisDrawModuleData> FieldParseTable = new IniParseTable<W3dDebrisDrawModuleData>();
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
+    internal override DrawModule CreateDrawModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new W3dDebrisDraw(this, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dDefaultDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dDefaultDraw.cs
@@ -61,8 +61,8 @@ public sealed class W3dDefaultDraw : DrawModule
 }
 
 /// <summary>
-/// All world objects should use a draw module. This module is used where an object should 
-/// never actually be drawn due either to the nature or type of the object or because its 
+/// All world objects should use a draw module. This module is used where an object should
+/// never actually be drawn due either to the nature or type of the object or because its
 /// drawing is handled by other logic, e.g. bridges.
 /// </summary>
 public sealed class W3dDefaultDrawModuleData : DrawModuleData
@@ -71,7 +71,7 @@ public sealed class W3dDefaultDrawModuleData : DrawModuleData
 
     internal static readonly IniParseTable<W3dDefaultDrawModuleData> DefaultFieldParseTable = new IniParseTable<W3dDefaultDrawModuleData>();
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
+    internal override DrawModule CreateDrawModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new W3dDefaultDraw();
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dFloorDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dFloorDraw.cs
@@ -17,13 +17,13 @@ namespace OpenSage.Logic.Object;
 public sealed class W3dFloorDraw : DrawModule
 {
     private readonly Drawable _drawable;
-    private readonly GameEngine _gameEngine;
+    private readonly IGameEngine _gameEngine;
     private readonly ModelInstance _modelInstance;
     private readonly W3dFloorDrawModuleData _moduleData;
 
     public override IEnumerable<BitArray<ModelConditionFlag>> ModelConditionStates { get; } = Array.Empty<BitArray<ModelConditionFlag>>();
 
-    internal W3dFloorDraw(W3dFloorDrawModuleData moduleData, GameEngine gameEngine, Drawable drawable)
+    internal W3dFloorDraw(W3dFloorDrawModuleData moduleData, IGameEngine gameEngine, Drawable drawable)
     {
         _drawable = drawable;
         _gameEngine = gameEngine;
@@ -110,7 +110,7 @@ public sealed class W3dFloorDrawModuleData : DrawModuleData
     [AddedIn(SageGame.Bfme2)]
     public WeatherTexture WeatherTexture { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
+    internal override DrawModule CreateDrawModule(Drawable drawable, IGameEngine gameEngine)
     {
         return Model.Value == null ? null : (DrawModule)new W3dFloorDraw(this, gameEngine, drawable);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dHordeModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dHordeModelDraw.cs
@@ -13,7 +13,7 @@ public class W3dHordeModelDraw : W3dScriptedModelDraw
     internal W3dHordeModelDraw(
         W3dHordeModelDrawModuleData data,
         Drawable drawable,
-        GameEngine gameEngine) : base(data, drawable, gameEngine)
+        IGameEngine gameEngine) : base(data, drawable, gameEngine)
     {
     }
 
@@ -35,7 +35,7 @@ public class W3dHordeModelDrawModuleData : W3dScriptedModelDrawModuleData
 
     public List<LodOption> LodOptions { get; private set; } = new List<LodOption>();
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
+    internal override DrawModule CreateDrawModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new W3dHordeModelDraw(this, drawable, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dLaserDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dLaserDraw.cs
@@ -99,7 +99,7 @@ public sealed class W3dLaserDrawModuleData : DrawModuleData
     [AddedIn(SageGame.Bfme)]
     public Envelope Envelope { get; private set; }
 
-    internal override W3dLaserDraw CreateDrawModule(Drawable drawable, GameEngine gameEngine)
+    internal override W3dLaserDraw CreateDrawModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new W3dLaserDraw();
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dModelDraw.cs
@@ -21,7 +21,7 @@ namespace OpenSage.Logic.Object;
 public class W3dModelDraw : DrawModule
 {
     private readonly W3dModelDrawModuleData _data;
-    private readonly GameEngine _gameEngine;
+    private readonly IGameEngine _gameEngine;
 
     private ModelConditionState _activeConditionState;
     protected AnimationState _activeAnimationState;
@@ -90,7 +90,7 @@ public class W3dModelDraw : DrawModule
     internal W3dModelDraw(
         W3dModelDrawModuleData data,
         Drawable drawable,
-        GameEngine gameEngine)
+        IGameEngine gameEngine)
     {
         _data = data;
         Drawable = drawable;
@@ -426,14 +426,14 @@ public class W3dModelDraw : DrawModule
 internal sealed class W3dModelDrawConditionState : DisposableBase
 {
     private readonly IEnumerable<ParticleSystem> _particleSystems;
-    private readonly GameEngine _gameEngine;
+    private readonly IGameEngine _gameEngine;
 
     public readonly ModelInstance Model;
 
     public W3dModelDrawConditionState(
         ModelInstance modelInstance,
         IEnumerable<ParticleSystem> particleSystems,
-        GameEngine gameEngine)
+        IGameEngine gameEngine)
     {
         Model = AddDisposable(modelInstance);
 
@@ -766,7 +766,7 @@ public class W3dModelDrawModuleData : DrawModuleData, IParseCallbacks
         _transitionStatesGenerals.Clear();
     }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
+    internal override DrawModule CreateDrawModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new W3dModelDraw(this, drawable, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dOverlordTankDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dOverlordTankDraw.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class W3dOverlordTankDraw : W3dTankDraw
 {
-    internal W3dOverlordTankDraw(W3dOverlordTankDrawModuleData data, Drawable drawable, GameEngine gameEngine)
+    internal W3dOverlordTankDraw(W3dOverlordTankDrawModuleData data, Drawable drawable, IGameEngine gameEngine)
         : base(data, drawable, gameEngine)
     {
     }
@@ -20,7 +20,7 @@ public sealed class W3dOverlordTankDraw : W3dTankDraw
 
 /// <summary>
 /// Special-case draw module which is interdependent with the W3DDependencyModelDraw module.
-/// Allows other objects to be attached to this object through use of AttachToBoneInContainer 
+/// Allows other objects to be attached to this object through use of AttachToBoneInContainer
 /// logic.
 /// </summary>
 public sealed class W3dOverlordTankDrawModuleData : W3dTankDrawModuleData
@@ -30,7 +30,7 @@ public sealed class W3dOverlordTankDrawModuleData : W3dTankDrawModuleData
     private static new readonly IniParseTable<W3dOverlordTankDrawModuleData> FieldParseTable = W3dTankDrawModuleData.FieldParseTable
         .Concat(new IniParseTable<W3dOverlordTankDrawModuleData>());
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
+    internal override DrawModule CreateDrawModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new W3dOverlordTankDraw(this, drawable, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dProjectileStreamDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dProjectileStreamDraw.cs
@@ -77,7 +77,7 @@ public sealed class W3dProjectileStreamDrawModuleData : DrawModuleData
     public float ScrollRate { get; private set; }
     public int MaxSegments { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
+    internal override DrawModule CreateDrawModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new W3dProjectileStreamDraw();
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dRopeDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dRopeDraw.cs
@@ -86,7 +86,7 @@ public sealed class W3dRopeDrawModuleData : DrawModuleData
 
     private static readonly IniParseTable<W3dRopeDrawModuleData> FieldParseTable = new IniParseTable<W3dRopeDrawModuleData>();
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
+    internal override DrawModule CreateDrawModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new W3dRopeDraw();
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dScienceModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dScienceModelDraw.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class W3dScienceModelDraw : W3dModelDraw
 {
-    internal W3dScienceModelDraw(W3dScienceModelDrawModuleData data, Drawable drawable, GameEngine gameEngine)
+    internal W3dScienceModelDraw(W3dScienceModelDrawModuleData data, Drawable drawable, IGameEngine gameEngine)
         : base(data, drawable, gameEngine)
     {
     }
@@ -30,7 +30,7 @@ public sealed class W3dScienceModelDrawModuleData : W3dModelDrawModuleData
 
     public string RequiredScience { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
+    internal override DrawModule CreateDrawModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new W3dScienceModelDraw(this, drawable, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dScriptedModelDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dScriptedModelDraw.cs
@@ -13,7 +13,7 @@ public class W3dScriptedModelDraw : W3dModelDraw
     internal W3dScriptedModelDraw(
         W3dScriptedModelDrawModuleData data,
         Drawable drawable,
-        GameEngine gameEngine)
+        IGameEngine gameEngine)
         : base(data, drawable, gameEngine)
     {
     }
@@ -79,7 +79,7 @@ public class W3dScriptedModelDrawModuleData : W3dModelDrawModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool RandomTextureFixedRandomIndex { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
+    internal override DrawModule CreateDrawModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new W3dScriptedModelDraw(this, drawable, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dSupplyDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dSupplyDraw.cs
@@ -11,7 +11,7 @@ public sealed class W3dSupplyDraw : W3dModelDraw
     private readonly Dictionary<string, int> _boxBoneMap;
     private readonly string _bonePrefix;
 
-    internal W3dSupplyDraw(W3dSupplyDrawModuleData data, Drawable drawable, GameEngine gameEngine)
+    internal W3dSupplyDraw(W3dSupplyDrawModuleData data, Drawable drawable, IGameEngine gameEngine)
         : base(data, drawable, gameEngine)
     {
         _bonePrefix = data.SupplyBonePrefix;
@@ -58,7 +58,7 @@ public sealed class W3dSupplyDrawModuleData : W3dModelDrawModuleData
 
     public string SupplyBonePrefix { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
+    internal override DrawModule CreateDrawModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new W3dSupplyDraw(this, drawable, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTankDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTankDraw.cs
@@ -23,7 +23,7 @@ public class W3dTankDraw : W3dModelDraw
         "TREADSR01",
     };
 
-    internal W3dTankDraw(W3dTankDrawModuleData data, Drawable drawable, GameEngine gameEngine)
+    internal W3dTankDraw(W3dTankDrawModuleData data, Drawable drawable, IGameEngine gameEngine)
         : base(data, drawable, gameEngine)
     {
         _data = data;
@@ -72,7 +72,7 @@ public class W3dTankDraw : W3dModelDraw
 }
 
 /// <summary>
-/// Default Draw used by tanks. Hardcoded to call for the TrackDebrisDirtRight and 
+/// Default Draw used by tanks. Hardcoded to call for the TrackDebrisDirtRight and
 /// TrackDebrisDirtLeft particle system definitions.
 /// </summary>
 public class W3dTankDrawModuleData : W3dModelDrawModuleData
@@ -104,7 +104,7 @@ public class W3dTankDrawModuleData : W3dModelDrawModuleData
     public float TreadDriveSpeedFraction { get; private set; }
     public float TreadPivotSpeedFraction { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
+    internal override DrawModule CreateDrawModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new W3dTankDraw(this, drawable, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTracerDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTracerDraw.cs
@@ -17,7 +17,7 @@ public class W3dTracerDraw : DrawModule
 
     public override IEnumerable<BitArray<ModelConditionFlag>> ModelConditionStates => Array.Empty<BitArray<ModelConditionFlag>>();
 
-    internal W3dTracerDraw(W3dTracerDrawModuleData data, GameEngine gameEngine)
+    internal W3dTracerDraw(W3dTracerDrawModuleData data, IGameEngine gameEngine)
     {
         _data = data;
     }
@@ -72,7 +72,7 @@ public sealed class W3dTracerDrawModuleData : DrawModuleData
 
     private static readonly IniParseTable<W3dTracerDrawModuleData> FieldParseTable = new IniParseTable<W3dTracerDrawModuleData>();
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
+    internal override DrawModule CreateDrawModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new W3dTracerDraw(this, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTreeDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTreeDraw.cs
@@ -16,13 +16,13 @@ namespace OpenSage.Logic.Object;
 [AddedIn(SageGame.Bfme)]
 public sealed class W3dTreeDraw : DrawModule
 {
-    private readonly GameEngine _gameEngine;
+    private readonly IGameEngine _gameEngine;
     private ModelInstance _modelInstance;
     private readonly W3dTreeDrawModuleData _moduleData;
 
     public override IEnumerable<BitArray<ModelConditionFlag>> ModelConditionStates { get; } = Array.Empty<BitArray<ModelConditionFlag>>();
 
-    internal W3dTreeDraw(W3dTreeDrawModuleData moduleData, GameEngine gameEngine)
+    internal W3dTreeDraw(W3dTreeDrawModuleData moduleData, IGameEngine gameEngine)
     {
         _gameEngine = gameEngine;
         _moduleData = moduleData;
@@ -143,7 +143,7 @@ public sealed class W3dTreeDrawModuleData : DrawModuleData
     [AddedIn(SageGame.Bfme)]
     public string MorphTree { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
+    internal override DrawModule CreateDrawModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new W3dTreeDraw(this, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
+++ b/src/OpenSage.Game/Logic/Object/Draw/W3dTruckDraw.cs
@@ -12,7 +12,7 @@ public sealed class W3dTruckDraw : W3dModelDraw
 
     private readonly (string name, bool affectedBySteering)[] _boneList;
 
-    internal W3dTruckDraw(W3dTruckDrawModuleData data, Drawable drawable, GameEngine gameEngine)
+    internal W3dTruckDraw(W3dTruckDrawModuleData data, Drawable drawable, IGameEngine gameEngine)
         : base(data, drawable, gameEngine)
     {
         _data = data;
@@ -185,7 +185,7 @@ public class W3dTruckDrawModuleData : W3dModelDrawModuleData
     [AddedIn(SageGame.Bfme2Rotwk)]
     public RandomTexture RandomTexture { get; private set; }
 
-    internal override DrawModule CreateDrawModule(Drawable drawable, GameEngine gameEngine)
+    internal override DrawModule CreateDrawModule(Drawable drawable, IGameEngine gameEngine)
     {
         return new W3dTruckDraw(this, drawable, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/ExperienceTracker.cs
+++ b/src/OpenSage.Game/Logic/Object/ExperienceTracker.cs
@@ -2,9 +2,9 @@
 
 namespace OpenSage.Logic.Object;
 
-public class ExperienceTracker(GameObject parent, GameEngine engine) : IPersistableObject
+public class ExperienceTracker(GameObject parent, IGameEngine gameEngine) : IPersistableObject
 {
-    private readonly GameEngine _engine = engine;
+    private readonly IGameEngine _gameEngine = gameEngine;
 
     /// <summary>
     /// Object I am owned by.
@@ -135,7 +135,7 @@ public class ExperienceTracker(GameObject parent, GameEngine engine) : IPersista
         if (ExperienceSink.IsValid)
         {
             // I have been set up to give my experience to someone else
-            var sinkObject = _engine.Scene3D.GameObjects.GetObjectById(ExperienceSink);
+            var sinkObject = _gameEngine.Scene3D.GameObjects.GetObjectById(ExperienceSink);
 
             if (sinkObject != null)
             {
@@ -212,7 +212,7 @@ public class ExperienceTracker(GameObject parent, GameEngine engine) : IPersista
     {
         if (ExperienceSink.IsValid)
         {
-            var sinkObject = _engine.Scene3D.GameObjects.GetObjectById(ExperienceSink);
+            var sinkObject = _gameEngine.Scene3D.GameObjects.GetObjectById(ExperienceSink);
 
             if (sinkObject != null)
             {

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectDefectionHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectDefectionHelper.cs
@@ -6,7 +6,7 @@ internal sealed class ObjectDefectionHelper : ObjectHelperModule
     private uint _frameEnd;
     private bool _unknown;
 
-    public ObjectDefectionHelper(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public ObjectDefectionHelper(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectFiringTrackerHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectFiringTrackerHelper.cs
@@ -7,7 +7,7 @@ internal sealed class ObjectFiringTrackerHelper : UpdateModule
 
     protected override UpdateOrder UpdateOrder => UpdateOrder.Order3;
 
-    public ObjectFiringTrackerHelper(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public ObjectFiringTrackerHelper(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectHelperModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectHelperModule.cs
@@ -2,7 +2,7 @@
 
 internal abstract class ObjectHelperModule : UpdateModule
 {
-    protected ObjectHelperModule(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    protected ObjectHelperModule(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectRepulsorHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectRepulsorHelper.cs
@@ -3,7 +3,7 @@
 internal sealed class ObjectRepulsorHelper : ObjectHelperModule
 {
     // TODO
-    public ObjectRepulsorHelper(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public ObjectRepulsorHelper(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectSpecialModelConditionHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectSpecialModelConditionHelper.cs
@@ -8,7 +8,7 @@
 internal sealed class ObjectSpecialModelConditionHelper : ObjectHelperModule
 {
     // TODO
-    public ObjectSpecialModelConditionHelper(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public ObjectSpecialModelConditionHelper(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectWeaponStatusHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectWeaponStatusHelper.cs
@@ -5,7 +5,7 @@ internal sealed class ObjectWeaponStatusHelper : ObjectHelperModule
     // TODO
     protected override UpdateOrder UpdateOrder => UpdateOrder.Order3;
 
-    public ObjectWeaponStatusHelper(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public ObjectWeaponStatusHelper(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/StatusDamageHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/StatusDamageHelper.cs
@@ -2,7 +2,7 @@
 
 internal sealed class StatusDamageHelper : ObjectHelperModule
 {
-    public StatusDamageHelper(GameObject gameObject, GameEngine gameEngine)
+    public StatusDamageHelper(GameObject gameObject, IGameEngine gameEngine)
         : base(gameObject, gameEngine)
     {
     }

--- a/src/OpenSage.Game/Logic/Object/Helpers/SubdualDamageHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/SubdualDamageHelper.cs
@@ -2,7 +2,7 @@
 
 internal sealed class SubdualDamageHelper : ObjectHelperModule
 {
-    public SubdualDamageHelper(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public SubdualDamageHelper(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/TempWeaponBonusHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/TempWeaponBonusHelper.cs
@@ -4,7 +4,7 @@ internal sealed class TempWeaponBonusHelper : ObjectHelperModule
 {
     private int _unknownInt;
 
-    public TempWeaponBonusHelper(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public TempWeaponBonusHelper(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 

--- a/src/OpenSage.Game/Logic/Object/Locomotor.cs
+++ b/src/OpenSage.Game/Logic/Object/Locomotor.cs
@@ -41,7 +41,7 @@ public sealed class Locomotor : IPersistableObject
     private const float DonutDistance = 4.0f * AIPathfind.PathfindCellSizeF;
     private const float MaxBrakingFactor = 5.0f;
 
-    private readonly GameEngine _gameEngine;
+    private readonly IGameEngine _gameEngine;
     private readonly float _baseSpeedFactor;
 
     private LogicFrame _donutTimer;
@@ -66,7 +66,7 @@ public sealed class Locomotor : IPersistableObject
 
     public float MinSpeed => LocomotorTemplate.MinSpeed;
 
-    public Locomotor(GameEngine gameEngine, LocomotorTemplate template, float baseSpeed)
+    public Locomotor(IGameEngine gameEngine, LocomotorTemplate template, float baseSpeed)
     {
         _gameEngine = gameEngine;
 

--- a/src/OpenSage.Game/Logic/Object/LocomotorSet.cs
+++ b/src/OpenSage.Game/Logic/Object/LocomotorSet.cs
@@ -6,11 +6,11 @@ namespace OpenSage.Logic.Object;
 public sealed class LocomotorSet : IPersistableObject
 {
     private readonly GameObject _gameObject;
-    private readonly GameEngine _gameEngine;
+    private readonly IGameEngine _gameEngine;
     private readonly List<Locomotor> _locomotors;
     private Surfaces _surfaces;
 
-    public LocomotorSet(GameObject gameObject, GameEngine gameEngine)
+    public LocomotorSet(GameObject gameObject, IGameEngine gameEngine)
     {
         _gameObject = gameObject;
         _gameEngine = gameEngine;

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/CashBountyPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/CashBountyPower.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class CashBountyPower : SpecialPowerModule
 {
-    internal CashBountyPower(GameObject gameObject, GameEngine gameEngine, CashBountyPowerModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal CashBountyPower(GameObject gameObject, IGameEngine gameEngine, CashBountyPowerModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -29,7 +29,7 @@ public sealed class CashBountyPowerModuleData : SpecialPowerModuleData
 
     public Percentage Bounty { get; private set; }
 
-    internal override CashBountyPower CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override CashBountyPower CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new CashBountyPower(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/CashHackSpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/CashHackSpecialPower.cs
@@ -12,7 +12,7 @@ public sealed class CashHackSpecialPower : SpecialPowerModule
 
     private uint _currentAmount;
 
-    internal CashHackSpecialPower(GameObject gameObject, GameEngine gameEngine, CashHackSpecialPowerModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal CashHackSpecialPower(GameObject gameObject, IGameEngine gameEngine, CashHackSpecialPowerModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
         _currentAmount = (uint)moduleData.MoneyAmount;
@@ -75,7 +75,7 @@ public sealed class CashHackSpecialPowerModuleData : SpecialPowerModuleData
     /// </summary>
     public int MoneyAmount { get; private set; }
 
-    internal override CashHackSpecialPower CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override CashHackSpecialPower CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new CashHackSpecialPower(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/CleanupAreaPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/CleanupAreaPower.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class CleanupAreaPower : SpecialPowerModule
 {
-    internal CleanupAreaPower(GameObject gameObject, GameEngine gameEngine, CleanupAreaPowerModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal CleanupAreaPower(GameObject gameObject, IGameEngine gameEngine, CleanupAreaPowerModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -40,7 +40,7 @@ public sealed class CleanupAreaPowerModuleData : SpecialPowerModuleData
 
     public float MaxMoveDistanceFromLocation { get; private set; }
 
-    internal override CleanupAreaPower CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override CleanupAreaPower CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new CleanupAreaPower(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/DefectorSpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/DefectorSpecialPower.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class DefectorSpecialPower : SpecialPowerModule
 {
-    internal DefectorSpecialPower(GameObject gameObject, GameEngine gameEngine, DefectorSpecialPowerModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal DefectorSpecialPower(GameObject gameObject, IGameEngine gameEngine, DefectorSpecialPowerModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -29,7 +29,7 @@ public sealed class DefectorSpecialPowerModuleData : SpecialPowerModuleData
     private static new readonly IniParseTable<DefectorSpecialPowerModuleData> FieldParseTable = SpecialPowerModuleData.FieldParseTable
         .Concat(new IniParseTable<DefectorSpecialPowerModuleData>());
 
-    internal override DefectorSpecialPower CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override DefectorSpecialPower CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new DefectorSpecialPower(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/OCLSpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/OCLSpecialPower.cs
@@ -13,7 +13,7 @@ public class OCLSpecialPowerModule : SpecialPowerModule
     private readonly OCLSpecialPowerModuleData _moduleData;
     private ObjectCreationList _activeOcl;
 
-    internal OCLSpecialPowerModule(GameObject gameObject, GameEngine gameEngine, OCLSpecialPowerModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal OCLSpecialPowerModule(GameObject gameObject, IGameEngine gameEngine, OCLSpecialPowerModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
         _activeOcl = _moduleData.OCL.Value;
@@ -209,7 +209,7 @@ public sealed class OCLSpecialPowerModuleData : SpecialPowerModuleData
     [AddedIn(SageGame.Bfme2)]
     public WeatherType ChangeWeather { get; private set; }
 
-    internal override OCLSpecialPowerModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override OCLSpecialPowerModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new OCLSpecialPowerModule(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialAbility.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialAbility.cs
@@ -6,7 +6,7 @@ public sealed class SpecialAbilityModule : SpecialPowerModule
 {
     // TODO
 
-    internal SpecialAbilityModule(GameObject gameObject, GameEngine gameEngine, SpecialAbilityModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal SpecialAbilityModule(GameObject gameObject, IGameEngine gameEngine, SpecialAbilityModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
     }
 
@@ -27,7 +27,7 @@ public sealed class SpecialAbilityModuleData : SpecialPowerModuleData
     private static new readonly IniParseTable<SpecialAbilityModuleData> FieldParseTable = SpecialPowerModuleData.FieldParseTable
         .Concat(new IniParseTable<SpecialAbilityModuleData>());
 
-    internal override SpecialAbilityModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override SpecialAbilityModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SpecialAbilityModule(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/SpecialPower.cs
@@ -33,7 +33,7 @@ public class SpecialPowerModule : BehaviorModule, IUpgradableScienceModule
 
     public SpecialPowerType SpecialPowerType => _moduleData.SpecialPower.Value.Type;
 
-    internal SpecialPowerModule(GameObject gameObject, GameEngine gameEngine, SpecialPowerModuleData moduleData) : base(gameObject, gameEngine)
+    internal SpecialPowerModule(GameObject gameObject, IGameEngine gameEngine, SpecialPowerModuleData moduleData) : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
         _reloadFrames = _moduleData.SpecialPower.Value.ReloadTime;
@@ -281,7 +281,7 @@ public class SpecialPowerModuleData : BehaviorModuleData
     [AddedIn(SageGame.Bfme2)]
     public ObjectFilter RequirementsFilterStrategic { get; private set; }
 
-    internal override SpecialPowerModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override SpecialPowerModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SpecialPowerModule(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -93,7 +93,7 @@ public class AIUpdate : UpdateModule
     // TODO(Port): Implement this.
     public bool IsMoving => false;
 
-    internal AIUpdate(GameObject gameObject, GameEngine gameEngine, AIUpdateModuleData moduleData)
+    internal AIUpdate(GameObject gameObject, IGameEngine gameEngine, AIUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         ModuleData = moduleData;
@@ -574,7 +574,7 @@ public class AIUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public int BurningDeathTime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new AIUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AnimalAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AnimalAIUpdate.cs
@@ -8,7 +8,7 @@ public class AnimalAIUpdate : AIUpdate
 {
     internal override AnimalAIUpdateModuleData ModuleData { get; }
 
-    internal AnimalAIUpdate(GameObject gameObject, GameEngine gameEngine, AnimalAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal AnimalAIUpdate(GameObject gameObject, IGameEngine gameEngine, AnimalAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
     }
@@ -39,7 +39,7 @@ public sealed class AnimalAIUpdateModuleData : AIUpdateModuleData
     public int UpdateTimer { get; private set; }
     public bool AfraidOfCastles { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new AnimalAIUpdate(gameObject, gameEngine, this); ;
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AssaultTransportAIUpdate.cs
@@ -9,7 +9,7 @@ public sealed class AssaultTransportAIUpdate : AIUpdate
 
     private readonly List<AssaultTransportMember> _members = new();
 
-    internal AssaultTransportAIUpdate(GameObject gameObject, GameEngine gameEngine, AssaultTransportAIUpdateModuleData moduleData)
+    internal AssaultTransportAIUpdate(GameObject gameObject, IGameEngine gameEngine, AssaultTransportAIUpdateModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
@@ -63,7 +63,7 @@ public sealed class AssaultTransportAIUpdateModuleData : AIUpdateModuleData
 
     public float MembersGetHealedAtLifeRatio { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new AssaultTransportAIUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/ChinookAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/ChinookAIUpdate.cs
@@ -14,7 +14,7 @@ public class ChinookAIUpdate : SupplyTruckAIUpdate
     private ChinookState _state;
     private ObjectId _airfieldToRepairAt;
 
-    internal ChinookAIUpdate(GameObject gameObject, GameEngine gameEngine, ChinookAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal ChinookAIUpdate(GameObject gameObject, IGameEngine gameEngine, ChinookAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
     }
@@ -67,7 +67,7 @@ internal sealed class ChinookAIUpdateStateMachine : AIUpdateStateMachine
 {
     public override ChinookAIUpdate AIUpdate { get; }
 
-    public ChinookAIUpdateStateMachine(GameObject gameObject, GameEngine gameEngine, ChinookAIUpdate aiUpdate)
+    public ChinookAIUpdateStateMachine(GameObject gameObject, IGameEngine gameEngine, ChinookAIUpdate aiUpdate)
         : base(gameObject, gameEngine, aiUpdate)
     {
         AIUpdate = aiUpdate;
@@ -134,7 +134,7 @@ public sealed class ChinookAIUpdateModuleData : SupplyTruckAIUpdateModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public string RotorWashParticleSystem { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new ChinookAIUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DeployStyleAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DeployStyleAIUpdate.cs
@@ -21,7 +21,7 @@ public class DeployStyleAIUpdate : AIUpdate
 
     private readonly UnknownStateData _unknownStateData = new();
 
-    internal DeployStyleAIUpdate(GameObject gameObject, GameEngine gameEngine, DeployStyleAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal DeployStyleAIUpdate(GameObject gameObject, IGameEngine gameEngine, DeployStyleAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
     }
@@ -103,7 +103,7 @@ public sealed class DeployStyleAIUpdateModuleData : AIUpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public string DeployedAttributeModifier { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new DeployStyleAIUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAIUpdate.cs
@@ -14,7 +14,7 @@ public sealed class DozerAIUpdate : AIUpdate, IBuilderAIUpdate
 
     private readonly DozerAndWorkerState _state;
 
-    internal DozerAIUpdate(GameObject gameObject, GameEngine gameEngine, DozerAIUpdateModuleData moduleData)
+    internal DozerAIUpdate(GameObject gameObject, IGameEngine gameEngine, DozerAIUpdateModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
@@ -92,7 +92,7 @@ public sealed class DozerAIUpdateModuleData : AIUpdateModuleData, IBuilderAIUpda
     public LogicFrameSpan BoredTime { get; private set; }
     public int BoredRange { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new DozerAIUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAndWorkerState.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAndWorkerState.cs
@@ -13,7 +13,7 @@ internal sealed class DozerAndWorkerState : IPersistableObject
     public GameObject? RepairTarget => TryGetRepairTarget(out var repairTarget) ? repairTarget : null;
 
     private readonly GameObject _gameObject;
-    private readonly GameEngine _gameEngine;
+    private readonly IGameEngine _gameEngine;
     private readonly AIUpdate _aiUpdate;
     private readonly IBuilderAIUpdateData _moduleData;
 
@@ -23,7 +23,7 @@ internal sealed class DozerAndWorkerState : IPersistableObject
     private readonly DozerSomething2[] _unknownList2 = new DozerSomething2[9]; // these seem to be in groups of 3, one group for each target
     private int _unknown4;
 
-    public DozerAndWorkerState(GameObject gameObject, GameEngine gameEngine, AIUpdate aiUpdate)
+    public DozerAndWorkerState(GameObject gameObject, IGameEngine gameEngine, AIUpdate aiUpdate)
     {
         _gameObject = gameObject;
         _gameEngine = gameEngine;
@@ -204,7 +204,7 @@ internal sealed class DozerAndWorkerState : IPersistableObject
 
     internal sealed class BuilderStateMachine : StateMachineBase
     {
-        public BuilderStateMachine(GameObject gameObject, GameEngine gameEngine, AIUpdate aiUpdate) : base(gameObject, gameEngine, aiUpdate)
+        public BuilderStateMachine(GameObject gameObject, IGameEngine gameEngine, AIUpdate aiUpdate) : base(gameObject, gameEngine, aiUpdate)
         {
             AddState(0, new BuilderUnknown0State(this));
             AddState(1, new BuilderUnknown1State(this));

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
@@ -13,7 +13,7 @@ public class FoundationAIUpdate : AIUpdate
     private LogicFrameSpan _updateInterval;
 
     //TODO: rather notify this when the corresponding order is processed and update again when the object is dead/destroyed
-    internal FoundationAIUpdate(GameObject gameObject, GameEngine gameEngine, FoundationAIUpdateModuleData moduleData)
+    internal FoundationAIUpdate(GameObject gameObject, IGameEngine gameEngine, FoundationAIUpdateModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
@@ -66,7 +66,7 @@ public class FoundationAIUpdateModuleData : AIUpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public int BuildVariation { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new FoundationAIUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/HackInternetAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/HackInternetAIUpdate.cs
@@ -13,7 +13,7 @@ public class HackInternetAIUpdate : AIUpdate
 
     private UnknownStateData? _packingUpData;
 
-    internal HackInternetAIUpdate(GameObject gameObject, GameEngine gameEngine, HackInternetAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal HackInternetAIUpdate(GameObject gameObject, IGameEngine gameEngine, HackInternetAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
     }
@@ -93,7 +93,7 @@ internal sealed class HackInternetAIUpdateStateMachine : AIUpdateStateMachine
 {
     public override HackInternetAIUpdate AIUpdate { get; }
 
-    public HackInternetAIUpdateStateMachine(GameObject gameObject, GameEngine gameEngine, HackInternetAIUpdate aiUpdate)
+    public HackInternetAIUpdateStateMachine(GameObject gameObject, IGameEngine gameEngine, HackInternetAIUpdate aiUpdate)
         : base(gameObject, gameEngine, aiUpdate)
     {
         AIUpdate = aiUpdate;
@@ -103,7 +103,7 @@ internal sealed class HackInternetAIUpdateStateMachine : AIUpdateStateMachine
         AddState(StopHackingInternetState.StateId, new StopHackingInternetState(this));
     }
 
-    internal LogicFrameSpan GetVariableFrames(LogicFrameSpan time, GameEngine gameEngine)
+    internal LogicFrameSpan GetVariableFrames(LogicFrameSpan time, IGameEngine gameEngine)
     {
         var variationFactor = AIUpdate.ModuleData.PackUnpackVariationFactor;
         var variation = gameEngine.GameLogic.Random.NextSingle(
@@ -166,7 +166,7 @@ public sealed class HackInternetAIUpdateModuleData : AIUpdateModuleData
     /// </example>
     public float PackUnpackVariationFactor { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new HackInternetAIUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/JetAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/JetAIUpdate.cs
@@ -56,7 +56,7 @@ public sealed class JetAIUpdate : AIUpdate
         MovingBackToHangar
     }
 
-    internal JetAIUpdate(GameObject gameObject, GameEngine gameEngine, JetAIUpdateModuleData moduleData)
+    internal JetAIUpdate(GameObject gameObject, IGameEngine gameEngine, JetAIUpdateModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
@@ -331,7 +331,7 @@ internal sealed class JetAIUpdateStateMachine : AIUpdateStateMachine
 {
     public override JetAIUpdate AIUpdate { get; }
 
-    public JetAIUpdateStateMachine(GameObject gameObject, GameEngine gameEngine, JetAIUpdate aiUpdate)
+    public JetAIUpdateStateMachine(GameObject gameObject, IGameEngine gameEngine, JetAIUpdate aiUpdate)
         : base(gameObject, gameEngine, aiUpdate)
     {
         AIUpdate = aiUpdate;
@@ -415,7 +415,7 @@ public sealed class JetAIUpdateModuleData : AIUpdateModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public Percentage TakeoffDistForMaxLift { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new JetAIUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/MissileAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/MissileAIUpdate.cs
@@ -31,7 +31,7 @@ public sealed class MissileAIUpdate : AIUpdate
 
     internal FXList DetonationFX { get; set; }
 
-    internal MissileAIUpdate(GameObject gameObject, GameEngine gameEngine, MissileAIUpdateModuleData moduleData)
+    internal MissileAIUpdate(GameObject gameObject, IGameEngine gameEngine, MissileAIUpdateModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
@@ -197,7 +197,7 @@ public sealed class MissileAIUpdateModuleData : AIUpdateModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public int DistanceScatterWhenJammed { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new MissileAIUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyAIUpdate.cs
@@ -40,7 +40,7 @@ public abstract class SupplyAIUpdate : AIUpdate
 
     protected virtual int GetAdditionalValuePerSupplyBox(ScopedAssetCollection<UpgradeTemplate> upgrades) => 0;
 
-    internal SupplyAIUpdate(GameObject gameObject, GameEngine gameEngine, SupplyAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal SupplyAIUpdate(GameObject gameObject, IGameEngine gameEngine, SupplyAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
         SupplyGatherState = SupplyGatherStates.Default;

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cs
@@ -12,7 +12,7 @@ public class SupplyTruckAIUpdate : SupplyAIUpdate
     private int _unknownInt;
     private bool _unknownBool;
 
-    internal SupplyTruckAIUpdate(GameObject gameObject, GameEngine gameEngine, SupplyTruckAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal SupplyTruckAIUpdate(GameObject gameObject, IGameEngine gameEngine, SupplyTruckAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
         _stateMachine = new SupplyAIUpdateStateMachine(gameObject, gameEngine, this);
@@ -40,7 +40,7 @@ public class SupplyTruckAIUpdateModuleData : SupplyAIUpdateModuleData
     internal new static readonly IniParseTable<SupplyTruckAIUpdateModuleData> FieldParseTable = SupplyAIUpdateModuleData.FieldParseTable
         .Concat(new IniParseTable<SupplyTruckAIUpdateModuleData> { });
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SupplyTruckAIUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TransportAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TransportAIUpdate.cs
@@ -6,7 +6,7 @@ public sealed class TransportAIUpdate : AIUpdate
 {
     internal override TransportAIUpdateModuleData ModuleData { get; }
 
-    internal TransportAIUpdate(GameObject gameObject, GameEngine gameEngine, TransportAIUpdateModuleData moduleData)
+    internal TransportAIUpdate(GameObject gameObject, IGameEngine gameEngine, TransportAIUpdateModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
@@ -32,7 +32,7 @@ public sealed class TransportAIUpdateModuleData : AIUpdateModuleData
     private new static readonly IniParseTable<TransportAIUpdateModuleData> FieldParseTable = AIUpdateModuleData.FieldParseTable
         .Concat(new IniParseTable<TransportAIUpdateModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new TransportAIUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TurretAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/TurretAIUpdate.cs
@@ -32,7 +32,7 @@ public class TurretAIUpdate : UpdateModule
         Recentering
     }
 
-    internal TurretAIUpdate(GameObject gameObject, GameEngine gameEngine, TurretAIUpdateModuleData moduleData)
+    internal TurretAIUpdate(GameObject gameObject, IGameEngine gameEngine, TurretAIUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -319,7 +319,7 @@ public sealed class TurretAIUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2Rotwk)]
     public int TurretMaxDeflectionACW { get; private set; }
 
-    internal TurretAIUpdate CreateTurretAIUpdate(GameObject gameObject, GameEngine gameEngine)
+    internal TurretAIUpdate CreateTurretAIUpdate(GameObject gameObject, IGameEngine gameEngine)
     {
         return new TurretAIUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WanderAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WanderAIUpdate.cs
@@ -6,7 +6,7 @@ public sealed class WanderAIUpdate : AIUpdate
 {
     internal override WanderAIUpdateModuleData ModuleData { get; }
 
-    internal WanderAIUpdate(GameObject gameObject, GameEngine gameEngine, WanderAIUpdateModuleData moduleData)
+    internal WanderAIUpdate(GameObject gameObject, IGameEngine gameEngine, WanderAIUpdateModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
@@ -32,7 +32,7 @@ public sealed class WanderAIUpdateModuleData : AIUpdateModuleData
     private new static readonly IniParseTable<WanderAIUpdateModuleData> FieldParseTable = AIUpdateModuleData.FieldParseTable
         .Concat(new IniParseTable<WanderAIUpdateModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new WanderAIUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
@@ -23,7 +23,7 @@ public class WorkerAIUpdate : SupplyAIUpdate, IBuilderAIUpdate
     private int _unknown6;
     private readonly WorkerAIUpdateStateMachine3 _stateMachine3;
 
-    internal WorkerAIUpdate(GameObject gameObject, GameEngine gameEngine, WorkerAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
+    internal WorkerAIUpdate(GameObject gameObject, IGameEngine gameEngine, WorkerAIUpdateModuleData moduleData) : base(gameObject, gameEngine, moduleData)
     {
         ModuleData = moduleData;
         _state = new DozerAndWorkerState(gameObject, gameEngine, this);
@@ -224,7 +224,7 @@ public class WorkerAIUpdate : SupplyAIUpdate, IBuilderAIUpdate
     {
         public override WorkerAIUpdate AIUpdate { get; }
 
-        public WorkerAIUpdateStateMachine3(GameObject gameObject, GameEngine gameEngine, WorkerAIUpdate aiUpdate) : base(gameObject, gameEngine, aiUpdate)
+        public WorkerAIUpdateStateMachine3(GameObject gameObject, IGameEngine gameEngine, WorkerAIUpdate aiUpdate) : base(gameObject, gameEngine, aiUpdate)
         {
             AIUpdate = aiUpdate;
 
@@ -284,7 +284,7 @@ public sealed class WorkerAIUpdateModuleData : SupplyAIUpdateModuleData, IBuilde
     [AddedIn(SageGame.Bfme)]
     public LogicFrameSpan HarvestActionTime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new WorkerAIUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AssistedTargetingUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AssistedTargetingUpdate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class AssistedTargetingUpdate : UpdateModule
 {
-    public AssistedTargetingUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public AssistedTargetingUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -36,7 +36,7 @@ public sealed class AssistedTargetingUpdateModuleData : UpdateModuleData
     public string LaserFromAssisted { get; private set; }
     public string LaserToTarget { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new AssistedTargetingUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
@@ -13,7 +13,7 @@ internal sealed class AutoDepositUpdate : UpdateModule
     private bool _shouldGrantInitialCaptureBonus = true; // this always starts as true, even if there is no capture bonus
     private bool _unknownBool2 = true;
 
-    internal AutoDepositUpdate(GameObject gameObject, GameEngine gameEngine, AutoDepositUpdateModuleData moduleData)
+    internal AutoDepositUpdate(GameObject gameObject, IGameEngine gameEngine, AutoDepositUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -144,7 +144,7 @@ public sealed class AutoDepositUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool OnlyWhenGarrisoned { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new AutoDepositUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/AutoFindHealingUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoFindHealingUpdate.cs
@@ -6,7 +6,7 @@ public sealed class AutoFindHealingUpdate : UpdateModule
 {
     private readonly AutoFindHealingUpdateModuleData _moduleData;
 
-    public AutoFindHealingUpdate(GameObject gameObject, GameEngine gameEngine, AutoFindHealingUpdateModuleData moduleData)
+    public AutoFindHealingUpdate(GameObject gameObject, IGameEngine gameEngine, AutoFindHealingUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -60,7 +60,7 @@ public sealed class AutoFindHealingUpdateModuleData : UpdateModuleData
     public float NeverHeal { get; private set; }
     public float AlwaysHeal { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new AutoFindHealingUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/BannerCarrierUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BannerCarrierUpdate.cs
@@ -8,7 +8,7 @@ public class BannerCarrierUpdate : UpdateModule
 {
     private BannerCarrierUpdateModuleData _moduleData;
 
-    public BannerCarrierUpdate(GameObject gameObject, GameEngine gameEngine, BannerCarrierUpdateModuleData moduleData)
+    public BannerCarrierUpdate(GameObject gameObject, IGameEngine gameEngine, BannerCarrierUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -58,7 +58,7 @@ public sealed class BannerCarrierUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public string UpgradeRequired { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new BannerCarrierUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/BaseRegenerateUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BaseRegenerateUpdate.cs
@@ -6,7 +6,7 @@ public sealed class BaseRegenerateUpdate : UpdateModule, IDamageModule
 {
     protected override LogicFrameSpan FramesBetweenUpdates { get; }
 
-    internal BaseRegenerateUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    internal BaseRegenerateUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
         SetNextUpdateFrame(new LogicFrame(uint.MaxValue));
         FramesBetweenUpdates = LogicFrameSpan.OneSecond(gameEngine.LogicFramesPerSecond);
@@ -54,7 +54,7 @@ public sealed class BaseRegenerateUpdateModuleData : UpdateModuleData
 
     private static readonly IniParseTable<BaseRegenerateUpdateModuleData> FieldParseTable = new IniParseTable<BaseRegenerateUpdateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new BaseRegenerateUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/BattlePlanUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BattlePlanUpdate.cs
@@ -30,7 +30,7 @@ public sealed class BattlePlanUpdate : UpdateModule
 
     private int _unknownInt;
 
-    internal BattlePlanUpdate(GameObject gameObject, GameEngine gameEngine, BattlePlanUpdateModuleData moduleData)
+    internal BattlePlanUpdate(GameObject gameObject, IGameEngine gameEngine, BattlePlanUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -406,7 +406,7 @@ public sealed class BattlePlanUpdateModuleData : UpdateModuleData
     // Revealing
     public LazyAssetReference<ObjectDefinition> VisionObjectName { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new BattlePlanUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/BoneFXUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BoneFXUpdate.cs
@@ -9,7 +9,7 @@ public sealed class BoneFXUpdate : UpdateModule
     private readonly List<uint> _particleSystemIds = new();
     private readonly int[] _unknownInts = new int[96];
 
-    public BoneFXUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public BoneFXUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -98,7 +98,7 @@ public sealed class BoneFXUpdateModuleData : UpdateModuleData
 
     public BoneFXUpdateParticleSystem PristineParticleSystem6 { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new BoneFXUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/CleanupHazardUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/CleanupHazardUpdate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class CleanupHazardUpdate : UpdateModule
 {
-    public CleanupHazardUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public CleanupHazardUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -38,7 +38,7 @@ public sealed class CleanupHazardUpdateModuleData : UpdateModuleData
     public int ScanRate { get; private set; }
     public float ScanRange { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new CleanupHazardUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/CommandButtonHuntUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/CommandButtonHuntUpdate.cs
@@ -6,7 +6,7 @@ public sealed class CommandButtonHuntUpdate : UpdateModule
 {
     private string _commandButtonName;
 
-    public CommandButtonHuntUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public CommandButtonHuntUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -31,7 +31,7 @@ public sealed class CommandButtonHuntUpdateModuleData : UpdateModuleData
 
     private static readonly IniParseTable<CommandButtonHuntUpdateModuleData> FieldParseTable = new IniParseTable<CommandButtonHuntUpdateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new CommandButtonHuntUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DeletionUpdate.cs
@@ -10,7 +10,7 @@ internal class DeletionUpdate : UpdateModule
 
     private LogicFrame _frameToDelete;
 
-    public DeletionUpdate(GameObject gameObject, GameEngine gameEngine, DeletionUpdateModuleData moduleData)
+    public DeletionUpdate(GameObject gameObject, IGameEngine gameEngine, DeletionUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -57,7 +57,7 @@ public sealed class DeletionUpdateModuleData : UpdateModuleData
     public LogicFrameSpan MinLifetime { get; private set; }
     public LogicFrameSpan MaxLifetime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new DeletionUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/DockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DockUpdate.cs
@@ -23,7 +23,7 @@ public abstract class DockUpdate : UpdateModule
     private ObjectId _unknownObjectId;
     private ushort _unknownInt1;
 
-    protected DockUpdate(GameObject gameObject, GameEngine gameEngine, DockUpdateModuleData moduleData)
+    protected DockUpdate(GameObject gameObject, IGameEngine gameEngine, DockUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;

--- a/src/OpenSage.Game/Logic/Object/Update/DynamicShroudClearingRangeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DynamicShroudClearingRangeUpdate.cs
@@ -15,7 +15,7 @@ public sealed class DynamicShroudClearingRangeUpdate : UpdateModule
     private float _unknown9;
     private float _unknownFloat;
 
-    public DynamicShroudClearingRangeUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public DynamicShroudClearingRangeUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -79,7 +79,7 @@ public sealed class DynamicShroudClearingRangeUpdateModuleData : UpdateModuleDat
 
     public RadiusDecalTemplate GridDecalTemplate { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new DynamicShroudClearingRangeUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ExperienceUpdate.cs
@@ -15,7 +15,7 @@ public class ExperienceUpdate : UpdateModule
 
     public bool ObjectGainsExperience { get; private set; }
 
-    internal ExperienceUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    internal ExperienceUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
         _initial = true;
     }

--- a/src/OpenSage.Game/Logic/Object/Update/FireSpreadUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FireSpreadUpdate.cs
@@ -7,7 +7,7 @@ namespace OpenSage.Logic.Object;
 public sealed class FireSpreadUpdate : UpdateModule
 {
     // TODO
-    public FireSpreadUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public FireSpreadUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -38,7 +38,7 @@ public sealed class FireSpreadUpdateModuleData : UpdateModuleData
     public TimeSpan MaxSpreadDelay { get; private set; }
     public int SpreadTryRange { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new FireSpreadUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/FireWeaponUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FireWeaponUpdate.cs
@@ -22,7 +22,7 @@ public sealed class FireWeaponUpdate : UpdateModule
     private uint _unknownUInt4;
     private uint _unknownUInt5;
 
-    public FireWeaponUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public FireWeaponUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -111,7 +111,7 @@ public sealed class FireWeaponUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public WeaponNugget FireWeaponNugget { get; private set; }
 
-    internal override FireWeaponUpdate CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override FireWeaponUpdate CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new FireWeaponUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/FlammableUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FlammableUpdate.cs
@@ -12,7 +12,7 @@ public sealed class FlammableUpdate : UpdateModule
     private float _remainingDamageBeforeCatchingFire;
     private uint _startedTakingFlameDamageFrame;
 
-    internal FlammableUpdate(GameObject gameObject, GameEngine gameEngine, FlammableUpdateModuleData moduleData)
+    internal FlammableUpdate(GameObject gameObject, IGameEngine gameEngine, FlammableUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -144,7 +144,7 @@ public sealed class FlammableUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public DamageType DamageType { get; internal set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new FlammableUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/HijackerUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/HijackerUpdate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class HijackerUpdate : UpdateModule
 {
-    public HijackerUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public HijackerUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -31,7 +31,7 @@ public sealed class HijackerUpdateModuleData : UpdateModuleData
 
     public string ParachuteName { get; private set; }
 
-    internal override HijackerUpdate CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override HijackerUpdate CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new HijackerUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/HordeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/HordeUpdate.cs
@@ -16,7 +16,7 @@ public sealed class HordeUpdate : UpdateModule
 
     protected override LogicFrameSpan FramesBetweenUpdates => _moduleData.UpdateRate;
 
-    internal HordeUpdate(GameObject gameObject, GameEngine gameEngine, HordeUpdateModuleData moduleData)
+    internal HordeUpdate(GameObject gameObject, IGameEngine gameEngine, HordeUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -160,7 +160,7 @@ public sealed class HordeUpdateModuleData : UpdateModuleData
     /// </summary>
     public WeaponBonusType Action { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new HordeUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
@@ -15,7 +15,7 @@ internal sealed class LifetimeUpdate : UpdateModule
         set => _frameToDie = value;
     }
 
-    public LifetimeUpdate(GameObject gameObject, GameEngine gameEngine, LifetimeUpdateModuleData moduleData)
+    public LifetimeUpdate(GameObject gameObject, IGameEngine gameEngine, LifetimeUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -69,7 +69,7 @@ public sealed class LifetimeUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme)]
     public DeathType DeathType { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new LifetimeUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/OCLUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/OCLUpdate.cs
@@ -7,7 +7,7 @@ public sealed class OCLUpdate : UpdateModule
 {
     private bool _unknownBool;
 
-    public OCLUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public OCLUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -56,7 +56,7 @@ public sealed class OCLUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public int Amount { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new OCLUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ParticleUplinkCannonUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ParticleUplinkCannonUpdate.cs
@@ -52,7 +52,7 @@ public sealed class ParticleUplinkCannonUpdate : UpdateModule
 
     private readonly ParticleUplinkCannonUpdateModuleData _moduleData;
 
-    internal ParticleUplinkCannonUpdate(GameObject gameObject, GameEngine gameEngine, ParticleUplinkCannonUpdateModuleData moduleData)
+    internal ParticleUplinkCannonUpdate(GameObject gameObject, IGameEngine gameEngine, ParticleUplinkCannonUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -264,7 +264,7 @@ public sealed class ParticleUplinkCannonUpdateModuleData : UpdateModuleData
 
     public LazyAssetReference<ObjectDefinition> DamagePulseRemnantObjectName { get; private set; }
 
-    internal override ParticleUplinkCannonUpdate CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override ParticleUplinkCannonUpdate CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new ParticleUplinkCannonUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/PowerPlantUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/PowerPlantUpdate.cs
@@ -12,7 +12,7 @@ public sealed class PowerPlantUpdate : UpdateModule
 
     private LogicFrame _rodsExtendedEndFrame;
 
-    internal PowerPlantUpdate(GameObject gameObject, GameEngine gameEngine, PowerPlantUpdateModuleData moduleData)
+    internal PowerPlantUpdate(GameObject gameObject, IGameEngine gameEngine, PowerPlantUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -93,7 +93,7 @@ public sealed class PowerPlantUpdateModuleData : UpdateModuleData
 
     public LogicFrameSpan RodsExtendTime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new PowerPlantUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/DefaultProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/DefaultProductionExitUpdate.cs
@@ -9,7 +9,7 @@ public sealed class DefaultProductionExitUpdate : UpdateModule, IHasRallyPoint, 
 
     private readonly DefaultProductionExitUpdateModuleData _moduleData;
 
-    internal DefaultProductionExitUpdate(GameObject gameObject, GameEngine gameEngine, DefaultProductionExitUpdateModuleData moduleData)
+    internal DefaultProductionExitUpdate(GameObject gameObject, IGameEngine gameEngine, DefaultProductionExitUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -52,7 +52,7 @@ public sealed class DefaultProductionExitUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public bool UseSpawnRallyPoint { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new DefaultProductionExitUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/QueueProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/QueueProductionExitUpdate.cs
@@ -12,7 +12,7 @@ public sealed class QueueProductionExitUpdate : UpdateModule, IHasRallyPoint, IP
     private LogicFrameSpan _framesUntilNextSpawn;
     private readonly QueueProductionExitUpdateModuleData _moduleData;
 
-    internal QueueProductionExitUpdate(GameObject gameObject, GameEngine gameEngine, QueueProductionExitUpdateModuleData moduleData)
+    internal QueueProductionExitUpdate(GameObject gameObject, IGameEngine gameEngine, QueueProductionExitUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -101,7 +101,7 @@ public sealed class QueueProductionExitUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool UseReturnToFormation { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new QueueProductionExitUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SpawnPointProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SpawnPointProductionExitUpdate.cs
@@ -10,7 +10,7 @@ public sealed class SpawnPointProductionExitUpdate : UpdateModule, IProductionEx
     private readonly SpawnPointProductionExitUpdateModuleData _moduleData;
     private int _nextIndex;
 
-    internal SpawnPointProductionExitUpdate(GameObject gameObject, GameEngine gameEngine, SpawnPointProductionExitUpdateModuleData moduleData)
+    internal SpawnPointProductionExitUpdate(GameObject gameObject, IGameEngine gameEngine, SpawnPointProductionExitUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -55,7 +55,7 @@ public sealed class SpawnPointProductionExitUpdateModuleData : UpdateModuleData
 
     public string SpawnPointBoneName { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SpawnPointProductionExitUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SupplyCenterProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SupplyCenterProductionExitUpdate.cs
@@ -9,7 +9,7 @@ public sealed class SupplyCenterProductionExitUpdate : UpdateModule, IHasRallyPo
 
     private readonly SupplyCenterProductionExitUpdateModuleData _moduleData;
 
-    internal SupplyCenterProductionExitUpdate(GameObject gameObject, GameEngine gameEngine, SupplyCenterProductionExitUpdateModuleData moduleData)
+    internal SupplyCenterProductionExitUpdate(GameObject gameObject, IGameEngine gameEngine, SupplyCenterProductionExitUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -55,7 +55,7 @@ public sealed class SupplyCenterProductionExitUpdateModuleData : UpdateModuleDat
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public int GrantTemporaryStealth { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SupplyCenterProductionExitUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionUpdate.cs
@@ -44,7 +44,7 @@ public sealed class ProductionUpdate : UpdateModule
 
     public IReadOnlyList<ProductionJob> ProductionQueue => _productionQueue;
 
-    internal ProductionUpdate(GameObject gameObject, GameEngine gameEngine, ProductionUpdateModuleData moduleData)
+    internal ProductionUpdate(GameObject gameObject, IGameEngine gameEngine, ProductionUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -711,7 +711,7 @@ public sealed class ProductionUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public List<ProductionModifier> ProductionModifiers { get; } = new List<ProductionModifier>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new ProductionUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ProjectileStreamUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProjectileStreamUpdate.cs
@@ -9,7 +9,7 @@ public sealed class ProjectileStreamUpdate : UpdateModule
     private uint _unknownInt2;
     private ObjectId _unknownObjectId;
 
-    public ProjectileStreamUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public ProjectileStreamUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -43,7 +43,7 @@ public sealed class ProjectileStreamUpdateModuleData : UpdateModuleData
 
     private static readonly IniParseTable<ProjectileStreamUpdateModuleData> FieldParseTable = new IniParseTable<ProjectileStreamUpdateModuleData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new ProjectileStreamUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/RadarUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RadarUpdate.cs
@@ -8,7 +8,7 @@ public sealed class RadarUpdate : UpdateModule
     private bool _isRadarExtending;
     private bool _isRadarExtended;
 
-    public RadarUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public RadarUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -37,7 +37,7 @@ public sealed class RadarUpdateModuleData : UpdateModuleData
 
     public int RadarExtendTime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new RadarUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/RebuildHoleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RebuildHoleUpdate.cs
@@ -26,7 +26,7 @@ public sealed class RebuildHoleUpdate : UpdateModule, IDieModule
     private string _structureObjectName; // the structure we're rebuilding
     private ObjectDefinition StructureObjectDefinition => GameEngine.Game.AssetStore.ObjectDefinitions.GetByName(_structureObjectName);
 
-    internal RebuildHoleUpdate(GameObject gameObject, GameEngine gameEngine, RebuildHoleUpdateModuleData moduleData)
+    internal RebuildHoleUpdate(GameObject gameObject, IGameEngine gameEngine, RebuildHoleUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -192,7 +192,7 @@ public sealed class RebuildHoleUpdateModuleData : UpdateModuleData
 
     public Percentage HoleHealthRegenPercentPerSecond { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new RebuildHoleUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/RepairDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RepairDockUpdate.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 public sealed class RepairDockUpdate : DockUpdate
 {
-    internal RepairDockUpdate(GameObject gameObject, GameEngine gameEngine, RepairDockUpdateModuleData moduleData)
+    internal RepairDockUpdate(GameObject gameObject, IGameEngine gameEngine, RepairDockUpdateModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
 
@@ -38,7 +38,7 @@ public sealed class RepairDockUpdateModuleData : DockUpdateModuleData
 
     public int TimeForFullHeal { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new RepairDockUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/SlavedUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SlavedUpdate.cs
@@ -37,7 +37,7 @@ public class SlavedUpdateModule : UpdateModule
 
     private FXParticleSystemTemplate _particleTemplate;
 
-    internal SlavedUpdateModule(GameObject gameObject, GameEngine gameEngine, SlavedUpdateModuleData moduleData)
+    internal SlavedUpdateModule(GameObject gameObject, IGameEngine gameEngine, SlavedUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -295,7 +295,7 @@ public sealed class SlavedUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public int FadeTime { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SlavedUpdateModule(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/SpecialAbilityUpdate/SpecialAbilityUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SpecialAbilityUpdate/SpecialAbilityUpdate.cs
@@ -13,7 +13,7 @@ public class SpecialAbilityUpdate : UpdateModule
     private bool _unknownBool3;
     private float _unknownFloat;
 
-    public SpecialAbilityUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public SpecialAbilityUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -214,7 +214,7 @@ public class SpecialAbilityUpdateModuleData : UpdateModuleData
 
     public int FreezeAfterTriggerDuration { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SpecialAbilityUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/SpectreGunshipDeploymentUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SpectreGunshipDeploymentUpdate.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 [AddedIn(SageGame.CncGeneralsZeroHour)]
 public sealed class SpectreGunshipDeploymentUpdate : UpdateModule
 {
-    public SpectreGunshipDeploymentUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public SpectreGunshipDeploymentUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -41,7 +41,7 @@ public sealed class SpectreGunshipDeploymentUpdateModuleData : BehaviorModuleDat
     public int AttackAreaRadius { get; private set; }
     public OCLCreateLocation CreateLocation { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SpectreGunshipDeploymentUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/StealthDetectorUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StealthDetectorUpdate.cs
@@ -12,7 +12,7 @@ public sealed class StealthDetectorUpdate : UpdateModule
 
     protected override LogicFrameSpan FramesBetweenUpdates => _moduleData.DetectionRate;
 
-    public StealthDetectorUpdate(GameObject gameObject, GameEngine gameEngine, StealthDetectorUpdateModuleData moduleData)
+    public StealthDetectorUpdate(GameObject gameObject, IGameEngine gameEngine, StealthDetectorUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -96,7 +96,7 @@ public sealed class StealthDetectorUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme2)]
     public string RequiredUpgrade { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new StealthDetectorUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/StealthUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StealthUpdate.cs
@@ -10,7 +10,7 @@ public sealed class StealthUpdate : UpdateModule
     private float _unknownFloat1;
     private float _unknownFloat2;
 
-    public StealthUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public StealthUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -180,7 +180,7 @@ public sealed class StealthUpdateModuleData : BehaviorModuleData
     [AddedIn(SageGame.Bfme2)]
     public string[] RequiredUpgradeNames { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new StealthUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/StickyBombUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StickyBombUpdate.cs
@@ -8,7 +8,7 @@ public sealed class StickyBombUpdate : UpdateModule
     private uint _unknown2;
     private uint _unknown3;
 
-    public StickyBombUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public StickyBombUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -47,7 +47,7 @@ public sealed class StickyBombUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public string GeometryBasedDamageFX { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new StickyBombUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/StructureCollapseUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StructureCollapseUpdate.cs
@@ -7,7 +7,7 @@ public class StructureCollapseUpdate : UpdateModule
 {
     private readonly StructureCollapseUpdateModuleData _moduleData;
 
-    public StructureCollapseUpdate(GameObject gameObject, GameEngine gameEngine, StructureCollapseUpdateModuleData moduleData)
+    public StructureCollapseUpdate(GameObject gameObject, IGameEngine gameEngine, StructureCollapseUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -64,7 +64,7 @@ public sealed class StructureCollapseUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme)]
     public int CollapseHeight { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new StructureCollapseUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/StructureToppleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StructureToppleUpdate.cs
@@ -7,7 +7,7 @@ public sealed class StructureToppleUpdate : UpdateModule
 {
     private float _unknownFloat;
 
-    public StructureToppleUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public StructureToppleUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -77,7 +77,7 @@ public sealed class StructureToppleUpdateModuleData : UpdateModuleData
     [AddedIn(SageGame.Bfme)]
     public int ForceToppleAngle { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new StructureToppleUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/SupplyCenterDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SupplyCenterDockUpdate.cs
@@ -8,7 +8,7 @@ public class SupplyCenterDockUpdate : DockUpdate
 {
     private SupplyCenterDockUpdateModuleData _moduleData;
 
-    internal SupplyCenterDockUpdate(GameObject gameObject, GameEngine gameEngine, SupplyCenterDockUpdateModuleData moduleData)
+    internal SupplyCenterDockUpdate(GameObject gameObject, IGameEngine gameEngine, SupplyCenterDockUpdateModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -75,7 +75,7 @@ public sealed class SupplyCenterDockUpdateModuleData : DockUpdateModuleData
     [AddedIn(SageGame.Bfme)]
     public float ValueMultiplier { get; private set; } = 1.0f;
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SupplyCenterDockUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/SupplyWarehouseDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SupplyWarehouseDockUpdate.cs
@@ -7,7 +7,7 @@ public class SupplyWarehouseDockUpdate : DockUpdate
     private SupplyWarehouseDockUpdateModuleData _moduleData;
     private int _currentBoxes;
 
-    internal SupplyWarehouseDockUpdate(GameObject gameObject, GameEngine gameEngine, SupplyWarehouseDockUpdateModuleData moduleData)
+    internal SupplyWarehouseDockUpdate(GameObject gameObject, IGameEngine gameEngine, SupplyWarehouseDockUpdateModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -73,7 +73,7 @@ public sealed class SupplyWarehouseDockUpdateModuleData : DockUpdateModuleData
     /// </summary>
     public bool DeleteWhenEmpty { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SupplyWarehouseDockUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/ToppleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ToppleUpdate.cs
@@ -71,7 +71,7 @@ public sealed class ToppleUpdate : UpdateModule, ICollideModule
 
     internal bool IsAbleToBeToppled => _toppleState == ToppleState.Upright;
 
-    internal ToppleUpdate(GameObject gameObject, GameEngine gameEngine, ToppleUpdateModuleData moduleData)
+    internal ToppleUpdate(GameObject gameObject, IGameEngine gameEngine, ToppleUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -428,7 +428,7 @@ public sealed class ToppleUpdateModuleData : UpdateModuleData
     public Percentage InitialAccelPercent { get; private set; } = new Percentage(StartAccelerationPercent);
     public LazyAssetReference<ObjectDefinition> StumpName { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new ToppleUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
@@ -14,7 +14,7 @@ public abstract class UpdateModule : BehaviorModule, IUpdateModule
 
     UpdateOrder IUpdateModule.UpdatePhase => UpdateOrder;
 
-    protected UpdateModule(GameObject gameObject, GameEngine gameEngine)
+    protected UpdateModule(GameObject gameObject, IGameEngine gameEngine)
         : base(gameObject, gameEngine)
     {
         _nextUpdateFrame.UpdateOrder = UpdateOrder;

--- a/src/OpenSage.Game/Logic/Object/Update/WaveGuideUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/WaveGuideUpdate.cs
@@ -5,7 +5,7 @@ namespace OpenSage.Logic.Object;
 public sealed class WaveGuideUpdate : UpdateModule
 {
     // TODO
-    public WaveGuideUpdate(GameObject gameObject, GameEngine gameEngine) : base(gameObject, gameEngine)
+    public WaveGuideUpdate(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
     }
 
@@ -64,7 +64,7 @@ public sealed class WaveGuideUpdateModuleData : UpdateModuleData
     public float BridgeParticleAngleFudge { get; private set; }
     public string LoopingSound { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new WaveGuideUpdate(gameObject, gameEngine);
     }

--- a/src/OpenSage.Game/Logic/Object/Update/WeaponSetUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/WeaponSetUpdate.cs
@@ -8,7 +8,7 @@ public sealed class WeaponSetUpdate : UpdateModule
 {
     private readonly WeaponSetUpdateModuleData _moduleData;
 
-    internal WeaponSetUpdate(GameObject gameObject, GameEngine gameEngine, WeaponSetUpdateModuleData moduleData)
+    internal WeaponSetUpdate(GameObject gameObject, IGameEngine gameEngine, WeaponSetUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
@@ -26,7 +26,7 @@ public sealed class WeaponSetUpdateModuleData : UpdateModuleData
     public List<WeaponSlotTurretData> WeaponSlotTurrets { get; } = new List<WeaponSlotTurretData>();
     public List<WeaponSlotHierarchicalTurretData> WeaponSlotHierarchicalTurrets { get; } = new List<WeaponSlotHierarchicalTurretData>();
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new WeaponSetUpdate(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ArmorUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ArmorUpgrade.cs
@@ -7,7 +7,7 @@ internal sealed class ArmorUpgrade : UpgradeModule
 {
     private readonly ArmorUpgradeModuleData _moduleData;
 
-    internal ArmorUpgrade(GameObject gameObject, GameEngine gameEngine, ArmorUpgradeModuleData moduleData)
+    internal ArmorUpgrade(GameObject gameObject, IGameEngine gameEngine, ArmorUpgradeModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -55,7 +55,7 @@ public sealed class ArmorUpgradeModuleData : UpgradeModuleData
     [AddedIn(SageGame.Bfme)]
     public bool IgnoreArmorUpgrade { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new ArmorUpgrade(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/CommandSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/CommandSetUpgrade.cs
@@ -8,7 +8,7 @@ internal class CommandSetUpgrade : UpgradeModule
 {
     private readonly CommandSetUpgradeModuleData _moduleData;
 
-    public CommandSetUpgrade(GameObject gameObject, GameEngine gameEngine, CommandSetUpgradeModuleData moduleData)
+    public CommandSetUpgrade(GameObject gameObject, IGameEngine gameEngine, CommandSetUpgradeModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -57,7 +57,7 @@ public sealed class CommandSetUpgradeModuleData : UpgradeModuleData
     [AddedIn(SageGame.CncGeneralsZeroHour)]
     public string TriggerAlt { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new CommandSetUpgrade(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ExperienceScalarUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ExperienceScalarUpgrade.cs
@@ -6,7 +6,7 @@ internal sealed class ExperienceScalarUpgrade : UpgradeModule
 {
     private readonly ExperienceScalarUpgradeModuleData _moduleData;
 
-    internal ExperienceScalarUpgrade(GameObject gameObject, GameEngine gameEngine, ExperienceScalarUpgradeModuleData moduleData)
+    internal ExperienceScalarUpgrade(GameObject gameObject, IGameEngine gameEngine, ExperienceScalarUpgradeModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -39,7 +39,7 @@ public sealed class ExperienceScalarUpgradeModuleData : UpgradeModuleData
 
     public float AddXPScalar { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new ExperienceScalarUpgrade(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/GeometryUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/GeometryUpgrade.cs
@@ -8,7 +8,7 @@ internal class GeometryUpgrade : UpgradeModule
 {
     private readonly GeometryUpgradeModuleData _moduleData;
 
-    internal GeometryUpgrade(GameObject gameObject, GameEngine gameEngine, GeometryUpgradeModuleData moduleData)
+    internal GeometryUpgrade(GameObject gameObject, IGameEngine gameEngine, GeometryUpgradeModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -57,7 +57,7 @@ public sealed class GeometryUpgradeModuleData : UpgradeModuleData
     public string RampMesh1 { get; private set; } // e.g. P2 where is that defined?
     public string RampMesh2 { get; private set; } // e.g. P3 where is that defined?
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new GeometryUpgrade(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/GrantScienceUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/GrantScienceUpgrade.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class GrantScienceUpgrade : UpgradeModule
 {
-    public GrantScienceUpgrade(GameObject gameObject, GameEngine gameEngine, UpgradeModuleData moduleData)
+    public GrantScienceUpgrade(GameObject gameObject, IGameEngine gameEngine, UpgradeModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
     }
@@ -31,7 +31,7 @@ public sealed class GrantScienceUpgradeModuleData : UpgradeModuleData
 
     public string GrantScience { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new GrantScienceUpgrade(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/LocomotorSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/LocomotorSetUpgrade.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class LocomotorSetUpgrade : UpgradeModule
 {
-    public LocomotorSetUpgrade(GameObject gameObject, GameEngine gameEngine, LocomotorSetUpgradeModuleData moduleData)
+    public LocomotorSetUpgrade(GameObject gameObject, IGameEngine gameEngine, LocomotorSetUpgradeModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
     }
@@ -30,7 +30,7 @@ public sealed class LocomotorSetUpgradeModuleData : UpgradeModuleData
     private static new readonly IniParseTable<LocomotorSetUpgradeModuleData> FieldParseTable = UpgradeModuleData.FieldParseTable
         .Concat(new IniParseTable<LocomotorSetUpgradeModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new LocomotorSetUpgrade(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/MaxHealthUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/MaxHealthUpgrade.cs
@@ -7,7 +7,7 @@ internal sealed class MaxHealthUpgrade : UpgradeModule
 {
     private readonly MaxHealthUpgradeModuleData _moduleData;
 
-    internal MaxHealthUpgrade(GameObject gameObject, GameEngine gameEngine, MaxHealthUpgradeModuleData moduleData)
+    internal MaxHealthUpgrade(GameObject gameObject, IGameEngine gameEngine, MaxHealthUpgradeModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -42,7 +42,7 @@ public sealed class MaxHealthUpgradeModuleData : UpgradeModuleData
     public float AddMaxHealth { get; private set; }
     public MaxHealthChangeType ChangeType { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new MaxHealthUpgrade(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
@@ -8,7 +8,7 @@ internal sealed class ObjectCreationUpgrade : UpgradeModule
 {
     private readonly ObjectCreationUpgradeModuleData _moduleData;
 
-    internal ObjectCreationUpgrade(GameObject gameObject, GameEngine gameEngine, ObjectCreationUpgradeModuleData moduleData)
+    internal ObjectCreationUpgrade(GameObject gameObject, IGameEngine gameEngine, ObjectCreationUpgradeModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -93,7 +93,7 @@ public sealed class ObjectCreationUpgradeModuleData : UpgradeModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool UseBuildingProduction { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new ObjectCreationUpgrade(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/PowerPlantUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/PowerPlantUpgrade.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class PowerPlantUpgrade : UpgradeModule
 {
-    internal PowerPlantUpgrade(GameObject gameObject, GameEngine gameEngine, PowerPlantUpgradeModuleData moduleData)
+    internal PowerPlantUpgrade(GameObject gameObject, IGameEngine gameEngine, PowerPlantUpgradeModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
     }
@@ -40,7 +40,7 @@ public sealed class PowerPlantUpgradeModuleData : UpgradeModuleData
     private static new readonly IniParseTable<PowerPlantUpgradeModuleData> FieldParseTable = UpgradeModuleData.FieldParseTable
         .Concat(new IniParseTable<PowerPlantUpgradeModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new PowerPlantUpgrade(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/RadarUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/RadarUpgrade.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class RadarUpgrade : UpgradeModule
 {
-    internal RadarUpgrade(GameObject gameObject, GameEngine gameEngine, RadarUpgradeModuleData moduleData)
+    internal RadarUpgrade(GameObject gameObject, IGameEngine gameEngine, RadarUpgradeModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
     }
@@ -35,7 +35,7 @@ public sealed class RadarUpgradeModuleData : UpgradeModuleData
 
     public bool DisableProof { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new RadarUpgrade(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/StealthUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/StealthUpgrade.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class StealthUpgrade : UpgradeModule
 {
-    public StealthUpgrade(GameObject gameObject, GameEngine gameEngine, StealthUpgradeModuleData moduleData)
+    public StealthUpgrade(GameObject gameObject, IGameEngine gameEngine, StealthUpgradeModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
     }
@@ -31,7 +31,7 @@ public sealed class StealthUpgradeModuleData : UpgradeModuleData
     private static new readonly IniParseTable<StealthUpgradeModuleData> FieldParseTable = UpgradeModuleData.FieldParseTable
         .Concat(new IniParseTable<StealthUpgradeModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new StealthUpgrade(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/SubObjectsUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/SubObjectsUpgrade.cs
@@ -10,7 +10,7 @@ internal class SubObjectsUpgrade : UpgradeModule
 {
     private readonly SubObjectsUpgradeModuleData _moduleData;
 
-    internal SubObjectsUpgrade(GameObject gameObject, GameEngine gameEngine, SubObjectsUpgradeModuleData moduleData)
+    internal SubObjectsUpgrade(GameObject gameObject, IGameEngine gameEngine, SubObjectsUpgradeModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -83,7 +83,7 @@ public sealed class SubObjectsUpgradeModuleData : UpgradeModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool HideSubObjectsOnRemove { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new SubObjectsUpgrade(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/UnpauseSpecialPowerUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/UnpauseSpecialPowerUpgrade.cs
@@ -7,7 +7,7 @@ internal sealed class UnpauseSpecialPowerUpgrade : UpgradeModule
 {
     private readonly UnpauseSpecialPowerUpgradeModuleData _moduleData;
 
-    internal UnpauseSpecialPowerUpgrade(GameObject gameObject, GameEngine gameEngine, UnpauseSpecialPowerUpgradeModuleData moduleData)
+    internal UnpauseSpecialPowerUpgrade(GameObject gameObject, IGameEngine gameEngine, UnpauseSpecialPowerUpgradeModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -51,7 +51,7 @@ public sealed class UnpauseSpecialPowerUpgradeModuleData : UpgradeModuleData
     [AddedIn(SageGame.Bfme2)]
     public bool ObeyRechageOnTrigger { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new UnpauseSpecialPowerUpgrade(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/UpgradeModule.cs
@@ -12,7 +12,7 @@ public abstract class UpgradeModule : BehaviorModule, IUpgradeableModule
 
     internal bool Triggered => _upgradeLogic.Triggered;
 
-    internal UpgradeModule(GameObject gameObject, GameEngine gameEngine, UpgradeModuleData moduleData) : base(gameObject, gameEngine)
+    internal UpgradeModule(GameObject gameObject, IGameEngine gameEngine, UpgradeModuleData moduleData) : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
         _upgradeLogic = new UpgradeLogic(moduleData.UpgradeData, OnUpgrade);

--- a/src/OpenSage.Game/Logic/Object/Upgrade/WeaponBonusUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/WeaponBonusUpgrade.cs
@@ -4,7 +4,7 @@ namespace OpenSage.Logic.Object;
 
 internal sealed class WeaponBonusUpgrade : UpgradeModule
 {
-    internal WeaponBonusUpgrade(GameObject gameObject, GameEngine gameEngine, WeaponBonusUpgradeModuleData moduleData)
+    internal WeaponBonusUpgrade(GameObject gameObject, IGameEngine gameEngine, WeaponBonusUpgradeModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
     }
@@ -29,7 +29,7 @@ public sealed class WeaponBonusUpgradeModuleData : UpgradeModuleData
     private static new readonly IniParseTable<WeaponBonusUpgradeModuleData> FieldParseTable = UpgradeModuleData.FieldParseTable
         .Concat(new IniParseTable<WeaponBonusUpgradeModuleData>());
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new WeaponBonusUpgrade(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Upgrade/WeaponSetUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/WeaponSetUpgrade.cs
@@ -6,7 +6,7 @@ internal sealed class WeaponSetUpgrade : UpgradeModule
 {
     private readonly WeaponSetUpgradeModuleData _moduleData;
 
-    internal WeaponSetUpgrade(GameObject gameObject, GameEngine gameEngine, WeaponSetUpgradeModuleData moduleData)
+    internal WeaponSetUpgrade(GameObject gameObject, IGameEngine gameEngine, WeaponSetUpgradeModuleData moduleData)
         : base(gameObject, gameEngine, moduleData)
     {
         _moduleData = moduleData;
@@ -44,7 +44,7 @@ public sealed class WeaponSetUpgradeModuleData : UpgradeModuleData
 
     public WeaponSetConditions WeaponCondition { get; private set; }
 
-    internal override BehaviorModule CreateModule(GameObject gameObject, GameEngine gameEngine)
+    internal override BehaviorModule CreateModule(GameObject gameObject, IGameEngine gameEngine)
     {
         return new WeaponSetUpgrade(gameObject, gameEngine, this);
     }

--- a/src/OpenSage.Game/Logic/Object/Weapon/Weapon.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/Weapon.cs
@@ -67,7 +67,7 @@ public sealed class Weapon : IPersistableObject
         GameObject gameObject,
         WeaponTemplate weaponTemplate,
         WeaponSlot slot,
-        GameEngine gameContext)
+        IGameEngine gameEngine)
     {
         ParentGameObject = gameObject;
         Template = weaponTemplate;
@@ -82,7 +82,7 @@ public sealed class Weapon : IPersistableObject
             new WeaponStateContext(
                 gameObject,
                 this,
-                gameContext));
+                gameEngine));
 
         _usingFlag = ModelConditionFlagUtility.GetUsingWeaponFlag(WeaponIndex);
     }

--- a/src/OpenSage.Game/Logic/Object/Weapon/WeaponEffects/WeaponEffectExecutionContext.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/WeaponEffects/WeaponEffectExecutionContext.cs
@@ -3,9 +3,9 @@
 internal sealed class WeaponEffectExecutionContext
 {
     public readonly Weapon Weapon;
-    public readonly GameEngine GameEngine;
+    public readonly IGameEngine GameEngine;
 
-    public WeaponEffectExecutionContext(Weapon weapon, GameEngine gameEngine)
+    public WeaponEffectExecutionContext(Weapon weapon, IGameEngine gameEngine)
     {
         Weapon = weapon;
         GameEngine = gameEngine;

--- a/src/OpenSage.Game/Logic/Object/Weapon/WeaponSet.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/WeaponSet.cs
@@ -6,7 +6,7 @@ namespace OpenSage.Logic.Object;
 public sealed class WeaponSet : IPersistableObject
 {
     private readonly GameObject _gameObject;
-    private readonly GameEngine _gameEngine;
+    private readonly IGameEngine _gameEngine;
     private readonly Weapon[] _weapons;
     private WeaponTemplateSet _currentWeaponTemplateSet;
     private WeaponSlot _currentWeaponSlot;
@@ -21,7 +21,7 @@ public sealed class WeaponSet : IPersistableObject
     internal Weapon CurrentWeapon => _weapons[(int)_currentWeaponSlot];
     public IEnumerable<Weapon> Weapons => _weapons;
 
-    internal WeaponSet(GameObject gameObject, GameEngine gameEngine)
+    internal WeaponSet(GameObject gameObject, IGameEngine gameEngine)
     {
         _gameObject = gameObject;
         _gameEngine = gameEngine;

--- a/src/OpenSage.Game/Logic/Object/Weapon/WeaponStates/WeaponStateMachine.cs
+++ b/src/OpenSage.Game/Logic/Object/Weapon/WeaponStates/WeaponStateMachine.cs
@@ -11,17 +11,17 @@ namespace OpenSage.Logic.Object;
 /// transitions to Inactive.
 ///
 /// When first created, the weapon has a full clip equal to ClipSize.
-/// 
+///
 /// Inactive
 /// ========
 /// The weapon starts out in the Inactive state.
-/// 
+///
 /// If:
 /// - the weapon is in the Inactive state
 /// - and it has less than a full clip
 /// - and AutoReloadsClip is Yes or ReturnToBase
 /// then it transitions to InactivePendingReload.
-/// 
+///
 /// When the weapon is given a new target, it transitions to the PreAttack state.
 ///
 /// InactivePendingReload
@@ -132,16 +132,16 @@ internal sealed class WeaponStateContext
 {
     public readonly GameObject GameObject;
     public readonly Weapon Weapon;
-    public readonly GameEngine GameEngine;
+    public readonly IGameEngine GameEngine;
 
     public WeaponStateContext(
         GameObject gameObject,
         Weapon weapon,
-        GameEngine gameContext)
+        IGameEngine gameEngine)
     {
         GameObject = gameObject;
         Weapon = weapon;
-        GameEngine = gameContext;
+        GameEngine = gameEngine;
     }
 }
 

--- a/src/OpenSage.Game/Logic/OrderGenerators/ConstructBuildingOrderGenerator.cs
+++ b/src/OpenSage.Game/Logic/OrderGenerators/ConstructBuildingOrderGenerator.cs
@@ -32,8 +32,8 @@ public sealed class ConstructBuildingOrderGenerator : OrderGenerator, IDisposabl
         int definitionIndex,
         GameData config,
         Player player,
-        GameEngine gameContext,
-        IScene3D scene) : base(gameContext.Game)
+        IGameEngine gameEngine,
+        IScene3D scene) : base(gameEngine.Game)
     {
         _buildingDefinition = buildingDefinition;
         _definitionIndex = definitionIndex;
@@ -45,7 +45,7 @@ public sealed class ConstructBuildingOrderGenerator : OrderGenerator, IDisposabl
 
         _previewObject = new GameObject(
             buildingDefinition,
-            gameContext,
+            gameEngine,
             player)
         {
             IsPlacementPreview = true

--- a/src/OpenSage.Game/Logic/OrderGenerators/SpecialPowerOrderGenerator.cs
+++ b/src/OpenSage.Game/Logic/OrderGenerators/SpecialPowerOrderGenerator.cs
@@ -39,7 +39,7 @@ public sealed class SpecialPowerOrderGenerator : OrderGenerator, IDisposable
     private readonly SpecialPowerCursorInformation _cursorInformation;
     private readonly GameData _config;
     private readonly Player _player;
-    private readonly GameEngine _gameEngine;
+    private readonly IGameEngine _gameEngine;
     private readonly SpecialPowerTargetType _targetType;
     private readonly IScene3D _scene;
 
@@ -53,10 +53,10 @@ public sealed class SpecialPowerOrderGenerator : OrderGenerator, IDisposable
        SpecialPowerCursorInformation cursorInformation,
        GameData config,
        Player player,
-       GameEngine gameContext,
+       IGameEngine gameEngine,
        SpecialPowerTargetType targetType,
        IScene3D scene,
-       in TimeInterval time) : base(gameContext.Game)
+       in TimeInterval time) : base(gameEngine.Game)
     {
         _specialPower = cursorInformation.SpecialPower;
         _cursorInformation = cursorInformation;
@@ -64,7 +64,7 @@ public sealed class SpecialPowerOrderGenerator : OrderGenerator, IDisposable
         _scene = scene;
         _config = config;
         _player = player;
-        _gameEngine = gameContext;
+        _gameEngine = gameEngine;
 
         // TODO: Improve this check.
         var radiusCursors = _scene.GameEngine.AssetLoadContext.AssetStore.InGameUI.Current.RadiusCursors;

--- a/src/OpenSage.Game/Scene25D.cs
+++ b/src/OpenSage.Game/Scene25D.cs
@@ -15,7 +15,7 @@ public class Scene25D(IScene3D scene3D, AssetStore assetStore)
     protected IGameObjectCollection GameObjects => scene3D.GameObjects;
     protected Camera Camera => scene3D.Camera;
     protected GameData GameData => assetStore.GameData.Current;
-    protected GameEngine GameEngine => scene3D.GameEngine;
+    protected IGameEngine GameEngine => scene3D.GameEngine;
 
     private Player LocalPlayer => scene3D.LocalPlayer;
 

--- a/src/OpenSage.Game/Scene3D.cs
+++ b/src/OpenSage.Game/Scene3D.cs
@@ -38,7 +38,7 @@ public sealed class Scene3D : DisposableBase, IScene3D
     private EditorCameraInputState _editorCameraInputState;
     public IEditorCameraController EditorCameraController { get; }
 
-    public GameEngine GameEngine { get; }
+    public IGameEngine GameEngine { get; }
 
     public SelectionGui SelectionGui { get; }
 

--- a/src/OpenSage.Game/Terrain/Bridge.cs
+++ b/src/OpenSage.Game/Terrain/Bridge.cs
@@ -19,12 +19,12 @@ public sealed class Bridge : DisposableBase
     private readonly List<Tuple<ModelSubObject, Matrix4x4>> _meshes;
 
     internal Bridge(
-        GameEngine gameContext,
+        IGameEngine gameEngine,
         MapObject mapObject,
         in Vector3 startPosition,
         in Vector3 endPosition)
     {
-        var template = gameContext.AssetLoadContext.AssetStore.BridgeTemplates.GetByName(mapObject.TypeName);
+        var template = gameEngine.AssetLoadContext.AssetStore.BridgeTemplates.GetByName(mapObject.TypeName);
         if (template == null)
         {
             return;
@@ -37,19 +37,19 @@ public sealed class Bridge : DisposableBase
         }
 
         // TODO: Cache this.
-        var genericBridgeDefinition = gameContext.AssetLoadContext.AssetStore.ObjectDefinitions.GetByName("GenericBridge");
+        var genericBridgeDefinition = gameEngine.AssetLoadContext.AssetStore.ObjectDefinitions.GetByName("GenericBridge");
 
-        _bridgeObject = gameContext.GameLogic.CreateObject(genericBridgeDefinition, null);
+        _bridgeObject = gameEngine.GameLogic.CreateObject(genericBridgeDefinition, null);
         _bridgeObject.SetMapObjectProperties(mapObject);
 
         _model = model;
 
-        _modelInstance = AddDisposable(_model.CreateInstance(gameContext.AssetLoadContext));
+        _modelInstance = AddDisposable(_model.CreateInstance(gameEngine.AssetLoadContext));
 
         _modelInstance.Update(TimeInterval.Zero);
 
         _meshes = CreateMeshes(
-            gameContext,
+            gameEngine,
             template,
             startPosition,
             endPosition,
@@ -58,7 +58,7 @@ public sealed class Bridge : DisposableBase
     }
 
     private List<Tuple<ModelSubObject, Matrix4x4>> CreateMeshes(
-        GameEngine gameContext,
+        IGameEngine gameEngine,
         BridgeTemplate template,
         in Vector3 startPosition,
         in Vector3 endPosition,
@@ -83,10 +83,10 @@ public sealed class Bridge : DisposableBase
         var lengthRight = GetLength(bridgeRight) * template.BridgeScale;
 
         var startPositionWithHeight = startPosition;
-        startPositionWithHeight.Z = gameContext.Scene3D.Terrain.HeightMap.GetHeight(startPosition.X, startPosition.Y) + heightBias;
+        startPositionWithHeight.Z = gameEngine.Scene3D.Terrain.HeightMap.GetHeight(startPosition.X, startPosition.Y) + heightBias;
 
         var endPositionWithHeight = endPosition;
-        endPositionWithHeight.Z = gameContext.Scene3D.Terrain.HeightMap.GetHeight(endPosition.X, endPosition.Y) + heightBias;
+        endPositionWithHeight.Z = gameEngine.Scene3D.Terrain.HeightMap.GetHeight(endPosition.X, endPosition.Y) + heightBias;
 
         var horizontalDistance = Vector3.Distance(startPosition, endPosition);
 
@@ -144,7 +144,7 @@ public sealed class Bridge : DisposableBase
         new BridgeTowers(
             template,
             _bridgeObject.Owner,
-            gameContext,
+            gameEngine,
             worldMatrix,
             0,
             transformedLeftBounds.Min.Y,

--- a/src/OpenSage.Game/Terrain/BridgeTowers.cs
+++ b/src/OpenSage.Game/Terrain/BridgeTowers.cs
@@ -7,14 +7,14 @@ namespace OpenSage.Terrain;
 public sealed class BridgeTowers
 {
     internal static BridgeTowers CreateForLandmarkBridge(
-        GameEngine gameContext,
+        IGameEngine gameEngine,
         GameObject gameObject)
     {
         var worldMatrix =
             Matrix4x4.CreateFromQuaternion(gameObject.Rotation)
             * Matrix4x4.CreateTranslation(gameObject.Translation);
 
-        var landmarkBridgeTemplate = gameContext.AssetLoadContext.AssetStore.BridgeTemplates.GetByName(gameObject.Definition.Name);
+        var landmarkBridgeTemplate = gameEngine.AssetLoadContext.AssetStore.BridgeTemplates.GetByName(gameObject.Definition.Name);
 
         var geometryShape = gameObject.Definition.Geometry.Shapes[0];
 
@@ -24,7 +24,7 @@ public sealed class BridgeTowers
         return new BridgeTowers(
             landmarkBridgeTemplate,
             gameObject.Owner,
-            gameContext,
+            gameEngine,
             worldMatrix,
             -halfWidth,
             -halfLength,
@@ -36,7 +36,7 @@ public sealed class BridgeTowers
     internal BridgeTowers(
         BridgeTemplate template,
         Player owner,
-        GameEngine gameContext,
+        IGameEngine gameEngine,
         Matrix4x4 worldMatrix,
         float startX,
         float startY,
@@ -46,7 +46,7 @@ public sealed class BridgeTowers
     {
         void CreateTower(ObjectDefinition objectDefinition, float x, float y)
         {
-            var tower = gameContext.GameLogic.CreateObject(objectDefinition, owner);
+            var tower = gameEngine.GameLogic.CreateObject(objectDefinition, owner);
 
             var translation = Vector3.Transform(
                 new Vector3(x, y, 0),


### PR DESCRIPTION
Fixes #1333 

I also cleaned up a few places where we had things like `GameEngine gameContext` and renamed them to `gameEngine`, so the parameter names should all be the same now.