### PR TITLE
Use consistent Update method for UpdateModule

### DIFF
--- a/src/OpenSage.Game/FX/FXList.cs
+++ b/src/OpenSage.Game/FX/FXList.cs
@@ -59,13 +59,4 @@ public sealed class FXList : BaseAsset
             nugget.Execute(context);
         }
     }
-
-    internal void Execute(BehaviorUpdateContext context)
-    {
-        Execute(
-            new FXListExecutionContext(
-                context.GameObject.Rotation,
-                context.GameObject.Translation,
-                context.GameEngine));
-    }
 }

--- a/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
+++ b/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
@@ -34,8 +34,6 @@ public abstract class BehaviorModule : ObjectModule
     {
     }
 
-    internal virtual void OnDamageStateChanged(BehaviorUpdateContext context, BodyDamageType fromDamage, BodyDamageType toDamage) { }
-
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);
@@ -43,22 +41,6 @@ public abstract class BehaviorModule : ObjectModule
         reader.BeginObject("Base");
         base.Load(reader);
         reader.EndObject();
-    }
-}
-
-internal sealed class BehaviorUpdateContext
-{
-    public readonly IGameEngine GameEngine;
-    public readonly GameObject GameObject;
-
-    public LogicFrame LogicFrame => GameEngine.GameLogic.CurrentFrame;
-
-    public BehaviorUpdateContext(
-        IGameEngine gameEngine,
-        GameObject gameObject)
-    {
-        GameEngine = gameEngine;
-        GameObject = gameObject;
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/AutoHealBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/AutoHealBehavior.cs
@@ -1,5 +1,4 @@
-﻿using FixedMath.NET;
-using OpenSage.Data.Ini;
+﻿using OpenSage.Data.Ini;
 using OpenSage.Mathematics;
 
 namespace OpenSage.Logic.Object;
@@ -8,8 +7,6 @@ namespace OpenSage.Logic.Object;
 // not UpgradeModule (but in the xsds it inherits from UpgradeModule).
 public sealed class AutoHealBehavior : UpdateModule, IUpgradeableModule, IDamageModule
 {
-    protected override LogicFrameSpan FramesBetweenUpdates => _moduleData.HealingDelay;
-
     private readonly AutoHealBehaviorModuleData _moduleData;
     private readonly UpgradeLogic _upgradeLogic;
     /// <summary>
@@ -50,11 +47,12 @@ public sealed class AutoHealBehavior : UpdateModule, IUpgradeableModule, IDamage
         }
     }
 
-    private protected override void RunUpdate(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
-        if (context.LogicFrame < _endOfStartHealingDelay)
+        if (GameEngine.GameLogic.CurrentFrame < _endOfStartHealingDelay)
         {
-            return;
+            // TODO(Port): Use correct value.
+            return UpdateSleepTime.None;
         }
 
         if (_moduleData.Radius == 0)
@@ -77,7 +75,8 @@ public sealed class AutoHealBehavior : UpdateModule, IUpgradeableModule, IDamage
                 HealUnit(GameObject);
             }
 
-            return;
+            // TODO(Port): Use correct value.
+            return UpdateSleepTime.None;
         }
 
         foreach (var candidate in GameEngine.Quadtree.FindNearby(GameObject, GameObject.Transform, _moduleData.Radius))
@@ -87,6 +86,9 @@ public sealed class AutoHealBehavior : UpdateModule, IUpgradeableModule, IDamage
 
             HealUnit(candidate);
         }
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     // todo: lots of duplicated logic between this and propagandatowerbehavior
@@ -127,7 +129,7 @@ public sealed class AutoHealBehavior : UpdateModule, IUpgradeableModule, IDamage
             gameObject.AttemptHealing(_moduleData.HealingAmount, GameObject);
             if (gameObject != GameObject)
             {
-                gameObject.SetBeingHealed(GameObject, NextUpdateFrame.Frame);
+                gameObject.SetBeingHealed(GameObject, _moduleData.HealingDelay);
             }
         }
     }

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BridgeBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BridgeBehavior.cs
@@ -18,6 +18,12 @@ public sealed class BridgeBehavior : UpdateModule
         return _towerIds[(int)towerType];
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Behaviors/BuildingBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/BuildingBehavior.cs
@@ -23,7 +23,7 @@ public class BuildingBehavior : UpdateModule
         _isGlowing = false;
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
         // TODO: get proper values for these
         var night = false;
@@ -88,6 +88,9 @@ public class BuildingBehavior : UpdateModule
         {
             _initial = false;
         }
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/CastleBehavior.cs
@@ -82,13 +82,15 @@ internal sealed class CastleBehavior : FoundationAIUpdate
         IsUnpacked = true;
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
+        var result = base.Update();
+
         if (IsUnpacked)
         {
             // not sure if this is correct, or does any object with BASE_FOUNDATION or BASE_SITE automatically get a FoundationAIUpdate?
-            FoundationAIUpdate.CheckForStructure(context, GameObject, ref _waitUntil, _updateInterval);
-            return;
+            FoundationAIUpdate.CheckForStructure(GameObject, GameEngine, ref _waitUntil, _updateInterval);
+            return result;
         }
 
         // TODO: Figure out the other unpack conditions
@@ -97,7 +99,7 @@ internal sealed class CastleBehavior : FoundationAIUpdate
             Unpack(GameObject.Owner, instant: true);
         }
 
-        var nearbyUnits = context.GameEngine.Game.PartitionCellManager.QueryObjects(
+        var nearbyUnits = GameEngine.Game.PartitionCellManager.QueryObjects(
             GameObject,
             GameObject.Translation,
             _moduleData.ScanDistance,
@@ -106,7 +108,7 @@ internal sealed class CastleBehavior : FoundationAIUpdate
         if (!nearbyUnits.Any())
         {
             GameObject.Owner = _nativePlayer;
-            return;
+            return result;
         }
 
         // TODO: check if all nearby units are from the same owner
@@ -121,9 +123,11 @@ internal sealed class CastleBehavior : FoundationAIUpdate
             if (distance < _moduleData.ScanDistance)
             {
                 GameObject.Owner = unit.Owner;
-                return;
+                return result;
             }
         }
+
+        return result;
     }
 
     private CastleEntry FindCastle(string side)

--- a/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDamagedBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/FireWeaponWhenDamagedBehavior.cs
@@ -85,14 +85,18 @@ public sealed class FireWeaponWhenDamagedBehavior : UpdateModule, IUpgradeableMo
         FireWeaponIfPresentAndReady(_reactionWeapons);
     }
 
-    private protected override void RunUpdate(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
         if (!UpgradeLogic.Triggered)
         {
-            return;
+            // TODO(Port): Use correct value.
+            return UpdateSleepTime.None;
         }
 
         FireWeaponIfPresentAndReady(_continuousWeapons);
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     private void FireWeaponIfPresentAndReady(Weapon?[] weapons)

--- a/src/OpenSage.Game/Logic/Object/Behaviors/GateOpenAndCloseBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/GateOpenAndCloseBehavior.cs
@@ -53,24 +53,27 @@ public class GateOpenAndCloseBehavior : UpdateModule
         }
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
-        var audioSystem = context.GameEngine.AudioSystem;
+        var audioSystem = GameEngine.AudioSystem;
+
+        var currentFrame = GameEngine.GameLogic.CurrentFrame;
 
         switch (_state)
         {
             case DoorState.Idle:
-                return;
+                // TODO(Port): Use correct value.
+                return UpdateSleepTime.None;
 
             case DoorState.StartOpening:
                 audioSystem.DisposeSource(_closingSoundLoop);
                 GameObject.ModelConditionFlags.Set(ModelConditionFlag.Door1Closing, false);
                 GameObject.ModelConditionFlags.Set(ModelConditionFlag.Door1Opening, true);
-                _toggleFinishedTime = context.LogicFrame + _moduleData.ResetTime;
-                _pathingToggleTime = context.LogicFrame + (_moduleData.ResetTime * _moduleData.PercentOpenForPathing);
+                _toggleFinishedTime = currentFrame + _moduleData.ResetTime;
+                _pathingToggleTime = currentFrame + (_moduleData.ResetTime * _moduleData.PercentOpenForPathing);
 
                 _openingSoundLoop = audioSystem.PlayAudioEvent(GameObject, _moduleData.SoundOpeningGateLoop?.Value, true);
-                _finishedSoundTime = context.LogicFrame + _moduleData.TimeBeforePlayingOpenSound;
+                _finishedSoundTime = currentFrame + _moduleData.TimeBeforePlayingOpenSound;
 
                 _state = DoorState.Opening;
                 _toggledColliders = false;
@@ -78,7 +81,7 @@ public class GateOpenAndCloseBehavior : UpdateModule
                 break;
 
             case DoorState.Opening:
-                if (!_toggledColliders && context.LogicFrame >= _pathingToggleTime)
+                if (!_toggledColliders && currentFrame >= _pathingToggleTime)
                 {
                     GameObject.HideCollider(_closedGeometry);
                     foreach (var openCollider in _openGeometries)
@@ -87,13 +90,13 @@ public class GateOpenAndCloseBehavior : UpdateModule
                     }
                     _toggledColliders = true;
                 }
-                if (!_playedFinishedSound && context.LogicFrame >= _finishedSoundTime)
+                if (!_playedFinishedSound && currentFrame >= _finishedSoundTime)
                 {
                     audioSystem.DisposeSource(_openingSoundLoop);
                     audioSystem.PlayAudioEvent(GameObject, _moduleData.SoundFinishedOpeningGate?.Value);
                     _playedFinishedSound = true;
                 }
-                if (context.LogicFrame >= _toggleFinishedTime)
+                if (currentFrame >= _toggleFinishedTime)
                 {
                     _open = true;
                     _state = DoorState.Idle;
@@ -104,11 +107,11 @@ public class GateOpenAndCloseBehavior : UpdateModule
                 audioSystem.DisposeSource(_openingSoundLoop);
                 GameObject.ModelConditionFlags.Set(ModelConditionFlag.Door1Opening, false);
                 GameObject.ModelConditionFlags.Set(ModelConditionFlag.Door1Closing, true);
-                _toggleFinishedTime = context.LogicFrame + _moduleData.ResetTime;
-                _pathingToggleTime = context.LogicFrame + (_moduleData.ResetTime * _moduleData.PercentOpenForPathing);
+                _toggleFinishedTime = currentFrame + _moduleData.ResetTime;
+                _pathingToggleTime = currentFrame + (_moduleData.ResetTime * _moduleData.PercentOpenForPathing);
 
                 _closingSoundLoop = audioSystem.PlayAudioEvent(GameObject, _moduleData.SoundClosingGateLoop?.Value, true);
-                _finishedSoundTime = context.LogicFrame + _moduleData.TimeBeforePlayingClosedSound;
+                _finishedSoundTime = currentFrame + _moduleData.TimeBeforePlayingClosedSound;
 
                 _state = DoorState.Closing;
                 _toggledColliders = false;
@@ -116,7 +119,7 @@ public class GateOpenAndCloseBehavior : UpdateModule
                 break;
 
             case DoorState.Closing:
-                if (!_toggledColliders && context.LogicFrame >= _pathingToggleTime)
+                if (!_toggledColliders && currentFrame >= _pathingToggleTime)
                 {
                     GameObject.ShowCollider(_closedGeometry);
                     foreach (var openCollider in _openGeometries)
@@ -125,19 +128,22 @@ public class GateOpenAndCloseBehavior : UpdateModule
                     }
                     _toggledColliders = true;
                 }
-                if (!_playedFinishedSound && context.LogicFrame >= _finishedSoundTime)
+                if (!_playedFinishedSound && currentFrame >= _finishedSoundTime)
                 {
                     audioSystem.DisposeSource(_closingSoundLoop);
                     audioSystem.PlayAudioEvent(GameObject, _moduleData.SoundFinishedClosingGate?.Value);
                     _playedFinishedSound = true;
                 }
-                if (context.LogicFrame >= _toggleFinishedTime)
+                if (currentFrame >= _toggleFinishedTime)
                 {
                     _open = false;
                     _state = DoorState.Idle;
                 }
                 break;
         }
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/GenerateMinefieldBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/GenerateMinefieldBehavior.cs
@@ -65,7 +65,7 @@ public sealed class GenerateMinefieldBehavior : BehaviorModule, IUpgradeableModu
 
     private void GenerateMinefield()
     {
-        _moduleData.GenerationFX?.Value.Execute(new BehaviorUpdateContext(GameEngine, GameObject));
+        _moduleData.GenerationFX?.Value.Execute(new FXListExecutionContext(GameObject.Rotation, GameObject.Translation, GameEngine));
 
         var mineTemplate = _moduleData.MineName?.Value;
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/MinefieldBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/MinefieldBehavior.cs
@@ -12,6 +12,12 @@ public sealed class MinefieldBehavior : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/OverchargeBehavior.cs
@@ -1,5 +1,4 @@
-﻿using FixedMath.NET;
-using ImGuiNET;
+﻿using ImGuiNET;
 using OpenSage.Data.Ini;
 using OpenSage.Mathematics;
 
@@ -43,13 +42,13 @@ public sealed class OverchargeBehavior : UpdateModule
         }
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
         if (!_enabled || // nothing to do if we aren't currently overcharging
-            GameObject.BodyModule.Health < GameObject.BodyModule.MaxHealth * _moduleData.NotAllowedWhenHealthBelowPercent || // must be above min health percent
-            context.LogicFrame.Value < NextUpdateFrame.Frame) // must be ready for us to do more damage
+            GameObject.BodyModule.Health < GameObject.BodyModule.MaxHealth * _moduleData.NotAllowedWhenHealthBelowPercent) // must be above min health percent
         {
-            return;
+            // TODO(Port): Use correct value.
+            return UpdateSleepTime.None;
         }
 
         GameObject.AttemptDamage(new DamageInfoInput(GameObject)
@@ -58,6 +57,9 @@ public sealed class OverchargeBehavior : UpdateModule
             Amount = GameObject.BodyModule.MaxHealth * _moduleData.HealthPercentToDrainPerSecond / GameEngine.LogicFramesPerSecond,
         });
         SetNextUpdateFrame(new LogicFrame((uint)GameEngine.LogicFramesPerSecond));
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Behaviors/ParkingPlaceBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/ParkingPlaceBehavior.cs
@@ -77,7 +77,7 @@ public sealed class ParkingPlaceBehaviour : UpdateModule, IHasRallyPoint, IProdu
         _parkingSlots[^1] = ParkingSlot.Empty;
     }
 
-    private protected override void RunUpdate(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
         if (_healingData.Count == 0)
         {
@@ -85,7 +85,7 @@ public sealed class ParkingPlaceBehaviour : UpdateModule, IHasRallyPoint, IProdu
         }
         else
         {
-            if (_nextHealFrame <= context.LogicFrame)
+            if (_nextHealFrame <= GameEngine.GameLogic.CurrentFrame)
             {
                 _nextHealFrame += _healUpdateRate;
                 foreach (var objectToHeal in _healingData)
@@ -96,7 +96,8 @@ public sealed class ParkingPlaceBehaviour : UpdateModule, IHasRallyPoint, IProdu
             }
         }
 
-        base.RunUpdate(context);
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     public int NextSpawnableSlot()

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PassiveAreaEffectBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PassiveAreaEffectBehavior.cs
@@ -18,15 +18,16 @@ public class PassiveAreaEffectBehavior : UpdateModule
         _moduleData = moduleData;
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
-        if (context.LogicFrame < _nextPing)
+        if (GameEngine.GameLogic.CurrentFrame < _nextPing)
         {
-            return;
+            // TODO(Port): Use correct value.
+            return UpdateSleepTime.None;
         }
-        _nextPing = context.LogicFrame + _moduleData.PingDelay;
+        _nextPing = GameEngine.GameLogic.CurrentFrame + _moduleData.PingDelay;
 
-        var nearbyObjects = context.GameEngine.Game.PartitionCellManager.QueryObjects(
+        var nearbyObjects = GameEngine.Game.PartitionCellManager.QueryObjects(
             GameObject,
             GameObject.Translation,
             _moduleData.EffectRadius,
@@ -41,6 +42,9 @@ public class PassiveAreaEffectBehavior : UpdateModule
                 nearbyObject.AddAttributeModifier(modifier.Value.Name, new AttributeModifier(modifier.Value));
             }
         }
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PoisonedBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PoisonedBehavior.cs
@@ -10,6 +10,12 @@ public sealed class PoisonedBehavior : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(2);

--- a/src/OpenSage.Game/Logic/Object/Behaviors/PropagandaTowerBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/PropagandaTowerBehavior.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using FixedMath.NET;
 using OpenSage.Content;
 using OpenSage.Data.Ini;
 using OpenSage.FX;
@@ -9,8 +8,6 @@ namespace OpenSage.Logic.Object;
 
 public sealed class PropagandaTowerBehavior : UpdateModule
 {
-    protected override LogicFrameSpan FramesBetweenUpdates => _moduleData.DelayBetweenUpdates;
-
     private readonly PropagandaTowerBehaviorModuleData _moduleData;
     private uint _unknownFrame;
     private readonly List<ObjectId> _objectIds = new();
@@ -26,11 +23,12 @@ public sealed class PropagandaTowerBehavior : UpdateModule
         _allowedKinds.Set(ObjectKinds.Vehicle, true);
     }
 
-    private protected override void RunUpdate(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
         if (GameObject.IsBeingConstructed())
         {
-            return;
+            // TODO(Port): Use correct value.
+            return UpdateSleepTime.None;
         }
 
         foreach (var unitId in ObjectsInRange)
@@ -47,7 +45,11 @@ public sealed class PropagandaTowerBehavior : UpdateModule
 
         var fx = GetFxList();
 
-        fx.Value.Execute(context);
+        fx.Value.Execute(
+            new FXListExecutionContext(
+                GameObject.Rotation,
+                GameObject.Translation,
+                GameEngine));
 
         foreach (var candidate in GameEngine.Quadtree.FindNearby(GameObject, GameObject.Transform, _moduleData.Radius))
         {
@@ -56,6 +58,9 @@ public sealed class PropagandaTowerBehavior : UpdateModule
             _objectIds.Add(candidate.Id);
             HealUnit(candidate);
         }
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     private GameObject GameObjectForId(ObjectId unitId)

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
@@ -109,36 +109,40 @@ public class SlowDeathBehavior : UpdateModule, IDieModule
         // TODO: Weapon
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
         if (!_isDying)
         {
-            return;
+            // TODO(Port): Use correct value.
+            return UpdateSleepTime.None;
         }
 
         // TODO: SlowDeathPhase.HitGround
 
         // Midpoint
-        if (!_passedMidpoint && context.LogicFrame >= _midpointTime)
+        if (!_passedMidpoint && GameEngine.GameLogic.CurrentFrame >= _midpointTime)
         {
             ExecutePhaseActions(SlowDeathPhase.Midpoint);
             _passedMidpoint = true;
         }
 
         // Destruction
-        if (context.LogicFrame >= _destructionTime)
+        if (GameEngine.GameLogic.CurrentFrame >= _destructionTime)
         {
             ExecutePhaseActions(SlowDeathPhase.Final);
-            context.GameObject.ModelConditionFlags.Set(ModelConditionFlag.Dying, false);
-            context.GameEngine.GameLogic.DestroyObject(context.GameObject);
+            GameObject.ModelConditionFlags.Set(ModelConditionFlag.Dying, false);
+            GameEngine.GameLogic.DestroyObject(GameObject);
             _isDying = false;
         }
 
         // Sinking
-        if (context.LogicFrame >= _sinkStartTime)
+        if (GameEngine.GameLogic.CurrentFrame >= _sinkStartTime)
         {
-            context.GameObject.VerticalOffset -= _moduleData.SinkRate;
+            GameObject.VerticalOffset -= _moduleData.SinkRate;
         }
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     internal override void DrawInspector()

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SlowDeathBehavior.cs
@@ -94,7 +94,7 @@ public class SlowDeathBehavior : UpdateModule, IDieModule
 
         if (_moduleData.OCLs.TryGetValue(phase, out var ocl) && ocl != null)
         {
-            GameEngine.ObjectCreationLists.Create(ocl.Value, new BehaviorUpdateContext(GameEngine, GameObject));
+            GameEngine.ObjectCreationLists.Create(ocl.Value, GameObject, GameEngine);
         }
 
         if (_moduleData.FXs.TryGetValue(phase, out var fx) && fx != null)

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
@@ -7,7 +7,7 @@ using OpenSage.Data.Ini;
 
 namespace OpenSage.Logic.Object;
 
-internal sealed class SpawnBehavior : BehaviorModule, IUpdateModule
+internal sealed class SpawnBehavior : UpdateModule
 {
     SpawnBehaviorModuleData _moduleData;
 
@@ -121,7 +121,7 @@ internal sealed class SpawnBehavior : BehaviorModule, IUpdateModule
         }
     }
 
-    public void Update(BehaviorUpdateContext context)
+    private protected override void RunUpdate(BehaviorUpdateContext context)
     {
         if (_initial && !GameObject.IsBeingConstructed())
         {

--- a/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/SpawnBehavior.cs
@@ -121,7 +121,7 @@ internal sealed class SpawnBehavior : UpdateModule
         }
     }
 
-    private protected override void RunUpdate(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
         if (_initial && !GameObject.IsBeingConstructed())
         {
@@ -130,6 +130,9 @@ internal sealed class SpawnBehavior : UpdateModule
         }
 
         // TODO: respawn killed/dead units
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Behaviors/TechBuildingBehavior.cs
+++ b/src/OpenSage.Game/Logic/Object/Behaviors/TechBuildingBehavior.cs
@@ -8,6 +8,12 @@ public sealed class TechBuildingBehavior : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Contain/GarrisonContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/GarrisonContain.cs
@@ -17,7 +17,7 @@ public sealed class GarrisonContain : OpenContainModule
     {
     }
 
-    private protected override void UpdateModuleSpecific(BehaviorUpdateContext context)
+    private protected override void UpdateModuleSpecific()
     {
         var isGarrisoned = ContainedObjectIds.Count > 0;
 

--- a/src/OpenSage.Game/Logic/Object/Contain/HealContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/HealContain.cs
@@ -15,7 +15,7 @@ public sealed class HealContain : OpenContainModule
         _moduleData = moduleData;
     }
 
-    private protected override void UpdateModuleSpecific(BehaviorUpdateContext context)
+    private protected override void UpdateModuleSpecific()
     {
         HealUnits(_moduleData.TimeForFullHeal);
         foreach (var unitId in ContainedObjectIds)

--- a/src/OpenSage.Game/Logic/Object/Contain/HordeContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/HordeContain.cs
@@ -151,9 +151,10 @@ public sealed class HordeContainBehavior : UpdateModule
         }
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
-
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OpenContain.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using FixedMath.NET;
 using ImGuiNET;
 using OpenSage.Audio;
 using OpenSage.Data.Ini;
@@ -117,9 +116,9 @@ public abstract class OpenContainModule : UpdateModule, IHasRallyPoint
         return GameObject.BodyModule.Health <= 0;
     }
 
-    internal sealed override void Update(BehaviorUpdateContext context)
+    public sealed override UpdateSleepTime Update()
     {
-        UpdateModuleSpecific(context);
+        UpdateModuleSpecific();
 
         if (HealthTooLowToHoldUnits())
         {
@@ -132,14 +131,17 @@ public abstract class OpenContainModule : UpdateModule, IHasRallyPoint
         }
         else
         {
-            while (_evacQueue.Count > 0 && TryEvacUnit(context.LogicFrame, _evacQueue[0].ObjectId))
+            while (_evacQueue.Count > 0 && TryEvacUnit(GameEngine.GameLogic.CurrentFrame, _evacQueue[0].ObjectId))
             {
                 _evacQueue.RemoveAt(0);
             }
         }
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
-    private protected virtual void UpdateModuleSpecific(BehaviorUpdateContext context) { }
+    private protected virtual void UpdateModuleSpecific() { }
 
     protected virtual bool TryEvacUnit(LogicFrame currentFrame, ObjectId unitId)
     {

--- a/src/OpenSage.Game/Logic/Object/Contain/OverlordContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/OverlordContain.cs
@@ -12,7 +12,7 @@ public sealed class OverlordContain : TransportContain
         _moduleData = moduleData;
     }
 
-    private protected override void UpdateModuleSpecific(BehaviorUpdateContext context)
+    private protected override void UpdateModuleSpecific()
     {
         // todo: ExperienceSinkForRider
     }

--- a/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TransportContain.cs
@@ -34,7 +34,7 @@ public class TransportContain : OpenContainModule
         return unit.Definition.TransportSlotCount;
     }
 
-    private protected override void UpdateModuleSpecific(BehaviorUpdateContext context)
+    private protected override void UpdateModuleSpecific()
     {
         if (_moduleData.HealthRegenPercentPerSecond != 0)
         {

--- a/src/OpenSage.Game/Logic/Object/Contain/TunnelContain.cs
+++ b/src/OpenSage.Game/Logic/Object/Contain/TunnelContain.cs
@@ -35,7 +35,7 @@ public sealed class TunnelContain : OpenContainModule, IDieModule
         }
     }
 
-    private protected override void UpdateModuleSpecific(BehaviorUpdateContext context)
+    private protected override void UpdateModuleSpecific()
     {
         HealUnits(_moduleData.TimeForFullHeal);
     }

--- a/src/OpenSage.Game/Logic/Object/Damage/DamageModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/DamageModule.cs
@@ -1,9 +1,21 @@
 ﻿namespace OpenSage.Logic.Object;
 
-public abstract class DamageModule : BehaviorModule
+public abstract class DamageModule : BehaviorModule, IDamageModule
 {
     protected DamageModule(GameObject gameObject, IGameEngine gameEngine) : base(gameObject, gameEngine)
     {
+    }
+
+    public virtual void OnDamage(in DamageInfo damageInfo) { }
+
+    public virtual void OnHealing(in DamageInfo damageInfo) { }
+
+    public virtual void OnBodyDamageStateChange(
+        in DamageInfo damageInfo,
+        BodyDamageType oldState,
+        BodyDamageType newState)
+    {
+
     }
 
     internal override void Load(StatePersister reader)
@@ -18,7 +30,7 @@ public abstract class DamageModule : BehaviorModule
 
 internal interface IDamageModule
 {
-    void OnDamage(in DamageInfo damageInfo);
+    void OnDamage(in DamageInfo damageInfo) { }
 
     void OnHealing(in DamageInfo damageInfo) { }
 

--- a/src/OpenSage.Game/Logic/Object/Damage/TransitionDamageFX.cs
+++ b/src/OpenSage.Game/Logic/Object/Damage/TransitionDamageFX.cs
@@ -22,11 +22,11 @@ public sealed class TransitionDamageFX : DamageModule
         _moduleData = moduleData;
     }
 
-    internal override void OnDamageStateChanged(BehaviorUpdateContext context, BodyDamageType fromDamage, BodyDamageType toDamage)
+    public override void OnBodyDamageStateChange(in DamageInfo damageInfo, BodyDamageType oldState, BodyDamageType newState)
     {
         List<TransitionDamageParticleSystem> particleSystems = null;
 
-        switch ((fromDamage, toDamage))
+        switch ((oldState, newState))
         {
             case (BodyDamageType.Pristine, BodyDamageType.Damaged):
                 particleSystems = _moduleData.DamagedParticleSystems;
@@ -43,11 +43,11 @@ public sealed class TransitionDamageFX : DamageModule
 
         if (particleSystems != null)
         {
-            var worldMatrix = context.GameObject.TransformMatrix;
+            var worldMatrix = GameObject.TransformMatrix;
 
             foreach (var particleSystemTemplate in particleSystems)
             {
-                context.GameEngine.ParticleSystems
+                GameEngine.ParticleSystems
                     .Create(particleSystemTemplate.ParticleSystem.Value, worldMatrix);
             }
         }

--- a/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/CreateObjectDie.cs
@@ -17,7 +17,8 @@ public sealed class CreateObjectDie : DieModule
     {
         GameEngine.ObjectCreationLists.Create(
             _moduleData.CreationList.Value,
-            new BehaviorUpdateContext(GameEngine, GameObject));
+            GameObject,
+            GameEngine);
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Die/EjectPilotDie.cs
+++ b/src/OpenSage.Game/Logic/Object/Die/EjectPilotDie.cs
@@ -25,7 +25,7 @@ public sealed class EjectPilotDie : DieModule
 
         var isOnGround = true; // todo: determine if unit is airborne
         var creationList = isOnGround ? _moduleData.GroundCreationList : _moduleData.AirCreationList;
-        foreach (var gameObject in GameEngine.ObjectCreationLists.Create(creationList.Value, new BehaviorUpdateContext(GameEngine, GameObject)))
+        foreach (var gameObject in GameEngine.ObjectCreationLists.Create(creationList.Value, GameObject, GameEngine))
         {
             gameObject.Rank = GameObject.Rank;
             GameEngine.AudioSystem.PlayAudioEvent(gameObject, GameObject.Definition.UnitSpecificSounds.VoiceEject?.Value);

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -140,8 +140,6 @@ public sealed class GameObject : Entity, IInspectable, ICollidable, IPersistable
 
     private readonly IGameEngine _gameEngine;
 
-    private readonly BehaviorUpdateContext _behaviorUpdateContext;
-
     internal BitArray<WeaponSetConditions> WeaponSetConditions;
     private readonly WeaponSet _weaponSet;
     public WeaponSet ActiveWeaponSet => _weaponSet;
@@ -472,8 +470,6 @@ public sealed class GameObject : Entity, IInspectable, ICollidable, IPersistable
         _gameEngine = gameEngine;
         Owner = owner ?? gameEngine.Game.PlayerManager.GetCivilianPlayer();
 
-        _behaviorUpdateContext = new BehaviorUpdateContext(gameEngine, this);
-
         _weaponSet = new WeaponSet(this, _gameEngine);
         WeaponSetConditions = new BitArray<WeaponSetConditions>();
         UpdateWeaponSet();
@@ -767,7 +763,7 @@ public sealed class GameObject : Entity, IInspectable, ICollidable, IPersistable
                 }
                 if (behavior is IUpdateModule updateModule && updateModule.UpdatePhase == updatePhase)
                 {
-                    updateModule.Update(_behaviorUpdateContext);
+                    updateModule.Update();
                 }
             }
         }

--- a/src/OpenSage.Game/Logic/Object/GameObject.cs
+++ b/src/OpenSage.Game/Logic/Object/GameObject.cs
@@ -209,7 +209,7 @@ public sealed class GameObject : Entity, IInspectable, ICollidable, IPersistable
     private int _unknown5;
     private uint _unknownFrame;
     public ObjectId HealedByObjectId;
-    public uint HealedEndFrame;
+    public LogicFrame HealedEndFrame;
     private BitArray<WeaponBonusType> _weaponBonusTypes = new();
     private byte _weaponSomethingPrimary;
     private byte _weaponSomethingSecondary;
@@ -1527,18 +1527,18 @@ public sealed class GameObject : Entity, IInspectable, ICollidable, IPersistable
         Owner.DeselectUnit(this);
     }
 
-    internal void SetBeingHealed(GameObject healer, uint endFrame)
+    internal void SetBeingHealed(GameObject healer, LogicFrameSpan duration)
     {
         HealedByObjectId = healer.Id;
-        HealedEndFrame = endFrame;
+        HealedEndFrame = _gameEngine.GameLogic.CurrentFrame + duration;
     }
 
     private void VerifyHealer()
     {
-        if (HealedByObjectId.IsValid && _gameEngine.GameLogic.CurrentFrame.Value >= HealedEndFrame)
+        if (HealedByObjectId.IsValid && _gameEngine.GameLogic.CurrentFrame >= HealedEndFrame)
         {
             HealedByObjectId = ObjectId.Invalid;
-            HealedEndFrame = 0; // todo: is this reset?
+            HealedEndFrame = LogicFrame.Zero; // todo: is this reset?
         }
     }
 
@@ -1776,7 +1776,7 @@ public sealed class GameObject : Entity, IInspectable, ICollidable, IPersistable
         reader.EndArray();
 
         reader.PersistObjectId(ref HealedByObjectId);
-        reader.PersistFrame(ref HealedEndFrame);
+        reader.PersistLogicFrame(ref HealedEndFrame);
         reader.PersistBitArray(ref WeaponSetConditions);
         reader.PersistBitArrayAsUInt32(ref _weaponBonusTypes);
 

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectDefectionHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectDefectionHelper.cs
@@ -10,6 +10,12 @@ internal sealed class ObjectDefectionHelper : ObjectHelperModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectFiringTrackerHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectFiringTrackerHelper.cs
@@ -11,6 +11,12 @@ internal sealed class ObjectFiringTrackerHelper : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectRepulsorHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectRepulsorHelper.cs
@@ -7,6 +7,12 @@ internal sealed class ObjectRepulsorHelper : ObjectHelperModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectSpecialModelConditionHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectSpecialModelConditionHelper.cs
@@ -12,6 +12,12 @@ internal sealed class ObjectSpecialModelConditionHelper : ObjectHelperModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Helpers/ObjectWeaponStatusHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/ObjectWeaponStatusHelper.cs
@@ -9,6 +9,12 @@ internal sealed class ObjectWeaponStatusHelper : ObjectHelperModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Helpers/StatusDamageHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/StatusDamageHelper.cs
@@ -12,6 +12,12 @@ internal sealed class StatusDamageHelper : ObjectHelperModule
         // TODO(Port): Implement this.
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Helpers/SubdualDamageHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/SubdualDamageHelper.cs
@@ -11,6 +11,12 @@ internal sealed class SubdualDamageHelper : ObjectHelperModule
         // TODO(Port): Implement this.
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Helpers/TempWeaponBonusHelper.cs
+++ b/src/OpenSage.Game/Logic/Object/Helpers/TempWeaponBonusHelper.cs
@@ -8,6 +8,12 @@ internal sealed class TempWeaponBonusHelper : ObjectHelperModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/SpecialPower/OCLSpecialPower.cs
+++ b/src/OpenSage.Game/Logic/Object/SpecialPower/OCLSpecialPower.cs
@@ -53,8 +53,7 @@ public class OCLSpecialPowerModule : SpecialPowerModule
         }
         else
         {
-            var context = new BehaviorUpdateContext(GameEngine, GameObject);
-            GameEngine.ObjectCreationLists.CreateAtPosition(_activeOcl, context, spawnPosition);
+            GameEngine.ObjectCreationLists.CreateAtPosition(_activeOcl, GameObject, GameEngine, spawnPosition);
         }
 
         if (_moduleData.CreateLocation is OCLCreateLocation.CreateAtEdgeNearSource

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -262,13 +262,13 @@ public class AIUpdate : UpdateModule
         // TODO(Port): Implement this.
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
         StateMachine.Update();
 
         if (_turretAIUpdate != null)
         {
-            _turretAIUpdate.Update(context, ModuleData.AutoAcquireEnemiesWhenIdle);
+            _turretAIUpdate.Update(ModuleData.AutoAcquireEnemiesWhenIdle);
         }
         else
         {
@@ -282,7 +282,7 @@ public class AIUpdate : UpdateModule
 
         if (GameObject.ModelConditionFlags.Get(ModelConditionFlag.Moving))
         {
-            context.GameEngine.Quadtree.Update(GameObject);
+            GameEngine.Quadtree.Update(GameObject);
         }
 
         if (CurrentLocomotor != null)
@@ -329,7 +329,8 @@ public class AIUpdate : UpdateModule
 
                 if (!reachedAngle)
                 {
-                    return;
+                    // TODO(Port): Use correct value.
+                    return UpdateSleepTime.None;
                 }
 
                 _targetDirection = null;
@@ -342,7 +343,8 @@ public class AIUpdate : UpdateModule
             }
         }
 
-        base.Update(context);
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     internal override void DrawInspector()

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAIUpdate.cs
@@ -64,10 +64,13 @@ public sealed class DozerAIUpdate : AIUpdate, IBuilderAIUpdate
         _state.ArrivedAtDestination();
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
-        base.Update(context);
-        _state.Update(context);
+        var sleepTime = base.Update();
+
+        _state.Update();
+
+        return sleepTime;
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/FoundationAIUpdate.cs
@@ -20,21 +20,25 @@ public class FoundationAIUpdate : AIUpdate
         _updateInterval = new LogicFrameSpan((uint)MathF.Ceiling(GameEngine.LogicFramesPerSecond / 2)); // 0.5s, we do not have to check every frame
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
-        CheckForStructure(context, GameObject, ref _waitUntil, _updateInterval);
+        var result = base.Update();
+
+        CheckForStructure(GameObject, GameEngine, ref _waitUntil, _updateInterval);
+
+        return result;
     }
 
-    internal static void CheckForStructure(BehaviorUpdateContext context, GameObject obj, ref LogicFrame waitUntil, LogicFrameSpan interval)
+    internal static void CheckForStructure(GameObject obj, IGameEngine gameEngine, ref LogicFrame waitUntil, LogicFrameSpan interval)
     {
-        if (context.LogicFrame < waitUntil)
+        if (gameEngine.GameLogic.CurrentFrame < waitUntil)
         {
             return;
         }
 
-        waitUntil = context.LogicFrame + interval;
+        waitUntil = gameEngine.GameLogic.CurrentFrame + interval;
 
-        var collidingObjects = context.GameEngine.Game.PartitionCellManager.QueryObjects(
+        var collidingObjects = gameEngine.Game.PartitionCellManager.QueryObjects(
             obj,
             obj.Translation,
             obj.Geometry.BoundingCircleRadius,

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/HackInternetAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/HackInternetAIUpdate.cs
@@ -20,7 +20,7 @@ public class HackInternetAIUpdate : AIUpdate
 
     private protected override HackInternetAIUpdateStateMachine CreateStateMachine() => new(GameObject, GameEngine, this);
 
-    private protected override void RunUpdate(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
         if (StateMachine.CurrentState is IdleState)
         {
@@ -30,6 +30,9 @@ public class HackInternetAIUpdate : AIUpdate
             }
             _packingUpData = null;
         }
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     public void StartHackingInternet()

--- a/src/OpenSage.Game/Logic/Object/Update/AssistedTargetingUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AssistedTargetingUpdate.cs
@@ -8,6 +8,12 @@ public sealed class AssistedTargetingUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoDepositUpdate.cs
@@ -19,19 +19,21 @@ internal sealed class AutoDepositUpdate : UpdateModule
         _moduleData = moduleData;
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
         if (GameObject.IsBeingConstructed())
         {
-            return;
+            // TODO(Port): Use correct value.
+            return UpdateSleepTime.None;
         }
 
-        if (context.LogicFrame < _nextAwardFrame)
+        if (GameEngine.GameLogic.CurrentFrame < _nextAwardFrame)
         {
-            return;
+            // TODO(Port): Use correct value.
+            return UpdateSleepTime.None;
         }
 
-        _nextAwardFrame = context.LogicFrame + _moduleData.DepositTiming;
+        _nextAwardFrame = GameEngine.GameLogic.CurrentFrame + _moduleData.DepositTiming;
         var amount = (uint)(_moduleData.DepositAmount * GameObject.ProductionModifier);
 
         if (_moduleData.UpgradedBoost.HasValue && GameObject.HasUpgrade(_moduleData.UpgradedBoost.Value.UpgradeType.Value))
@@ -48,6 +50,9 @@ internal sealed class AutoDepositUpdate : UpdateModule
                 GameObject.ExperienceTracker.AddExperiencePoints((int)amount);
             }
         }
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     public void GrantCaptureBonus()

--- a/src/OpenSage.Game/Logic/Object/Update/AutoFindHealingUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AutoFindHealingUpdate.cs
@@ -14,7 +14,7 @@ public sealed class AutoFindHealingUpdate : UpdateModule
 
     private LogicFrameSpan _framesUntilNextScan;
 
-    private protected override void RunUpdate(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
         if (_framesUntilNextScan == LogicFrameSpan.Zero)
         {
@@ -26,6 +26,9 @@ public sealed class AutoFindHealingUpdate : UpdateModule
         {
             _framesUntilNextScan--;
         }
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Update/BannerCarrierUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BannerCarrierUpdate.cs
@@ -19,9 +19,10 @@ public class BannerCarrierUpdate : UpdateModule
 
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
-
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/BattlePlanUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BattlePlanUpdate.cs
@@ -50,25 +50,27 @@ public sealed class BattlePlanUpdate : UpdateModule
     //    base.OnDie(context, deathType, status);
     //}
 
-    private protected override void RunUpdate(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
+        var currentFrame = GameEngine.GameLogic.CurrentFrame;
+
         SetDoorState();
 
         switch (_state)
         {
             case BattlePlanUpdateState.None:
-                if (_desired is not BattlePlanType.None && context.LogicFrame >= _stateChangeCompleteFrame)
+                if (_desired is not BattlePlanType.None && currentFrame >= _stateChangeCompleteFrame)
                 {
                     // the state has been changed
                     _state = BattlePlanUpdateState.Activating;
                     _current = _desired;
                     PlayUnpackSound();
                     PlayAnnouncementSound();
-                    SetStateChangeCompleteFrame(context.LogicFrame);
+                    SetStateChangeCompleteFrame(currentFrame);
                 }
                 break;
             case BattlePlanUpdateState.Activating:
-                if (context.LogicFrame >= _stateChangeCompleteFrame)
+                if (currentFrame >= _stateChangeCompleteFrame)
                 {
                     _state = BattlePlanUpdateState.Active;
                     ActivateCurrentBattlePlan();
@@ -82,12 +84,12 @@ public sealed class BattlePlanUpdate : UpdateModule
                     _state = BattlePlanUpdateState.Deactivating;
                     // DisableAffectedUnits(); // todo: this currently causes an exception due to modifying the gameobject collection, but it's unclear why
                     PlayPackSound();
-                    SetStateChangeCompleteFrame(context.LogicFrame);
+                    SetStateChangeCompleteFrame(currentFrame);
                     ClearActiveBattlePlan();
                 }
                 break;
             case BattlePlanUpdateState.Deactivating:
-                if (context.LogicFrame >= _stateChangeCompleteFrame)
+                if (currentFrame >= _stateChangeCompleteFrame)
                 {
                     _state = BattlePlanUpdateState.None;
                     _current = BattlePlanType.None;
@@ -96,6 +98,9 @@ public sealed class BattlePlanUpdate : UpdateModule
             default:
                 throw new ArgumentOutOfRangeException();
         }
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     private void ClearActiveBattlePlan()

--- a/src/OpenSage.Game/Logic/Object/Update/BoneFXUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/BoneFXUpdate.cs
@@ -13,6 +13,12 @@ public sealed class BoneFXUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/CleanupHazardUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/CleanupHazardUpdate.cs
@@ -8,6 +8,12 @@ public sealed class CleanupHazardUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/CommandButtonHuntUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/CommandButtonHuntUpdate.cs
@@ -10,6 +10,12 @@ public sealed class CommandButtonHuntUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/DockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DockUpdate.cs
@@ -90,7 +90,7 @@ public abstract class DockUpdate : UpdateModule
         }
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
         if (GameObject.ModelConditionFlags.Get(ModelConditionFlag.DockingActive))
         {
@@ -114,6 +114,9 @@ public abstract class DockUpdate : UpdateModule
                     break;
             }
         }
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Update/DynamicShroudClearingRangeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/DynamicShroudClearingRangeUpdate.cs
@@ -19,6 +19,12 @@ public sealed class DynamicShroudClearingRangeUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/FireSpreadUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FireSpreadUpdate.cs
@@ -11,6 +11,12 @@ public sealed class FireSpreadUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/FireWeaponUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FireWeaponUpdate.cs
@@ -26,6 +26,12 @@ public sealed class FireWeaponUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         var version = reader.PersistVersion(2);

--- a/src/OpenSage.Game/Logic/Object/Update/FlammableUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/FlammableUpdate.cs
@@ -21,6 +21,12 @@ public sealed class FlammableUpdate : UpdateModule
 
     // TODO
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/HijackerUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/HijackerUpdate.cs
@@ -8,6 +8,12 @@ public sealed class HijackerUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/HordeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/HordeUpdate.cs
@@ -14,15 +14,13 @@ public sealed class HordeUpdate : UpdateModule
 
     private bool _isInHorde;
 
-    protected override LogicFrameSpan FramesBetweenUpdates => _moduleData.UpdateRate;
-
     internal HordeUpdate(GameObject gameObject, IGameEngine gameEngine, HordeUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
         _moduleData = moduleData;
     }
 
-    private protected override void RunUpdate(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
         var nearby = GameEngine.Scene3D.Quadtree.FindNearby(GameObject, GameObject.Transform, _moduleData.Radius);
         var nearbyInConstraints = nearby.Where(MatchesAlliance).Where(MatchesType).Select(o => o.FindBehavior<HordeUpdate>()).ToList();
@@ -47,6 +45,8 @@ public sealed class HordeUpdate : UpdateModule
                 RemoveFromHorde();
             }
         }
+
+        return UpdateSleepTime.Frames(_moduleData.UpdateRate);
     }
 
     private void AddToHorde()

--- a/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/LifetimeUpdate.cs
@@ -27,13 +27,16 @@ internal sealed class LifetimeUpdate : UpdateModule
         _frameToDie = gameEngine.GameLogic.CurrentFrame + new LogicFrameSpan((uint)lifetimeFrames);
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
-        if (context.LogicFrame >= _frameToDie)
+        if (GameEngine.GameLogic.CurrentFrame >= _frameToDie)
         {
             GameObject.Kill(deathType: _moduleData.DeathType);
             _frameToDie = LogicFrame.MaxValue;
         }
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Update/OCLUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/OCLUpdate.cs
@@ -11,6 +11,12 @@ public sealed class OCLUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/ParticleUplinkCannonUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ParticleUplinkCannonUpdate.cs
@@ -58,6 +58,12 @@ public sealed class ParticleUplinkCannonUpdate : UpdateModule
         _moduleData = moduleData;
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(2);

--- a/src/OpenSage.Game/Logic/Object/Update/PowerPlantUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/PowerPlantUpdate.cs
@@ -37,16 +37,17 @@ public sealed class PowerPlantUpdate : UpdateModule
         _rodsExtendedEndFrame = LogicFrame.MaxValue;
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
-        base.Update(context);
-
-        if (_rodsExtended && _rodsExtendedEndFrame < context.LogicFrame)
+        if (_rodsExtended && _rodsExtendedEndFrame < GameEngine.GameLogic.CurrentFrame)
         {
             GameObject.Drawable.ModelConditionFlags.Set(ModelConditionFlag.PowerPlantUpgrading, false);
             GameObject.Drawable.ModelConditionFlags.Set(ModelConditionFlag.PowerPlantUpgraded, true);
             _rodsExtendedEndFrame = LogicFrame.MaxValue;
         }
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/DefaultProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/DefaultProductionExitUpdate.cs
@@ -19,6 +19,12 @@ public sealed class DefaultProductionExitUpdate : UpdateModule, IHasRallyPoint, 
 
     Vector3? IProductionExit.GetNaturalRallyPoint() => _moduleData.NaturalRallyPoint;
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/QueueProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/QueueProductionExitUpdate.cs
@@ -43,14 +43,15 @@ public sealed class QueueProductionExitUpdate : UpdateModule, IHasRallyPoint, IP
         _framesUntilNextSpawn = ExitDelay;
     }
 
-    private protected override void RunUpdate(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
         if (_framesUntilNextSpawn.Value > 0)
         {
             _framesUntilNextSpawn--;
         }
 
-        base.RunUpdate(context);
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     internal override void DrawInspector()

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SpawnPointProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SpawnPointProductionExitUpdate.cs
@@ -42,6 +42,12 @@ public sealed class SpawnPointProductionExitUpdate : UpdateModule, IProductionEx
         => GameObject.Drawable.FindBone(_moduleData.SpawnPointBoneName + index.ToString("D2"));
 
     Vector3? IProductionExit.GetNaturalRallyPoint() => null;
+
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
 }
 
 public sealed class SpawnPointProductionExitUpdateModuleData : UpdateModuleData

--- a/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SupplyCenterProductionExitUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProductionExit/SupplyCenterProductionExitUpdate.cs
@@ -19,6 +19,12 @@ public sealed class SupplyCenterProductionExitUpdate : UpdateModule, IHasRallyPo
 
     Vector3? IProductionExit.GetNaturalRallyPoint() => _moduleData.NaturalRallyPoint;
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/ProjectileStreamUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/ProjectileStreamUpdate.cs
@@ -13,6 +13,12 @@ public sealed class ProjectileStreamUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/RadarUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RadarUpdate.cs
@@ -12,6 +12,12 @@ public sealed class RadarUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/RebuildHoleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/RebuildHoleUpdate.cs
@@ -52,7 +52,7 @@ public sealed class RebuildHoleUpdate : UpdateModule, IDieModule
     // scaffolds have a status of 0001 0000 0000 0000 0000 0100 in sav file (0100 is under construction)
     private const int UnknownScaffoldStatus = 20;
 
-    private protected override void RunUpdate(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
         if (GameObject.BodyModule.Health < GameObject.BodyModule.MaxHealth)
         {
@@ -62,7 +62,9 @@ public sealed class RebuildHoleUpdate : UpdateModule, IDieModule
         if (_framesUntilConstructionBegins != LogicFrameSpan.Zero)
         {
             _framesUntilConstructionBegins--;
-            return;
+
+            // TODO(Port): Use correct value.
+            return UpdateSleepTime.None;
         }
 
         GameObject worker;
@@ -134,6 +136,9 @@ public sealed class RebuildHoleUpdate : UpdateModule, IDieModule
             // AIUpdate should always be WorkerAIUpdate, so throw if it's not
             throw new InvalidStateException("worker does not have WorkerAIUpdate module");
         }
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     void IDieModule.OnDie(in DamageInfoInput damageInput)

--- a/src/OpenSage.Game/Logic/Object/Update/SpecialAbilityUpdate/SpecialAbilityUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SpecialAbilityUpdate/SpecialAbilityUpdate.cs
@@ -17,6 +17,12 @@ public class SpecialAbilityUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/SpectreGunshipDeploymentUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SpectreGunshipDeploymentUpdate.cs
@@ -9,6 +9,12 @@ public sealed class SpectreGunshipDeploymentUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/StealthDetectorUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StealthDetectorUpdate.cs
@@ -10,8 +10,6 @@ public sealed class StealthDetectorUpdate : UpdateModule
     private readonly StealthDetectorUpdateModuleData _moduleData;
     public bool Active;
 
-    protected override LogicFrameSpan FramesBetweenUpdates => _moduleData.DetectionRate;
-
     public StealthDetectorUpdate(GameObject gameObject, IGameEngine gameEngine, StealthDetectorUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
@@ -19,14 +17,18 @@ public sealed class StealthDetectorUpdate : UpdateModule
         Active = !_moduleData.InitiallyDisabled;
     }
 
-    private protected override void RunUpdate(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
         if (!Active)
         {
-            return;
+            // TODO(Port): Use correct value.
+            return UpdateSleepTime.None;
         }
 
         // todo: detect stealth
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.Frames(_moduleData.DetectionRate);
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Update/StealthUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StealthUpdate.cs
@@ -14,6 +14,12 @@ public sealed class StealthUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         var version = reader.PersistVersion(2);

--- a/src/OpenSage.Game/Logic/Object/Update/StickyBombUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StickyBombUpdate.cs
@@ -12,6 +12,12 @@ public sealed class StickyBombUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/StructureCollapseUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StructureCollapseUpdate.cs
@@ -13,8 +13,10 @@ public class StructureCollapseUpdate : UpdateModule
         _moduleData = moduleData;
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Update/StructureToppleUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/StructureToppleUpdate.cs
@@ -11,6 +11,12 @@ public sealed class StructureToppleUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/SupplyCenterDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SupplyCenterDockUpdate.cs
@@ -35,9 +35,9 @@ public class SupplyCenterDockUpdate : DockUpdate
         return amount;
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
-        base.Update(context);
+        return base.Update();
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Update/SupplyWarehouseDockUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/SupplyWarehouseDockUpdate.cs
@@ -30,14 +30,15 @@ public class SupplyWarehouseDockUpdate : DockUpdate
         return false;
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
-        base.Update(context);
-
         if (_currentBoxes <= 0 && _moduleData.DeleteWhenEmpty)
         {
             GameEngine.GameLogic.DestroyObject(GameObject);
         }
+
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 
     internal override void Load(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
@@ -16,16 +16,16 @@ public abstract class UpdateModule : BehaviorModule, IUpdateModule
         _nextUpdateFrame.UpdateOrder = UpdateOrder;
     }
 
-    void IUpdateModule.Update(BehaviorUpdateContext context)
+    void IUpdateModule.Update()
     {
-        if (context.LogicFrame.Value < _nextUpdateFrame.Frame)
+        if (GameEngine.GameLogic.CurrentFrame.Value < _nextUpdateFrame.Frame)
         {
             return;
         }
 
         var sleepTime = Update();
 
-        _nextUpdateFrame = new UpdateFrame(context.LogicFrame + sleepTime.FrameSpan, UpdateOrder);
+        _nextUpdateFrame = new UpdateFrame(GameEngine.GameLogic.CurrentFrame + sleepTime.FrameSpan, UpdateOrder);
     }
 
     public abstract UpdateSleepTime Update();
@@ -127,7 +127,7 @@ internal interface IUpdateModule
 {
     UpdateOrder UpdatePhase { get; }
 
-    void Update(BehaviorUpdateContext context);
+    void Update();
 }
 
 public interface IProjectileUpdate

--- a/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/UpdateModule.cs
@@ -6,10 +6,6 @@ public abstract class UpdateModule : BehaviorModule, IUpdateModule
 {
     private UpdateFrame _nextUpdateFrame;
 
-    protected internal UpdateFrame NextUpdateFrame => _nextUpdateFrame;
-
-    protected virtual LogicFrameSpan FramesBetweenUpdates { get; } = new(1);
-
     protected virtual UpdateOrder UpdateOrder => UpdateOrder.Order2;
 
     UpdateOrder IUpdateModule.UpdatePhase => UpdateOrder;
@@ -20,34 +16,19 @@ public abstract class UpdateModule : BehaviorModule, IUpdateModule
         _nextUpdateFrame.UpdateOrder = UpdateOrder;
     }
 
-    private protected virtual void RunUpdate(BehaviorUpdateContext context) { }
-
     void IUpdateModule.Update(BehaviorUpdateContext context)
-    {
-        Update(context);
-    }
-
-    // todo: seal this method?
-    internal virtual void Update(BehaviorUpdateContext context)
     {
         if (context.LogicFrame.Value < _nextUpdateFrame.Frame)
         {
             return;
         }
 
-        SetNextUpdateFrame(context.LogicFrame + FramesBetweenUpdates);
-        RunUpdate(context);
-
         var sleepTime = Update();
 
         _nextUpdateFrame = new UpdateFrame(context.LogicFrame + sleepTime.FrameSpan, UpdateOrder);
     }
 
-    // TODO: Remove other Update methods after everything uses this.
-    public virtual UpdateSleepTime Update()
-    {
-        return UpdateSleepTime.Frames(FramesBetweenUpdates);
-    }
+    public abstract UpdateSleepTime Update();
 
     protected void SetNextUpdateFrame(LogicFrame frame)
     {

--- a/src/OpenSage.Game/Logic/Object/Update/WaveGuideUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/WaveGuideUpdate.cs
@@ -9,6 +9,12 @@ public sealed class WaveGuideUpdate : UpdateModule
     {
     }
 
+    public override UpdateSleepTime Update()
+    {
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
+    }
+
     internal override void Load(StatePersister reader)
     {
         reader.PersistVersion(1);

--- a/src/OpenSage.Game/Logic/Object/Update/WeaponSetUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/WeaponSetUpdate.cs
@@ -14,9 +14,10 @@ public sealed class WeaponSetUpdate : UpdateModule
         _moduleData = moduleData;
     }
 
-    internal override void Update(BehaviorUpdateContext context)
+    public override UpdateSleepTime Update()
     {
-
+        // TODO(Port): Use correct value.
+        return UpdateSleepTime.None;
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
+++ b/src/OpenSage.Game/Logic/Object/Upgrade/ObjectCreationUpgrade.cs
@@ -16,12 +16,9 @@ internal sealed class ObjectCreationUpgrade : UpgradeModule
 
     protected override void OnUpgrade()
     {
-        // TODO: Get rid of this context thing.
-        var context = new BehaviorUpdateContext(GameEngine, GameObject);
-
         foreach (var item in _moduleData.UpgradeObject.Value.Nuggets)
         {
-            var createdObjects = item.Execute(context);
+            var createdObjects = item.Execute(GameObject, GameEngine);
 
             foreach (var createdObject in createdObjects)
             {

--- a/src/OpenSage.Mathematics/Percentage.cs
+++ b/src/OpenSage.Mathematics/Percentage.cs
@@ -21,6 +21,8 @@ public readonly struct Percentage
     public static Percentage operator /(Percentage p1, Percentage p2) => new Percentage(p1._value / p2._value);
     public static bool operator <(float f, Percentage p) => f < p._value;
     public static bool operator >(float f, Percentage p) => f > p._value;
+    public static bool operator <(Percentage p1, Percentage p2) => p1._value < p2._value;
+    public static bool operator >(Percentage p1, Percentage p2) => p1._value > p2._value;
     public static Percentage operator -(Percentage p) => new Percentage(-p._value);
     public static explicit operator float(Percentage p) => p._value;
 


### PR DESCRIPTION
I was planning to implement sleepy update modules properly in this PR, but the refactor to use a consistent `Update` method was big enough by itself, so here it is. In the next PR I'll implement the sleepy update system, where we'll have a single list of all the update modules in the game, sorted by next update frame + priority.