### PR TITLE
Port some state machine code

### DIFF
--- a/src/OpenSage.Game/Logic/AI/AIStates/AIState32.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/AIState32.cs
@@ -25,7 +25,11 @@ internal sealed class AIState32 : FollowWaypointsState
     {
         public AIState32StateMachine(AIUpdateStateMachine parentStateMachine) : base(parentStateMachine)
         {
-            AddState(IdleState.StateId, new IdleState(this));
+            DefineState(
+                AIStateIds.Idle,
+                new IdleState(this),
+                AIStateIds.Idle,
+                AIStateIds.Idle);
         }
 
         public override void Persist(StatePersister reader)

--- a/src/OpenSage.Game/Logic/AI/AIStates/AttackAreaState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/AttackAreaState.cs
@@ -33,8 +33,9 @@ internal sealed class AttackAreaStateMachine : StateMachineBase
 {
     public AttackAreaStateMachine(AIUpdateStateMachine parentStateMachine) : base(parentStateMachine)
     {
-        AddState(IdleState.StateId, new IdleState(this));
-        AddState(10, new AttackState(this));
+        // Order matters: first state is the default state.
+        DefineState(AIStateIds.AttackObject, new AttackState(this), AIStateIds.Idle, AIStateIds.Idle);
+        DefineState(AIStateIds.Idle, new IdleState(this), AIStateIds.Idle, AIStateIds.Idle);
     }
 
     public override void Persist(StatePersister reader)

--- a/src/OpenSage.Game/Logic/AI/AIStates/AttackMoveState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/AttackMoveState.cs
@@ -30,7 +30,7 @@ internal sealed class AttackMoveStateMachine : StateMachineBase
 {
     public AttackMoveStateMachine(AIUpdateStateMachine parentStateMachine) : base(parentStateMachine)
     {
-        AddState(IdleState.StateId, new IdleState(this));
+        DefineState(AIStateIds.Idle, new IdleState(this), AIStateIds.Idle, AIStateIds.Idle);
     }
 
     public override void Persist(StatePersister reader)

--- a/src/OpenSage.Game/Logic/AI/AIStates/AttackState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/AttackState.cs
@@ -27,14 +27,38 @@ internal sealed class AttackState : State
     }
 }
 
+internal static class AttackStateIds
+{
+    /// <summary>
+    /// Chase a moving target (optionally following it).
+    /// </summary>
+    public static readonly StateId ChaseTarget = new(0);
+
+    /// <summary>
+    /// Approach a non-moving target.
+    /// </summary>
+    public static readonly StateId ApproachTarget = new(1);
+
+    /// <summary>
+    /// Rotate to face GoalObject or GoalPosition.
+    /// </summary>
+    public static readonly StateId AimAtTarget = new(2);
+
+    /// <summary>
+    /// Fire the machine owner's current weapon.
+    /// </summary>
+    public static readonly StateId FireWeapon = new(3);
+}
+
 internal sealed class AttackStateMachine : StateMachineBase
 {
     public AttackStateMachine(StateMachineBase parentStateMachine) : base(parentStateMachine)
     {
-        AddState(0, new AttackMoveTowardsTargetState(this));
-        AddState(1, new AttackMoveTowardsTargetState(this));
-        AddState(2, new AttackAimWeaponState(this));
-        AddState(3, new AttackFireWeaponState(this));
+        // TODO(Port): These states are far from completely configured.
+        DefineState(AttackStateIds.ChaseTarget, new AttackMoveTowardsTargetState(this), StateId.ExitMachineWithFailure, StateId.ExitMachineWithFailure);
+        DefineState(AttackStateIds.ApproachTarget, new AttackMoveTowardsTargetState(this), AttackStateIds.AimAtTarget, StateId.ExitMachineWithFailure);
+        DefineState(AttackStateIds.AimAtTarget, new AttackAimWeaponState(this), AttackStateIds.FireWeapon, StateId.ExitMachineWithFailure);
+        DefineState(AttackStateIds.FireWeapon, new AttackFireWeaponState(this), AttackStateIds.AimAtTarget, AttackStateIds.AimAtTarget);
     }
 
     public override void Persist(StatePersister reader)

--- a/src/OpenSage.Game/Logic/AI/AIStates/ChinookAIUpdate/ChinookCombatDropState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/ChinookAIUpdate/ChinookCombatDropState.cs
@@ -16,7 +16,7 @@ internal sealed class ChinookCombatDropState : State
         _stateMachine = stateMachine;
     }
 
-    public override void OnEnter()
+    public override StateReturnType OnEnter()
     {
         _ropes.Clear();
 
@@ -25,9 +25,11 @@ internal sealed class ChinookCombatDropState : State
         {
             _ropes.Add(new Rope());
         }
+
+        return StateReturnType.Continue;
     }
 
-    public override void OnExit()
+    public override void OnExit(StateExitType status)
     {
         _ropes.Clear();
     }

--- a/src/OpenSage.Game/Logic/AI/AIStates/DockState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/DockState.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System;
+
 namespace OpenSage.Logic.AI.AIStates;
 
 internal sealed class DockState : State
@@ -31,15 +33,69 @@ internal sealed class DockState : State
 
 internal sealed class DockStateMachine : StateMachineBase
 {
+    private static class DockStateIds
+    {
+        /// <summary>
+        /// Given a queue position, move to it.
+        /// </summary>
+        public static readonly StateId Approach = new(0);
+
+        /// <summary>
+        /// Wait for dock to give us enter clearance.
+        /// </summary>
+        public static readonly StateId WaitForClearance = new(1);
+
+        /// <summary>
+        /// Advance in approach position as line move forward.
+        /// </summary>
+        public static readonly StateId AdvancePosition = new(2);
+
+        /// <summary>
+        /// Move to the dock entrance.
+        /// </summary>
+        public static readonly StateId MoveToEntry = new(3);
+
+        /// <summary>
+        /// Move to the actual dock position.
+        /// </summary>
+        public static readonly StateId MoveToDock = new(4);
+
+        /// <summary>
+        /// Invoke the dock's action until it is done.
+        /// </summary>
+        public static readonly StateId ProcessDock = new(5);
+
+        /// <summary>
+        /// Move to the dock exit, can exit the dock machine.
+        /// </summary>
+        public static readonly StateId MoveToExit = new(6);
+
+        /// <summary>
+        /// Move to rally if desired, exit the dock machine no matter what.
+        /// </summary>
+        public static readonly StateId MoveToRally = new(7);
+    }
+
     private uint _unknownInt;
 
     public DockStateMachine(AIUpdateStateMachine parentStateMachine) : base(parentStateMachine)
     {
-        AddState(0, new DockApproachDockState(this));
-        AddState(1, new DockUnknown1State(this));
-        AddState(3, new DockUnknown3State(this));
-        AddState(4, new DockUnknown4State(this));
-        AddState(5, new DockWaitForActionState(this));
+        ReadOnlySpan<StateConditionInfo> waitForClearanceConditions =
+        [
+            new StateConditionInfo(IsAbleToAdvance, DockStateIds.AdvancePosition),
+        ];
+
+        DefineState(DockStateIds.Approach, new DockApproachDockState(this), DockStateIds.WaitForClearance, StateId.ExitMachineWithFailure);
+        DefineState(DockStateIds.WaitForClearance, new DockUnknown1State(this), DockStateIds.MoveToEntry, StateId.ExitMachineWithFailure, waitForClearanceConditions);
+        DefineState(DockStateIds.MoveToEntry, new DockUnknown3State(this), DockStateIds.MoveToDock, DockStateIds.MoveToExit);
+        DefineState(DockStateIds.MoveToDock, new DockUnknown4State(this), DockStateIds.ProcessDock, DockStateIds.MoveToExit);
+        DefineState(DockStateIds.ProcessDock, new DockWaitForActionState(this), DockStateIds.MoveToExit, DockStateIds.MoveToExit);
+    }
+
+    private static bool IsAbleToAdvance(State state)
+    {
+        // TODO(Port): Implement this.
+        throw new NotImplementedException();
     }
 
     public override void Persist(StatePersister reader)

--- a/src/OpenSage.Game/Logic/AI/AIStates/GuardState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/GuardState.cs
@@ -25,6 +25,16 @@ internal sealed class GuardState : State
     }
 }
 
+internal static class GuardStateIds
+{
+    public static readonly StateId Inner = new(5000);
+    public static readonly StateId Idle = new(5001);
+    public static readonly StateId Outer = new(5002);
+    public static readonly StateId Return = new(5003);
+    public static readonly StateId GetCrate = new(5004);
+    public static readonly StateId AttackAggressor = new(5005);
+}
+
 internal sealed class GuardStateMachine : StateMachineBase
 {
     private ObjectId _guardObjectId;
@@ -34,9 +44,10 @@ internal sealed class GuardStateMachine : StateMachineBase
 
     public GuardStateMachine(AIUpdateStateMachine parentStateMachine) : base(parentStateMachine)
     {
-        AddState(5001, new GuardIdleState(this));
-        AddState(5002, new GuardUnknown5002State(this));
-        AddState(5003, new GuardMoveState(this));
+        // TODO(Port): This configuration is incomplete.
+        DefineState(GuardStateIds.Idle, new GuardIdleState(this), GuardStateIds.Inner, GuardStateIds.Return);
+        DefineState(GuardStateIds.Outer, new GuardUnknown5002State(this), GuardStateIds.GetCrate, GuardStateIds.GetCrate);
+        DefineState(GuardStateIds.Return, new GuardMoveState(this), GuardStateIds.Idle, GuardStateIds.Inner);
     }
 
     public override void Persist(StatePersister reader)

--- a/src/OpenSage.Game/Logic/AI/AIStates/HackInternetAIUpdate/HackInternetState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/HackInternetAIUpdate/HackInternetState.cs
@@ -9,8 +9,6 @@ namespace OpenSage.Logic.AI.AIStates;
 
 internal sealed class HackInternetState : State
 {
-    public const uint StateId = 1001;
-
     private readonly HackInternetAIUpdateStateMachine _stateMachine;
 
     private LogicFrameSpan _framesUntilNextHack;
@@ -20,16 +18,18 @@ internal sealed class HackInternetState : State
         _stateMachine = stateMachine;
     }
 
-    public override void OnEnter()
+    public override StateReturnType OnEnter()
     {
         GameObject.ModelConditionFlags.Set(ModelConditionFlag.Unpacking, false);
         GameObject.ModelConditionFlags.Set(ModelConditionFlag.FiringA, true);
         GameObject.ModelConditionFlags.Set(ModelConditionFlag.Packing, false);
 
         SetFramesUntilNextHack(GameObject);
+
+        return StateReturnType.Continue;
     }
 
-    public override UpdateStateResult Update()
+    public override StateReturnType Update()
     {
         if (_framesUntilNextHack-- == LogicFrameSpan.Zero)
         {
@@ -46,10 +46,10 @@ internal sealed class HackInternetState : State
             GameObject.ExperienceTracker.AddExperiencePoints(_stateMachine.AIUpdate.ModuleData.XpPerCashUpdate);
         }
 
-        return UpdateStateResult.Continue();
+        return StateReturnType.Continue;
     }
 
-    public override void OnExit()
+    public override void OnExit(StateExitType status)
     {
         GameObject.ModelConditionFlags.Set(ModelConditionFlag.FiringA, false);
     }

--- a/src/OpenSage.Game/Logic/AI/AIStates/HackInternetAIUpdate/StartHackingInternetState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/HackInternetAIUpdate/StartHackingInternetState.cs
@@ -8,8 +8,6 @@ internal sealed class StartHackingInternetState : State
 {
     private readonly HackInternetAIUpdateStateMachine _stateMachine;
 
-    public const uint StateId = 1000;
-
     private LogicFrameSpan _framesUntilHackingBegins;
 
     public StartHackingInternetState(HackInternetAIUpdateStateMachine stateMachine) : base(stateMachine)
@@ -17,7 +15,7 @@ internal sealed class StartHackingInternetState : State
         _stateMachine = stateMachine;
     }
 
-    public override void OnEnter()
+    public override StateReturnType OnEnter()
     {
         GameObject.ModelConditionFlags.Set(ModelConditionFlag.Unpacking, true);
         GameObject.ModelConditionFlags.Set(ModelConditionFlag.FiringA, false);
@@ -30,19 +28,21 @@ internal sealed class StartHackingInternetState : State
         GameObject.Drawable.SetAnimationDuration(frames);
 
         _framesUntilHackingBegins = frames;
+
+        return StateReturnType.Continue;
     }
 
-    public override UpdateStateResult Update()
+    public override StateReturnType Update()
     {
         if (_framesUntilHackingBegins-- == LogicFrameSpan.Zero)
         {
-            return UpdateStateResult.TransitionToState(HackInternetState.StateId);
+            return StateReturnType.Success;
         }
 
-        return UpdateStateResult.Continue();
+        return StateReturnType.Continue;
     }
 
-    public override void OnExit()
+    public override void OnExit(StateExitType status)
     {
         GameObject.ModelConditionFlags.Set(ModelConditionFlag.Unpacking, false);
     }

--- a/src/OpenSage.Game/Logic/AI/AIStates/HackInternetAIUpdate/StopHackingInternetState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/HackInternetAIUpdate/StopHackingInternetState.cs
@@ -6,8 +6,6 @@ namespace OpenSage.Logic.AI.AIStates;
 
 internal sealed class StopHackingInternetState : State
 {
-    public const uint StateId = 1002;
-
     private readonly HackInternetAIUpdateStateMachine _stateMachine;
 
     private LogicFrameSpan _framesUntilFinishedPacking;
@@ -17,7 +15,7 @@ internal sealed class StopHackingInternetState : State
         _stateMachine = stateMachine;
     }
 
-    public override void OnEnter()
+    public override StateReturnType OnEnter()
     {
         GameObject.ModelConditionFlags.Set(ModelConditionFlag.Unpacking, false);
         GameObject.ModelConditionFlags.Set(ModelConditionFlag.FiringA, false);
@@ -30,19 +28,21 @@ internal sealed class StopHackingInternetState : State
         GameObject.Drawable.SetAnimationDuration(frames);
 
         _framesUntilFinishedPacking = frames;
+
+        return StateReturnType.Continue;
     }
 
-    public override UpdateStateResult Update()
+    public override StateReturnType Update()
     {
         if (_framesUntilFinishedPacking-- == LogicFrameSpan.Zero)
         {
-            return UpdateStateResult.TransitionToState(IdleState.StateId);
+            return StateReturnType.Success;
         }
 
-        return UpdateStateResult.Continue();
+        return StateReturnType.Continue;
     }
 
-    public override void OnExit()
+    public override void OnExit(StateExitType status)
     {
         GameObject.ModelConditionFlags.Set(ModelConditionFlag.Packing, false);
     }

--- a/src/OpenSage.Game/Logic/AI/AIStates/IdleState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/IdleState.cs
@@ -4,11 +4,11 @@ namespace OpenSage.Logic.AI.AIStates;
 
 internal sealed class IdleState : State
 {
-    public const uint StateId = 0;
-
     private ushort _unknownShort;
     private bool _unknownBool1;
     private bool _unknownBool2;
+
+    public override bool IsIdle => true;
 
     internal IdleState(StateMachineBase stateMachine) : base(stateMachine)
     {

--- a/src/OpenSage.Game/Logic/AI/AIStates/JetAIUpdate/WaitForAirfieldWinchesterState.cs
+++ b/src/OpenSage.Game/Logic/AI/AIStates/JetAIUpdate/WaitForAirfieldWinchesterState.cs
@@ -9,8 +9,6 @@ namespace OpenSage.Logic.AI.AIStates;
 /// </summary>
 internal sealed class WaitForAirfieldWinchesterState : State
 {
-    public const uint StateId = 1013;
-
     internal WaitForAirfieldWinchesterState(JetAIUpdateStateMachine stateMachine) : base(stateMachine)
     {
     }

--- a/src/OpenSage.Game/Logic/AI/State.cs
+++ b/src/OpenSage.Game/Logic/AI/State.cs
@@ -1,50 +1,223 @@
 ﻿#nullable enable
 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using OpenSage.Logic.Object;
 
 namespace OpenSage.Logic.AI;
 
-internal abstract class State : IPersistableObject
+public abstract class State : IPersistableObject
 {
-    public uint Id { get; internal set; }
+    private StateId _successStateId;
+    private StateId _failureStateId;
+
+    private readonly List<StateConditionInfo> _conditions = new();
+
+    public StateId Id { get; internal set; }
 
     private protected GameObject GameObject => _stateMachine.GameObject;
     private protected IGameEngine GameEngine => _stateMachine.GameEngine;
 
     private readonly StateMachineBase _stateMachine;
 
+    public virtual bool IsIdle => false;
+
     private protected State(StateMachineBase stateMachine)
     {
         _stateMachine = stateMachine;
     }
 
-    public virtual void OnEnter() { }
+    internal void OnSuccess(StateId toStateId)
+    {
+        _successStateId = toStateId;
+    }
 
-    public virtual UpdateStateResult Update() => UpdateStateResult.Continue();
+    internal void OnFailure(StateId toStateId)
+    {
+        _failureStateId = toStateId;
+    }
 
-    public virtual void OnExit() { }
+    internal void OnCondition(StateConditionInfo condition)
+    {
+        _conditions.Add(condition);
+    }
+
+    /// <summary>
+    /// Executed once when entering state.
+    /// </summary>
+    public virtual StateReturnType OnEnter() => StateReturnType.Continue;
+
+    /// <summary>
+    /// Executed once when leaving state.
+    /// </summary>
+    public virtual void OnExit(StateExitType status) { }
+
+    /// <summary>
+    /// Given a return code, handle state transitions.
+    /// </summary>
+    internal StateReturnType CheckForTransitions(StateReturnType status)
+    {
+        DebugUtility.AssertCrash(status.Kind != StateReturnTypeKind.Sleep, "Please handle sleep states prior to this!");
+
+        // Handle transitions.
+        switch (status.Kind)
+        {
+            case StateReturnTypeKind.Success:
+                return CheckForTransitionSuccessOrFailure(_successStateId);
+
+            case StateReturnTypeKind.Failure:
+                return CheckForTransitionSuccessOrFailure(_failureStateId);
+
+            case StateReturnTypeKind.Continue:
+                if (CheckTransitionConditions(out var result))
+                {
+                    return result;
+                }
+                break;
+        }
+
+        // The machine keeps running.
+        return StateReturnType.Continue;
+    }
+
+    private StateReturnType CheckForTransitionSuccessOrFailure(StateId stateId)
+    {
+        if (stateId == StateId.ExitMachineWithSuccess)
+        {
+            _stateMachine.SetStateInternal(StateId.MachineDone);
+            return StateReturnType.Success;
+        }
+        else if (stateId == StateId.ExitMachineWithFailure)
+        {
+            _stateMachine.SetStateInternal(StateId.MachineDone);
+            return StateReturnType.Failure;
+        }
+
+        // Move to new state.
+        return _stateMachine.SetStateInternal(stateId);
+    }
+
+    private bool CheckTransitionConditions(out StateReturnType result)
+    {
+        foreach (var condition in _conditions)
+        {
+            if (!condition.Test(this))
+            {
+                continue;
+            }
+
+            // Test returned true, change to associated state.
+
+            // TODO(Port): Debug logging.
+
+            // Check if machine should exit.
+            if (condition.ToStateId == StateId.ExitMachineWithSuccess)
+            {
+                result = StateReturnType.Success;
+                return true;
+            }
+            else if (condition.ToStateId == StateId.ExitMachineWithFailure)
+            {
+                result = StateReturnType.Failure;
+                return true;
+            }
+            else
+            {
+                // Move to new state.
+                result = _stateMachine.SetStateInternal(condition.ToStateId);
+                return true;
+            }
+        }
+
+        result = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Given a return code, handle state transitions while state is sleeping.
+    /// </summary>
+    internal StateReturnType CheckForSleepTransitions(StateReturnType status)
+    {
+        DebugUtility.AssertCrash(status.Kind == StateReturnTypeKind.Sleep, "Please only pass sleep states here");
+
+        if (CheckTransitionConditions(out var result))
+        {
+            return result;
+        }
+
+        return status;
+    }
+
+    // TODO(Port): Make this abstract.
+    public virtual StateReturnType Update() => StateReturnType.Continue;
 
     public abstract void Persist(StatePersister reader);
 }
 
-public readonly struct UpdateStateResult
+public readonly struct StateReturnType
 {
-    public static UpdateStateResult Continue() => new(UpdateStateResultType.Continue, null);
+    public static readonly StateReturnType Continue = new(StateReturnTypeKind.Continue, null);
+    public static readonly StateReturnType Success = new(StateReturnTypeKind.Success, null);
+    public static readonly StateReturnType Failure = new(StateReturnTypeKind.Failure, null);
+    public static StateReturnType Sleep(LogicFrameSpan forFrames) => new(StateReturnTypeKind.Sleep, forFrames);
 
-    public static UpdateStateResult TransitionToState(uint stateId) => new(UpdateStateResultType.TransitionToState, stateId);
+    // We use 0x3fffffff so that we can add offsets and not overflow...
+    // At 30fps that's around ~414 days.
+    public static readonly StateReturnType SleepForever = Sleep(new LogicFrameSpan(0x3fffffff));
 
-    public readonly UpdateStateResultType Type;
-    public readonly uint? TransitionToStateId;
+    public readonly StateReturnTypeKind Kind;
 
-    private UpdateStateResult(UpdateStateResultType type, uint? transitionToStateId)
+    public readonly LogicFrameSpan SleepForFrames;
+
+    private StateReturnType(StateReturnTypeKind kind, LogicFrameSpan? sleepForFrames)
     {
-        Type = type;
-        TransitionToStateId = transitionToStateId;
+        Kind = kind;
+        SleepForFrames = sleepForFrames ?? LogicFrameSpan.Zero;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is StateReturnType other && this == other;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Kind, SleepForFrames);
+    }
+
+    public static bool operator ==(StateReturnType left, StateReturnType right)
+    {
+        return left.Kind == right.Kind && left.SleepForFrames == right.SleepForFrames;
+    }
+
+    public static bool operator !=(StateReturnType left, StateReturnType right)
+    {
+        return !(left == right);
     }
 }
 
-public enum UpdateStateResultType
+public enum StateReturnTypeKind
 {
     Continue,
-    TransitionToState,
+    Success,
+    Failure,
+    Sleep,
 }
+
+public enum StateExitType
+{
+    /// <summary>
+    /// State exited due to normal state transitioning.
+    /// </summary>
+    Normal,
+
+    /// <summary>
+    /// State exited due to state machine reset.
+    /// </summary>
+    Reset,
+}
+
+public readonly record struct StateConditionInfo(StateTransitionDelegate Test, StateId ToStateId);
+
+public delegate bool StateTransitionDelegate(State state);

--- a/src/OpenSage.Game/Logic/AI/StateMachineBase.cs
+++ b/src/OpenSage.Game/Logic/AI/StateMachineBase.cs
@@ -7,45 +7,141 @@ using OpenSage.Logic.Object;
 
 namespace OpenSage.Logic.AI;
 
-internal abstract class StateMachineBase : IPersistableObject
+internal abstract class StateMachineBase : IPersistableObject, IDisposable
 {
     public GameObject GameObject { get; }
     public IGameEngine GameEngine { get; }
     public virtual AIUpdate AIUpdate { get; }
 
-    private readonly Dictionary<uint, State> _states;
+    private readonly Dictionary<StateId, State> _states;
 
-    private uint _unknownFrame;
-    private uint _unknownInt1;
+    private LogicFrame _sleepTill;
 
-    private uint _currentStateId;
-    internal State? CurrentState { get; private set; }
+    private StateId _defaultStateId;
 
-    private ObjectId _targetObjectId;
-    private Vector3 _targetPosition;
-    private bool _unknownBool1;
-    private bool _unknownBool2;
+    private State? _currentState;
+
+    public StateId CurrentStateId => _currentState?.Id ?? StateId.Invalid;
+
+    public bool IsInIdleState => _currentState?.IsIdle ?? true; // Stateless things are considered idle.
+
+    private ObjectId _goalObjectId;
+    private Vector3 _goalPosition;
+    private bool _locked;
+    private bool _defaultStateInitialized;
 
     protected StateMachineBase(GameObject gameObject, IGameEngine gameEngine, AIUpdate aiUpdate)
     {
         GameObject = gameObject;
         GameEngine = gameEngine;
         AIUpdate = aiUpdate;
-        _states = new Dictionary<uint, State>();
+        _states = new Dictionary<StateId, State>();
     }
 
     protected StateMachineBase(StateMachineBase parent) : this(parent.GameObject, parent.GameEngine, parent.AIUpdate)
     {
     }
 
-    public void AddState(uint id, State state)
+    public void Dispose()
     {
-        state.Id = id;
-
-        _states.Add(id, state);
+        _currentState?.OnExit(StateExitType.Reset);
     }
 
-    protected State GetState(uint id)
+    /// <summary>
+    /// Clears the state machine.
+    /// </summary>
+    private void Clear()
+    {
+        // If the machine is locked, it cannot be cleared.
+        if (_locked)
+        {
+            // TODO(Port): Debug logging.
+            return;
+        }
+
+        // Invoke the old state's OnExit().
+        _currentState?.OnExit(StateExitType.Reset);
+
+        _currentState = null;
+
+        ClearInternal();
+    }
+
+    /// <summary>
+    /// Clear the internal variables of the state machine to known values.
+    /// </summary>
+    private void ClearInternal()
+    {
+        _goalObjectId = ObjectId.Invalid;
+        _goalPosition = Vector3.Zero;
+
+        // TODO(Port): Debug logging.
+    }
+
+    /// <summary>
+    /// Resets the machine to its default state.
+    /// </summary>
+    protected virtual StateReturnType ResetToDefaultState()
+    {
+        // If the machine is locked, it cannot be reset.
+        if (_locked)
+        {
+            // TODO(Port): Debug logging.
+            return StateReturnType.Failure;
+        }
+
+        if (!_defaultStateInitialized)
+        {
+            DebugUtility.Crash("You may not call ResetToDefaultState() before InitializeDefaultState()");
+            return StateReturnType.Failure;
+        }
+
+        // Allow current state to exit with StateExitType.Reset if present.
+        _currentState?.OnExit(StateExitType.Reset);
+        _currentState = null;
+
+        // The current state has done an OnExit. Clear the internal guts before
+        // we set the new state. To clear it after the new state is set might be
+        // overwriting things the new state transition causes to happen.
+        ClearInternal();
+
+        // Change to the default state.
+        var status = SetStateInternal(_defaultStateId);
+
+        DebugUtility.AssertCrash(status != StateReturnType.Failure, "Error setting default state");
+
+        return status;
+    }
+
+    /// <summary>
+    /// Given a unique (for this machine) ID number, and an instance of the
+    /// <see cref="State"/> class, the machine records this as a possible state,
+    /// and retains the ID mapping.
+    ///
+    /// These state IDs are used to change the machine's state via <see cref="SetState(StateId)"/>.
+    /// </summary>
+    protected void DefineState(StateId id, State state, StateId successId, StateId failureId, params ReadOnlySpan<StateConditionInfo> conditions)
+    {
+        _states.Add(id, state);
+
+        // Store the ID in the state itself, as well.
+        state.Id = id;
+
+        state.OnSuccess(successId);
+        state.OnFailure(failureId);
+
+        foreach (var condition in conditions)
+        {
+            state.OnCondition(condition);
+        }
+
+        if (_defaultStateId == StateId.Invalid)
+        {
+            _defaultStateId = id;
+        }
+    }
+
+    protected State GetState(StateId id)
     {
         if (_states.TryGetValue(id, out var result))
         {
@@ -55,54 +151,275 @@ internal abstract class StateMachineBase : IPersistableObject
         throw new InvalidOperationException($"State {id} is not defined in {GetType().Name}");
     }
 
-    internal void SetState(uint id)
+    internal StateReturnType SetState(StateId newStateId)
     {
-        CurrentState?.OnExit();
+        // If the machine is locked, it cannot change state via external events.
+        if (_locked)
+        {
+            return StateReturnType.Continue;
+        }
 
-        CurrentState = GetState(id);
-
-        CurrentState.OnEnter();
+        return SetStateInternal(newStateId);
     }
 
-    internal virtual void Update()
+    /// <summary>
+    /// Changes the current state of the machine.
+    /// This causes the old state's <see cref="State.OnExit(StateExitType)"/>
+    /// to be invoked, and the new state's <see cref="State.OnEnter"/>
+    /// to be invoked.
+    /// </summary>
+    internal StateReturnType SetStateInternal(StateId newStateId)
     {
-        if (CurrentState == null)
+        State? newState = null;
+
+        // Anytime the state changes, stop sleeping.
+        _sleepTill = LogicFrame.Zero;
+
+        // If we're not setting the "done" state ID, we will continue with the
+        // actual transition.
+        if (newStateId != StateId.MachineDone)
         {
-            return;
+            // If incoming state is invalid, go to the machine's default state.
+            if (newStateId == StateId.Invalid)
+            {
+                newStateId = _defaultStateId;
+                if (newStateId == StateId.Invalid)
+                {
+                    DebugUtility.Crash("You may NEVER set the current state to an invalid state ID");
+                    return StateReturnType.Failure;
+                }
+            }
+
+            // Extract the state associated with the given ID.
+            newState = GetState(newStateId);
+
+            // TODO(Port): Debug logging.
         }
 
-        var updateResult = CurrentState.Update();
+        // Invoke the old state's OnExit().
+        _currentState?.OnExit(StateExitType.Normal);
 
-        switch (updateResult.Type)
+        // Set the new state.
+        _currentState = newState;
+
+        return CallStateMethod(
+            static state => state.OnEnter(),
+            static () =>
+            {
+                // Irrelevant return code; we must return something.
+                return StateReturnType.Continue;
+            });
+    }
+
+    private StateReturnType CallStateMethod(
+        Func<State, StateReturnType> stateMethod,
+        Func<StateReturnType> noCurrentStateCallback)
+    {
+        if (_currentState != null)
         {
-            case UpdateStateResultType.Continue:
-                break;
+            // The state method (OnEnter() or Update()) could conceivably change
+            // _currentState, so save it for a moment...
+            var stateBeforeEnter = _currentState;
 
-            case UpdateStateResultType.TransitionToState:
-                SetState(updateResult.TransitionToStateId ?? throw new InvalidStateException());
-                break;
+            var status = stateMethod(_currentState);
 
-            default:
-                break;
+            // It is possible that the state's OnEnter() method may cause the
+            // state to be destroyed.
+            if (_currentState == null)
+            {
+                return StateReturnType.Failure;
+            }
+
+            // Here's the scenario:
+            // 1. State A calls Foo() and then says "sleep for 2000 frames"
+            // 2. However, Foo() called SetState() to State B. Thus our current
+            //    state is not the same.
+            // 3. Thus, if the state changed, we must ignore any sleep result
+            //    and pretend we got StateReturnType.Continue so that the new
+            //    state will be called immediately.
+            if (stateBeforeEnter != _currentState)
+            {
+                status = StateReturnType.Continue;
+            }
+
+            if (status.Kind == StateReturnTypeKind.Sleep)
+            {
+                // Hey, we're sleepy!
+                var now = GameEngine.GameLogic.CurrentFrame;
+                _sleepTill = now + status.SleepForFrames;
+                return _currentState.CheckForSleepTransitions(status);
+            }
+            else
+            {
+                // Check for state transitions, possibly exiting this machine.
+                return _currentState.CheckForTransitions(status);
+            }
         }
+        else
+        {
+            return noCurrentStateCallback();
+        }
+    }
+
+    /// <summary>
+    /// Runs one step of the machine.
+    /// </summary>
+    internal virtual StateReturnType Update()
+    {
+        var now = GameEngine.GameLogic.CurrentFrame;
+        if (_sleepTill != LogicFrame.Zero && now < _sleepTill)
+        {
+            if (_currentState == null)
+            {
+                return StateReturnType.Failure;
+            }
+            return _currentState.CheckForSleepTransitions(StateReturnType.Sleep(_sleepTill - now));
+        }
+
+        // Not sleeping anymore.
+        _sleepTill = LogicFrame.Zero;
+
+        return CallStateMethod(
+            static state => state.Update(),
+            static () =>
+            {
+                DebugUtility.Crash("State machine has no current state -- did you remember to call InitializeDefaultState()?");
+                return StateReturnType.Failure;
+            });
+    }
+
+    /// <summary>
+    /// Defines the default state of the machine,
+    /// and sets the machine's state to it.
+    /// </summary>
+    public StateReturnType InitializeDefaultState()
+    {
+        // TODO(Port): Debug logging.
+
+        DebugUtility.AssertCrash(!_locked, "Machine is locked here, but probably should not be");
+
+        if (_defaultStateInitialized)
+        {
+            DebugUtility.Crash("You may not call InitializeDefaultState() twice for the same StateMachine");
+            return StateReturnType.Failure;
+        }
+        else
+        {
+            _defaultStateInitialized = true;
+            return SetStateInternal(_defaultStateId);
+        }
+    }
+
+    public bool IsGoalObjectDestroyed => _goalObjectId != ObjectId.Invalid && GoalObject == null;
+
+    public void Halt()
+    {
+        _locked = true;
+
+        // Don't exit current state, just clear it.
+        _currentState = null;
+
+        // TODO(Port): Debug logging.
+    }
+
+    public GameObject? GoalObject
+    {
+        get => GameEngine.GameLogic.GetObjectById(_goalObjectId);
+        set
+        {
+            if (_locked)
+            {
+                return;
+            }
+            SetGoalObjectImpl(value);
+        }
+    }
+
+    private void SetGoalObjectImpl(GameObject? obj)
+    {
+        if (obj != null)
+        {
+            _goalObjectId = obj.Id;
+            SetGoalPositionImpl(obj.Translation);
+        }
+        else
+        {
+            _goalObjectId = ObjectId.Invalid;
+        }
+    }
+
+    public Vector3 GoalPosition
+    {
+        get => _goalPosition;
+        set
+        {
+            if (_locked)
+            {
+                return;
+            }
+
+            SetGoalPositionImpl(value);
+        }
+    }
+
+    private void SetGoalPositionImpl(in Vector3 pos)
+    {
+        _goalPosition = pos;
+
+        // Don't clear the goal object, or everything breaks.
+        // Like construction of buildings.
     }
 
     public virtual void Persist(StatePersister reader)
     {
         reader.PersistVersion(1);
 
-        reader.PersistFrame(ref _unknownFrame);
-        reader.PersistUInt32(ref _unknownInt1);
+        reader.PersistLogicFrame(ref _sleepTill);
+        reader.PersistStateId(ref _defaultStateId);
 
-        reader.PersistUInt32(ref _currentStateId);
-        CurrentState = GetState(_currentStateId);
+        var currentStateId = CurrentStateId;
+        reader.PersistStateId(ref currentStateId);
+        if (reader.Mode == StatePersistMode.Read)
+        {
+            // We are going to jump into the current state.
+            // We don't call OnEnter or OnExit, because
+            // the state was already active when we saved.
+            _currentState = GetState(currentStateId);
+        }
 
-        reader.SkipUnknownBytes(1);
-
-        reader.PersistObject(CurrentState);
-        reader.PersistObjectId(ref _targetObjectId);
-        reader.PersistVector3(ref _targetPosition);
-        reader.PersistBoolean(ref _unknownBool1);
-        reader.PersistBoolean(ref _unknownBool2);
+        var snapshotAllStates = false;
+#if DEBUG
+        //snapshotAllStates = true;
+#endif
+        reader.PersistBoolean(ref snapshotAllStates);
+        if (snapshotAllStates)
+        {
+            // Count all states in the mapping.
+            // TODO(Port): Implement this.
+        }
+        else
+        {
+            DebugUtility.AssertCrash(_currentState != null, "Current state was null on xfer, trying to heal...");
+            // Too late to find out why we are getting null in our state,
+            // but if we let it go, we will crash in PersistObject.
+            _currentState ??= GetState(_defaultStateId);
+            reader.PersistObject(_currentState);
+        }
+            
+        reader.PersistObjectId(ref _goalObjectId);
+        reader.PersistVector3(ref _goalPosition);
+        reader.PersistBoolean(ref _locked);
+        reader.PersistBoolean(ref _defaultStateInitialized);
     }
+}
+
+public record struct StateId(uint Value)
+{
+    // Special arguments for OnCondition. It means when the given condition
+    // becomes true, the state machine will exit and return the given status.
+    public static readonly StateId ExitMachineWithSuccess = new(9998);
+    public static readonly StateId ExitMachineWithFailure = new(9999);
+
+    public static readonly StateId MachineDone = new(999998);
+    public static readonly StateId Invalid = new(999999);
 }

--- a/src/OpenSage.Game/Logic/AI/StateMachineBase.cs
+++ b/src/OpenSage.Game/Logic/AI/StateMachineBase.cs
@@ -405,7 +405,7 @@ internal abstract class StateMachineBase : IPersistableObject, IDisposable
             _currentState ??= GetState(_defaultStateId);
             reader.PersistObject(_currentState);
         }
-            
+
         reader.PersistObjectId(ref _goalObjectId);
         reader.PersistVector3(ref _goalPosition);
         reader.PersistBoolean(ref _locked);

--- a/src/OpenSage.Game/Logic/AI/SupplyAIUpdateStateMachine.cs
+++ b/src/OpenSage.Game/Logic/AI/SupplyAIUpdateStateMachine.cs
@@ -13,11 +13,37 @@ internal sealed class SupplyAIUpdateStateMachine : StateMachineBase
     {
         AIUpdate = aiUpdate;
 
-        AddState(0, new SupplyUnknown0State(this));
-        AddState(1, new SupplyUnknown1State(this));
-        AddState(2, new SupplyUnknown2State(this)); // occurred when loaded chinook was flying over war factory (only remaining building) attempting to drop off supplies
-        AddState(3, new SupplyUnknown3State(this)); // occurred when loaded chinook was flying over war factory (only remaining building) attempting to drop off supplies
-        AddState(4, new SupplyUnknown4State(this));
+        // TODO(Port): This configuration is incomplete.
+
+        DefineState(
+            SupplyTruckStateIds.Busy,
+            new SupplyUnknown1State(this),
+            SupplyTruckStateIds.Busy,
+            SupplyTruckStateIds.Busy);
+
+        DefineState(
+            SupplyTruckStateIds.Idle,
+            new SupplyUnknown0State(this),
+            SupplyTruckStateIds.Busy,
+            SupplyTruckStateIds.Busy);
+
+        DefineState(
+            SupplyTruckStateIds.Wanting,
+            new SupplyUnknown2State(this),
+            SupplyTruckStateIds.Regrouping,
+            SupplyTruckStateIds.Busy);
+
+        DefineState(
+            SupplyTruckStateIds.Regrouping,
+            new SupplyUnknown3State(this),
+            SupplyTruckStateIds.Wanting,
+            SupplyTruckStateIds.Busy);
+
+        DefineState(
+            SupplyTruckStateIds.Docking,
+            new SupplyUnknown4State(this),
+            SupplyTruckStateIds.Busy,
+            SupplyTruckStateIds.Busy);
     }
 
     public override void Persist(StatePersister reader)
@@ -28,4 +54,33 @@ internal sealed class SupplyAIUpdateStateMachine : StateMachineBase
         base.Persist(reader);
         reader.EndObject();
     }
+}
+
+internal static class SupplyTruckStateIds
+{
+    /// <summary>
+    /// Not doing anything. Should I autopilot?
+    /// </summary>
+    public static readonly StateId Idle = new(0);
+
+    /// <summary>
+    /// Direct player involvement (move) has taken me off autopilot.
+    /// </summary>
+    public static readonly StateId Busy = new(1);
+
+    /// <summary>
+    /// Search for warehouse or center and dock with it.
+    /// </summary>
+    public static readonly StateId Wanting = new(2);
+
+    /// <summary>
+    /// Wanting failed, so hanging out at base until something changes.
+    /// Autopilot will turn off.
+    /// </summary>
+    public static readonly StateId Regrouping = new(3);
+
+    /// <summary>
+    /// Docking substates are running; wait for them to finish.
+    /// </summary>
+    public static readonly StateId Docking = new(4);
 }

--- a/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
+++ b/src/OpenSage.Game/Logic/Object/BehaviorModule.cs
@@ -66,9 +66,9 @@ public readonly struct LogicFrame : IEquatable<LogicFrame>
         return new LogicFrame(left.Value + 1);
     }
 
-    public static LogicFrame operator -(LogicFrame left, LogicFrame right)
+    public static LogicFrameSpan operator -(LogicFrame left, LogicFrame right)
     {
-        return new LogicFrame(left.Value - right.Value);
+        return new LogicFrameSpan(left.Value - right.Value);
     }
 
     public static LogicFrame operator -(LogicFrame left, uint right)

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/AIUpdate.cs
@@ -112,6 +112,15 @@ public class AIUpdate : UpdateModule
     // TODO(Port): Implement this.
     public bool IsMoving => false;
 
+    public virtual bool IsIdle
+    {
+        get
+        {
+            var stateMachine = StateMachine;
+            return stateMachine.CurrentStateId == AIStateIds.Idle || stateMachine.IsInIdleState;
+        }
+    }
+
     internal AIUpdate(GameObject gameObject, IGameEngine gameEngine, AIUpdateModuleData moduleData)
         : base(gameObject, gameEngine)
     {
@@ -132,7 +141,12 @@ public class AIUpdate : UpdateModule
         }
     }
 
-    private protected virtual AIUpdateStateMachine CreateStateMachine() => new(GameObject, GameEngine, this);
+    private protected virtual AIUpdateStateMachine CreateStateMachine()
+    {
+        var result = new AIUpdateStateMachine(GameObject, GameEngine, this);
+        result.InitializeDefaultState();
+        return result;
+    }
 
     internal void SetLocomotor(LocomotorSetType type)
     {

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/ChinookAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/ChinookAIUpdate.cs
@@ -63,6 +63,24 @@ internal enum ChinookState
     OnGround = 4,
 }
 
+internal static class ChinookAIStateIds
+{
+    public static readonly StateId TakingOff = new(1001);
+    public static readonly StateId Landing = new(1002);
+    public static readonly StateId MoveToAndLand = new(1003);
+    public static readonly StateId MoveToAndEvac = new(1004);
+    public static readonly StateId LandAndEvac = new(1005);
+    public static readonly StateId EvacAndTakeoff = new(1006);
+    public static readonly StateId MoveToAndEvacAndExit = new(1007);
+    public static readonly StateId LandAndEvacAndExit = new(1008);
+    public static readonly StateId EvacAndExit = new(1009);
+    public static readonly StateId TakeOffAndExit = new(1010);
+    public static readonly StateId HeadOffMap = new(1011);
+    public static readonly StateId MoveToCombatDrop = new(1012);
+    public static readonly StateId DoCombatDrop = new(1013);
+    public static readonly StateId MoveToAndEvacAndExitInit = new(1014);
+}
+
 internal sealed class ChinookAIUpdateStateMachine : AIUpdateStateMachine
 {
     public override ChinookAIUpdate AIUpdate { get; }
@@ -72,19 +90,19 @@ internal sealed class ChinookAIUpdateStateMachine : AIUpdateStateMachine
     {
         AIUpdate = aiUpdate;
 
-        AddState(1001, new ChinookTakeoffAndLandingState(this, false)); // Takeoff
-        AddState(1002, new ChinookTakeoffAndLandingState(this, true));  // Landing
-        AddState(1003, new MoveTowardsState(this));                     // Moving towards airfield to repair at
-        AddState(1004, new MoveTowardsState(this));                     // Moving towards evacuation point
-        AddState(1005, new ChinookTakeoffAndLandingState(this, true));  // Landing for evacuation
+        DefineState(ChinookAIStateIds.TakingOff, new ChinookTakeoffAndLandingState(this, false), AIStateIds.Idle, AIStateIds.Idle);
+        DefineState(ChinookAIStateIds.Landing, new ChinookTakeoffAndLandingState(this, true), AIStateIds.Idle, AIStateIds.Idle);
+        DefineState(ChinookAIStateIds.MoveToAndLand, new MoveTowardsState(this), ChinookAIStateIds.Landing, AIStateIds.Idle);
+        DefineState(ChinookAIStateIds.MoveToAndEvac, new MoveTowardsState(this), ChinookAIStateIds.LandAndEvac, AIStateIds.Idle);
+        DefineState(ChinookAIStateIds.LandAndEvac, new ChinookTakeoffAndLandingState(this, true), ChinookAIStateIds.EvacAndTakeoff, AIStateIds.Idle);
         // 1006?
-        AddState(1007, new MoveTowardsState(this));                     // Moving towards reinforcement point
-        AddState(1008, new ChinookTakeoffAndLandingState(this, true));  // Landing for reinforcement
+        DefineState(ChinookAIStateIds.MoveToAndEvacAndExit, new MoveTowardsState(this), ChinookAIStateIds.LandAndEvacAndExit, AIStateIds.Idle);
+        DefineState(ChinookAIStateIds.LandAndEvacAndExit, new ChinookTakeoffAndLandingState(this, true), ChinookAIStateIds.EvacAndExit, AIStateIds.Idle);
         // 1009?
-        AddState(1010, new ChinookTakeoffAndLandingState(this, false)); // Takeoff after reinforcement
-        AddState(1011, new ChinookExitMapState(this));                  // Exit map after reinforcement
-        AddState(1012, new ChinookMoveToCombatDropState(this));         // Moving towards combat drop location
-        AddState(1013, new ChinookCombatDropState(this));               // Combat drop
+        DefineState(ChinookAIStateIds.TakeOffAndExit, new ChinookTakeoffAndLandingState(this, false), ChinookAIStateIds.HeadOffMap, AIStateIds.Idle);
+        DefineState(ChinookAIStateIds.HeadOffMap, new ChinookExitMapState(this), AIStateIds.Idle, AIStateIds.Idle);
+        DefineState(ChinookAIStateIds.MoveToCombatDrop, new ChinookMoveToCombatDropState(this), ChinookAIStateIds.DoCombatDrop, AIStateIds.Idle);
+        DefineState(ChinookAIStateIds.DoCombatDrop, new ChinookCombatDropState(this), AIStateIds.Idle, AIStateIds.Idle);
     }
 }
 

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAndWorkerState.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/DozerAndWorkerState.cs
@@ -202,13 +202,20 @@ internal sealed class DozerAndWorkerState : IPersistableObject
         }
     }
 
+    internal static class BuilderStateIds
+    {
+        public static readonly StateId Idle = new(0);
+        public static readonly StateId Build = new(1);
+        public static readonly StateId Repair = new(2);
+    }
+
     internal sealed class BuilderStateMachine : StateMachineBase
     {
         public BuilderStateMachine(GameObject gameObject, IGameEngine gameEngine, AIUpdate aiUpdate) : base(gameObject, gameEngine, aiUpdate)
         {
-            AddState(0, new BuilderUnknown0State(this));
-            AddState(1, new BuilderUnknown1State(this));
-            AddState(2, new BuilderUnknown2State(this));
+            DefineState(BuilderStateIds.Idle, new BuilderUnknown0State(this), StateId.Invalid, StateId.Invalid);
+            DefineState(BuilderStateIds.Build, new BuilderUnknown1State(this), BuilderStateIds.Idle, BuilderStateIds.Idle);
+            DefineState(BuilderStateIds.Repair, new BuilderUnknown2State(this), BuilderStateIds.Idle, BuilderStateIds.Idle);
         }
 
         public override void Persist(StatePersister reader)

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/JetAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/JetAIUpdate.cs
@@ -338,8 +338,13 @@ internal sealed class JetAIUpdateStateMachine : AIUpdateStateMachine
     {
         AIUpdate = aiUpdate;
 
-        AddState(WaitForAirfieldWinchesterState.StateId, new WaitForAirfieldWinchesterState(this));
+        DefineState(JetAIStateIds.CirclingDeadAirfield, new WaitForAirfieldWinchesterState(this), AIStateIds.Idle, AIStateIds.Idle);
     }
+}
+
+internal static class JetAIStateIds
+{
+    public static readonly StateId CirclingDeadAirfield = new(1013);
 }
 
 /// <summary>

--- a/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
+++ b/src/OpenSage.Game/Logic/Object/Update/AIUpdate/WorkerAIUpdate.cs
@@ -223,6 +223,12 @@ public class WorkerAIUpdate : SupplyAIUpdate, IBuilderAIUpdate
         reader.PersistObject(_stateMachine3);
     }
 
+    internal sealed class WorkerStateIds
+    {
+        public static readonly StateId AsDozer = new(0);
+        public static readonly StateId AsSupplyTruck = new(1);
+    }
+
     internal sealed class WorkerAIUpdateStateMachine3 : StateMachineBase
     {
         public override WorkerAIUpdate AIUpdate { get; }
@@ -231,8 +237,9 @@ public class WorkerAIUpdate : SupplyAIUpdate, IBuilderAIUpdate
         {
             AIUpdate = aiUpdate;
 
-            AddState(0, new WorkerUnknown0State(this));
-            AddState(1, new WorkerUnknown1State(this));
+            // TODO(Port): This configuration is incomplete.
+            DefineState(WorkerStateIds.AsDozer, new WorkerUnknown0State(this), StateId.Invalid, StateId.Invalid);
+            DefineState(WorkerStateIds.AsSupplyTruck, new WorkerUnknown1State(this), StateId.Invalid, StateId.Invalid);
         }
 
         public override void Persist(StatePersister reader)

--- a/src/OpenSage.Game/StatePersister.cs
+++ b/src/OpenSage.Game/StatePersister.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using OpenSage.Content;
 using OpenSage.FileFormats;
+using OpenSage.Logic.AI;
 using OpenSage.Logic.Object;
 using OpenSage.Mathematics;
 
@@ -605,6 +606,20 @@ public static class StatePersisterExtensions
         persister.PersistUpdateFrameValue(ref value);
 
         persister.EndObject();
+    }
+
+    public static void PersistStateId(this StatePersister persister, ref StateId value, [CallerArgumentExpression("value")] string name = "")
+    {
+        persister.PersistFieldName(name);
+
+        persister.PersistStateIdValue(ref value);
+    }
+
+    public static void PersistStateIdValue(this StatePersister persister, ref StateId value)
+    {
+        var innerValue = value.Value;
+        persister.PersistUInt32Value(ref innerValue);
+        value = new StateId(innerValue);
     }
 
     public static void PersistEnumOptional<TEnum>(this StatePersister persister, ref TEnum? value, [CallerArgumentExpression("value")] string name = "")


### PR DESCRIPTION
This PR does some foundational refactoring of our state machine code, in preparation for porting some actual state classes. We were fairly close with our existing implementation. I've changed how states are configured to match the original, including specifying a "next" state, for both "success" and "failure" conditions.

I went through a few iterations on this, to see if there was a more elegant way to write this code. But because state classes (in particular the idle state) can be used in multiple different state machines, potentially with different IDs, it is necessary to have state IDs defined completely separately from the state classes they're associated with. So a direct port seemed like the best option.